### PR TITLE
Turn up volume if zero when unmuted

### DIFF
--- a/src/js/media-mute-button.js
+++ b/src/js/media-mute-button.js
@@ -19,6 +19,10 @@ class MediaMuteButton extends MediaChromeButton {
   onClick(e) {
     const media = this.media;
     media.muted = !media.muted;
+
+    if (!media.muted && media.volume === 0) {
+      media.volume = 0.25;
+    }
   }
 
   update() {

--- a/src/js/media-volume-range.js
+++ b/src/js/media-volume-range.js
@@ -51,15 +51,22 @@ class MediaVolumeRange extends MediaChromeRange {
   }
 
   mediaSetCallback(media) {
-    media.addEventListener('volumechange', this.update.bind(this));
+    this._handleVolumeChange = this.update.bind(this);
+    media.addEventListener('volumechange', this._handleVolumeChange);
 
     // Update the media with the last set volume preference
+    // This would preferably live with the media element,
+    // not a control.
     try {
       const volPref = window.localStorage.getItem('media-chrome-pref-volume');
-      media.volume = volPref;
+      if (volPref !== null) media.volume = volPref;
     } catch (e) { }
 
     this.update();
+  }
+
+  mediaUnsetCallback(media) {
+    media.removeEventListener('volumechange', this._handleVolumeChange);
   }
 
   update() {

--- a/src/js/media-volume-range.js
+++ b/src/js/media-volume-range.js
@@ -5,10 +5,10 @@ class MediaVolumeRange extends MediaChromeRange {
   constructor() {
     super();
 
-    const media = this.media;
-
     this.range.addEventListener('input', () => {
       const media = this.media;
+
+      if (!media) return;
 
       const volume = this.range.value / 1000;
       media.volume = volume;
@@ -22,22 +22,24 @@ class MediaVolumeRange extends MediaChromeRange {
     // Store the last set positive volume before a drag
     // so we have it when unmuting
     this.range.addEventListener('mousedown', () => {
-      const volume = this.media.volume;
+      const volume = this.media && this.media.volume;
 
       if (volume > 0) {
-        this.lastNonZeroVolume = volume;
+        this._lastNonZeroVolume = volume;
       }
     });
 
     this.range.addEventListener('change', () => {
       const media = this.media;
 
+      if (!media) return;
+
       // If the user is just sliding the volume to zero, we want to treat
       // that the same as muting. And when they unmute, go back to the volume
       // that was previously set.
       if (media.volume == 0) {
         media.muted = true;
-        media.volume = this.lastNonZeroVolume || 1;
+        media.volume = this._lastNonZeroVolume || 1;
       }
 
       // Store the last set volume as a local preference, if ls is supported
@@ -51,7 +53,7 @@ class MediaVolumeRange extends MediaChromeRange {
   }
 
   mediaSetCallback(media) {
-    this._handleVolumeChange = this.update.bind(this);
+    this._handleVolumeChange = this._updateRange.bind(this);
     media.addEventListener('volumechange', this._handleVolumeChange);
 
     // Update the media with the last set volume preference
@@ -62,14 +64,14 @@ class MediaVolumeRange extends MediaChromeRange {
       if (volPref !== null) media.volume = volPref;
     } catch (e) { }
 
-    this.update();
+    this._updateRange();
   }
 
   mediaUnsetCallback(media) {
     media.removeEventListener('volumechange', this._handleVolumeChange);
   }
 
-  update() {
+  _updateRange() {
     const media = this.media;
     const range = this.range;
 


### PR DESCRIPTION
Currently when the video/audio starts muted with volume zero, and then you click the _unmute_ button, nothing appears to change. It is actually toggling mute/unmute, but because the volume is still zero, the icon doesn't change.

This update bumps the volume to 0.25 when unmuting the volume is zero.