### PR TITLE
Change main container name and deprecate media-chrome el

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,16 +1,12 @@
 # Architecture Notes
 
-## Element Media Discovery
+## Connecting elements to the media
 
-Media elements can rely on their `media` attribute to set the media element they will interact with. Otherwise they will find the closest `media-container` element, and interact with the contained media element. This roughly matches the pattern of form elements (a submit button will submit its parent form).
+Media chrome elements rely on their `media=''` attribute to set the media element (`<video>` or `<audio>`) they will interact with.
 
-This search happens every time the media is needed, meaning the parent (and media) can be changed easily, and also we might look for _noticeable_ inefficiencies in high frequency operations.
+Any media chrome element inside of a `<media-container>` element will have the media element automaticallly injected via their `el.media` property (by the media-container's mutation observer). This roughly matches the pattern of HTML `<form>` elements (a submit button will submit its parent form if no `form=''` attribute is set).
 
-An alternate approach would have been to have the media-container inject the media into any new children using mutation observers, but that seemed less elegant.
-
----
-
-Changing to have media-container push the media into its children. This keeps the media chrome and media loading logic in media chrome and not in control elements.
+Note: Originally it was built into the media-chrome-element to find the media via a parent media-container, but switched this to have the logic in media-container to simplify the relationhip and avoid a search everytime the media API is needed.
 
 ## Element Independence
 
@@ -18,6 +14,6 @@ A goal of this project is that each UI element could be used independently of th
 
 ## Support Unidirectional Data Flow
 
-Many js application frameworks today like React follow a "unidirectional data flow" pattern. We want media chrome elements to be smart by default, e.g. understanding how to listen to media events without a ton of extra overhead, however we don't want to prohibit using them in a react-style app.
+Many js application frameworks today like React follow a "unidirectional data flow" pattern. We want media chrome elements to be smart by default, understanding how to listen to media events without a ton of extra overhead, however we don't want to prohibit using them in a react-style app.
 
-To do this the elements will have the option of being passed a media to attach listeners to, or will discover a parent element's media or media-container element. If those don't exist the element will assume state will be externally provided.
+To do this the elements will have the option of being passed a media to attach listeners to. And alternatively allow the element state to be set externally.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,15 +2,15 @@
 
 ## Element Media Discovery
 
-Media elements can rely on their `media` attribute to set the media element they will interact with. Otherwise they will find the closest `media-chrome` element, and interact with the contained media element. This roughly matches the pattern of form elements (a submit button will submit its parent form).
+Media elements can rely on their `media` attribute to set the media element they will interact with. Otherwise they will find the closest `media-container` element, and interact with the contained media element. This roughly matches the pattern of form elements (a submit button will submit its parent form).
 
 This search happens every time the media is needed, meaning the parent (and media) can be changed easily, and also we might look for _noticeable_ inefficiencies in high frequency operations.
 
-An alternate approach would have been to have the media-chrome inject the media into any new children using mutation observers, but that seemed less elegant.
+An alternate approach would have been to have the media-container inject the media into any new children using mutation observers, but that seemed less elegant.
 
 ---
 
-Changing to have media-chrome push the media into its children. This keeps the media chrome and media loading logic in media chrome and not in control elements.
+Changing to have media-container push the media into its children. This keeps the media chrome and media loading logic in media chrome and not in control elements.
 
 ## Element Independence
 
@@ -20,4 +20,4 @@ A goal of this project is that each UI element could be used independently of th
 
 Many js application frameworks today like React follow a "unidirectional data flow" pattern. We want media chrome elements to be smart by default, e.g. understanding how to listen to media events without a ton of extra overhead, however we don't want to prohibit using them in a react-style app.
 
-To do this the elements will have the option of being passed a media to attach listeners to, or will discover a parent element's media or media-chrome element. If those don't exist the element will assume state will be externally provided.
+To do this the elements will have the option of being passed a media to attach listeners to, or will discover a parent element's media or media-container element. If those don't exist the element will assume state will be externally provided.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Fully customizable media player controls using web components (native custom ele
 ```html
 <script type="module" src="https://unpkg.com/media-chrome"></script>
 
-<media-chrome>
+<media-container>
   <video
     slot="media"
     src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/high.mp4"
@@ -30,7 +30,7 @@ Fully customizable media player controls using web components (native custom ele
     <media-pip-button>PIP</media-pip-button>
     <media-fullscreen-button>Fullscreen</media-fullscreen-button>
   </media-control-bar>
-</media-chrome>
+</media-container>
 ```
 
 #### Results (<a href="https://codepen.io/heff/pen/ZEGdBzN?editors=1000" target="_blank">Try the CodePen example</a>)
@@ -83,7 +83,7 @@ This will register the custom elements with the browser so they can be used as H
 
 ### Using in your HTML
 
-Each control element can be used independently. When using outside of a `<media-chrome>` element, a control needs to be told which media it's controlling via the `media` attribute or property.
+Each control element can be used independently. When using outside of a `<media-container>` element, a control needs to be told which media it's controlling via the `media` attribute or property.
 
 Using the `media` attribute and CSS selector.
 
@@ -100,20 +100,20 @@ const playButton = document.createElement('media-play-button');
 playButton.media = video;
 ```
 
-Or set automatically by wrapping both the media element and control element in a `<media-chrome>` element. Include the `slot="media"` attribute in the tag of your [compatible player](#compatible-players)'s element.
+Or set automatically by wrapping both the media element and control element in a `<media-container>` element. Include the `slot="media"` attribute in the tag of your [compatible player](#compatible-players)'s element.
 
 ```javascript
-<media-chrome>
+<media-container>
   <video slot="media"></video>
   <media-play-button>Play</media-play-button>
-</media-chrome>
+</media-container>
 ```
 
 ## Customizing the controls
 Use HTML to add or remove any of the controls. Then you can use CSS to style the controls as you would other HTML elements.
 
 ```html
-<media-chrome>
+<media-container>
   <video
     slot="media"
     src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/high.mp4"
@@ -126,7 +126,7 @@ Use HTML to add or remove any of the controls. Then you can use CSS to style the
     <media-pip-button>PIP</media-pip-button>
     <media-fullscreen-button>Fullscreen</media-fullscreen-button>
   </media-control-bar>
-</media-chrome>
+</media-container>
 ```
 
 You can then use CSS to style the controls as you would other HTML elements.
@@ -135,7 +135,7 @@ You can then use CSS to style the controls as you would other HTML elements.
 
 | Element                      | Description                                                                                           |
 |------------------------------|-------------------------------------------------------------------------------------------------------|
-| `<media-chrome>`       | An optional container for the other controls and media elements.
+| `<media-container>`       | An optional container for the other controls and media elements.
 | `<media-control-bar>`       | Optional controls container to help align the controls in the standard fashion.                       |
 | `<media-play-button>`       | Toggle media playback                                                                                 |
 | `<media-mute-button>`       | Toggle the sound. The icon responds to volume changes and acts as part of the typical volume control. |
@@ -159,16 +159,16 @@ Some "players" add on to existing video and audio elements, so nothing more is n
 | [Shaka Player](https://github.com/google/shaka-player)    | Nothing else needed.                                                                                        |
 | YouTube                                                   | Requires the [`<youtube-video>` element](https://github.com/muxinc/youtube-video-element).                  |
 
-If using the `<media-chrome>` element, be sure to include the `slot="media"` attribute in the player's tag.
+If using the `<media-container>` element, be sure to include the `slot="media"` attribute in the player's tag.
 
 ```html
-<media-chrome>
+<media-container>
   <youtube-video
     slot="media"
     src="https://www.youtube.com/watch?v=rubNgGj3pYo"
   >
   </youtube-video>
-</media-chrome>
+</media-container>
 ```
 
 ## Why?

--- a/examples/demo.html
+++ b/examples/demo.html
@@ -4,7 +4,7 @@
 </head>
 <body>
 
-<media-chrome>
+<media-container>
   <video
     slot="media"
     src="http://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/high.mp4"
@@ -17,7 +17,7 @@
     <media-playback-rate-button></media-playback-rate-button>
     <media-fullscreen-button></media-fullscreen-button>
   </media-control-bar>
-</media-chrome>
+</media-container>
 
 </body>
 </html>

--- a/examples/hls.html
+++ b/examples/hls.html
@@ -5,7 +5,7 @@
 </head>
 <body>
 
-<media-chrome>
+<media-container>
   <hls-video
     src="http://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe.m3u8"
     slot="media"
@@ -17,7 +17,7 @@
     <media-volume-range></media-volume-range>
     <media-fullscreen-button></media-fullscreen-button>
   </media-control-bar>
-</media-chrome>
+</media-container>
 
 </body>
 </html>

--- a/examples/netflix-theme.html
+++ b/examples/netflix-theme.html
@@ -9,7 +9,7 @@
     font-family: "Helvetica Neue", sans-serif;
   }
 
-  media-chrome {
+  media-container {
     height: 290px;
 
     --media-range-thumb-background: rgba(255,0,0, 1);
@@ -110,7 +110,7 @@
 
 </style>
 
-<media-chrome>
+<media-container>
   <video
     slot="media"
     src="http://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/high.mp4"
@@ -131,7 +131,7 @@
     </div>
     <media-fullscreen-button></media-fullscreen-button>
   </media-control-bar>
-</media-chrome>
+</media-container>
 
 </body>
 </html>

--- a/examples/youtube-theme.html
+++ b/examples/youtube-theme.html
@@ -130,7 +130,7 @@
   }
 </style>
 
-<media-chrome class="media-theme-youtube">
+<media-container class="media-theme-youtube">
   <video
     slot="media"
     src="http://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/high.mp4"
@@ -153,7 +153,7 @@
     <media-pip-button></media-pip-button>
     <media-fullscreen-button></media-fullscreen-button>
   </media-control-bar>
-</media-chrome>
+</media-container>
 
 <script>
   const mediaMuteButton = document.querySelector('media-mute-button');

--- a/examples/youtube.html
+++ b/examples/youtube.html
@@ -5,7 +5,7 @@
 </head>
 <body>
 
-<media-chrome>
+<media-container>
   <youtube-video
     src="https://www.youtube.com/watch?v=rubNgGj3pYo"
     slot="media"
@@ -17,7 +17,7 @@
     <media-volume-range></media-volume-range>
     <media-fullscreen-button></media-fullscreen-button>
   </media-control-bar>
-</media-chrome>
+</media-container>
 
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 </head>
 <body>
 
-<media-chrome>
+<media-container>
   <video
     slot="media"
     src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/high.mp4"
@@ -25,7 +25,7 @@
     <media-pip-button></media-pip-button>
     <media-fullscreen-button></media-fullscreen-button>
   </media-control-bar>
-</media-chrome>
+</media-container>
 
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 import MediaChromeButton from './src/js/media-chrome-button.js';
-import MediaChromeContainer from './src/js/media-chrome-container.js';
+import MediaContainer from './src/js/media-container.js';
 import MediaChromeHTMLElement from './src/js/media-chrome-html-element.js';
 import MediaChromeMenuButton from './src/js/media-chrome-menu-button.js';
 import MediaChromeMenu from './src/js/media-chrome-menu.js';
@@ -24,9 +24,16 @@ import MediaThumbnailPreviewElement from './src/js/media-thumbnail-preview-eleme
 import MediaTitleElement from './src/js/media-title-element.js';
 import MediaVolumeRange from './src/js/media-volume-range.js';
 
+// Alias <media-container> as <media-chrome>
+// and deprecate <media-chrome> as the main element
+class MediaChrome extends MediaContainer {};
+if (window && !window.customElements.get('media-chrome')) {
+  window.customElements.define('media-chrome', MediaChrome);
+}
+
 export {
   MediaChromeButton,
-  MediaChromeContainer,
+  MediaContainer,
   MediaChromeHTMLElement,
   MediaChromeMenuButton,
   MediaChromeMenu,

--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -62,7 +62,7 @@ template.innerHTML = `
   </div>
 `;
 
-class MediaChromeContainer extends HTMLElement {
+class MediaContainer extends HTMLElement {
   constructor() {
     super();
 
@@ -243,7 +243,6 @@ class MediaChromeContainer extends HTMLElement {
   autoHide(seconds) {}
 }
 
-// Define as both <media-chrome>
-defineCustomElement('media-chrome', MediaChromeContainer);
+defineCustomElement('media-container', MediaContainer);
 
-export default MediaChromeContainer;
+export default MediaContainer;


### PR DESCRIPTION
In #10 we talked about changing the name of the main `<media-chrome>` element to disambiguate the class and element with the parent project. This PR changes it to `<media-container>` but aliases it to `<media-chrome>` so it's not an immediately breaking change.

More demos will need to be updated.