### PR TITLE
Dj/readme screenshot fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Simple HTML and CSS.
 
 Listen for the `update` event on the element to get the selected start and end timestamps. Full example in examples/clip-selector.html.
 
-![media range selector example](/screenshots/media-clip-selector.gif?raw=true)
+![media range selector example](./screenshots/media-clip-selector.gif?raw=true)
 
 
 ## Usage


### PR DESCRIPTION
This is broken on the README in `main`.. fixed here

https://github.com/muxinc/media-chrome/tree/dj/readme-screenshot-fix#use-media-clip-selector-to-select-segments-of-a-video