### PR TITLE
Update 'isServer' to also check for customElements

### DIFF
--- a/src/js/utils/server-safe-globals.js
+++ b/src/js/utils/server-safe-globals.js
@@ -11,8 +11,6 @@ const documentShim = {
   createElement: function() { return {}; }
 };
 
-export const isServer = !!(
-  typeof window === 'undefined' || typeof window.customElements === 'undefined'
-);
+export const isServer = typeof window === 'undefined' || typeof window.customElements === 'undefined';
 export const Window = isServer ? windowShim : window;
 export const Document = isServer ? documentShim : window.document;

--- a/src/js/utils/server-safe-globals.js
+++ b/src/js/utils/server-safe-globals.js
@@ -11,6 +11,8 @@ const documentShim = {
   createElement: function() { return {}; }
 };
 
-export const isServer = !!(typeof window === 'undefined')
+export const isServer = !!(
+  typeof window === 'undefined' || typeof window.customElements === 'undefined'
+);
 export const Window = isServer ? windowShim : window;
 export const Document = isServer ? documentShim : window.document;


### PR DESCRIPTION
In some environments there are preexisting `window` shims that do not have the `customElements` on the window object. This update will check for those cases.

See: https://github.com/sanity-io/sanity-plugin-mux-input/issues/36#issuecomment-867955123