### PR TITLE
fix files that get published to npm, fix custom element constructor and fix some missing server safe globals

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "dist/index.js",
   "files": [
     "dist/*",
-    "README.md"
+    "README.md",
+    "examples/*"
   ],
   "scripts": {
     "clean": "rimraf dist",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,8 @@
   "description": "Custom elements (web components) for making audio and video player controls that look great in your website or app.",
   "main": "dist/index.js",
   "files": [
-    "./dist/*",
-    "README.md",
-    "./examples/*"
+    "dist/*",
+    "README.md"
   ],
   "scripts": {
     "clean": "rimraf dist",

--- a/src/js/media-mute-button.js
+++ b/src/js/media-mute-button.js
@@ -1,5 +1,6 @@
 import MediaChromeButton from './media-chrome-button.js';
 import { defineCustomElement } from './utils/defineCustomElement.js';
+import { Document as document } from './utils/server-safe-globals.js';
 import { mediaUIEvents } from './media-chrome-html-element.js';
 
 const offIcon =

--- a/src/js/media-pip-button.js
+++ b/src/js/media-pip-button.js
@@ -1,5 +1,6 @@
 import MediaChromeButton from './media-chrome-button.js';
 import { defineCustomElement } from './utils/defineCustomElement.js';
+import { Document as document } from './utils/server-safe-globals.js';
 import { mediaUIEvents } from './media-chrome-html-element.js';
 
 const pipIcon =

--- a/src/js/media-play-button.js
+++ b/src/js/media-play-button.js
@@ -1,4 +1,5 @@
 import MediaChromeButton from './media-chrome-button.js';
+import { Document as document } from './utils/server-safe-globals.js';
 import { defineCustomElement } from './utils/defineCustomElement.js';
 import { mediaUIEvents } from './media-chrome-html-element.js';
 

--- a/src/js/media-seek-backward-button.js
+++ b/src/js/media-seek-backward-button.js
@@ -1,6 +1,7 @@
 import MediaChromeButton from './media-chrome-button.js';
 import { defineCustomElement } from './utils/defineCustomElement.js';
 import { mediaUIEvents } from './media-chrome-html-element.js';
+import { Document as document } from './utils/server-safe-globals.js';
 
 const backwardIcon =
   '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="24" height="24" viewBox="0 0 24 24"><defs><path class="icon" id="a" d="M0 0h24v24H0V0z"/></defs><clipPath id="b"><use xlink:href="#a" overflow="visible"/></clipPath><path class="icon" d="M12 5V1L7 6l5 5V7c3.3 0 6 2.7 6 6s-2.7 6-6 6-6-2.7-6-6H4c0 4.4 3.6 8 8 8s8-3.6 8-8-3.6-8-8-8zm-2.4 8.5h.4c.2 0 .4-.1.5-.2s.2-.2.2-.4v-.2s-.1-.1-.1-.2-.1-.1-.2-.1h-.5s-.1.1-.2.1-.1.1-.1.2v.2h-1c0-.2 0-.3.1-.5s.2-.3.3-.4.3-.2.4-.2.4-.1.5-.1c.2 0 .4 0 .6.1s.3.1.5.2.2.2.3.4.1.3.1.5v.3s-.1.2-.1.3-.1.2-.2.2-.2.1-.3.2c.2.1.4.2.5.4s.2.4.2.6c0 .2 0 .4-.1.5s-.2.3-.3.4-.3.2-.5.2-.4.1-.6.1c-.2 0-.4 0-.5-.1s-.3-.1-.5-.2-.2-.2-.3-.4-.1-.4-.1-.6h.8v.2s.1.1.1.2.1.1.2.1h.5s.1-.1.2-.1.1-.1.1-.2v-.5s-.1-.1-.1-.2-.1-.1-.2-.1h-.6v-.7zm5.7.7c0 .3 0 .6-.1.8l-.3.6s-.3.3-.5.3-.4.1-.6.1-.4 0-.6-.1-.3-.2-.5-.3-.2-.3-.3-.6-.1-.5-.1-.8v-.7c0-.3 0-.6.1-.8l.3-.6s.3-.3.5-.3.4-.1.6-.1.4 0 .6.1.3.2.5.3.2.3.3.6.1.5.1.8v.7zm-.8-.8v-.5c0-.1-.1-.2-.1-.3s-.1-.1-.2-.2-.2-.1-.3-.1-.2 0-.3.1l-.2.2s-.1.2-.1.3v2s.1.2.1.3.1.1.2.2.2.1.3.1.2 0 .3-.1l.2-.2s.1-.2.1-.3v-1.5z" clip-path="url(#b)"/></svg>';

--- a/src/js/media-seek-forward-button.js
+++ b/src/js/media-seek-forward-button.js
@@ -1,5 +1,6 @@
 import MediaChromeButton from './media-chrome-button.js';
 import { defineCustomElement } from './utils/defineCustomElement.js';
+import { Document as document } from './utils/server-safe-globals.js';
 import { mediaUIEvents } from './media-chrome-html-element.js';
 
 const forwardIcon =

--- a/src/js/media-volume-range.js
+++ b/src/js/media-volume-range.js
@@ -14,10 +14,6 @@ class MediaVolumeRange extends MediaChromeRange {
         detail: volume
       });
     });
-  }
-
-  connectedCallback () {
-    this._updateRange();
 
     // Store the last set positive volume before a drag
     // so we have it when unmuting
@@ -39,6 +35,10 @@ class MediaVolumeRange extends MediaChromeRange {
     //     media.volume = this._lastNonZeroVolume || 1;
     //   }
     // });
+  }
+
+  connectedCallback () {
+    this._updateRange();
   }
 
   mediaVolumeSet(volume) {

--- a/src/js/media-volume-range.js
+++ b/src/js/media-volume-range.js
@@ -14,7 +14,9 @@ class MediaVolumeRange extends MediaChromeRange {
         detail: volume
       });
     });
+  }
 
+  connectedCallback () {
     this._updateRange();
 
     // Store the last set positive volume before a drag


### PR DESCRIPTION
- [x] currently only dist/index.js get published to npm & unpkg - the syntax in the`files: []` array was incorrectly specifying which files get included:

**before**

```
❯ npx npm-packlist
LICENSE
dist/index.js
package.json
README.md
```

**after** - now the extras and individual elements will be included

```
❯ npx npm-packlist
LICENSE
dist/utils/defineCustomElement.js
dist/utils/fullscreenApi.js
dist/extras/media-clip-selector/index.js
dist/index.js
dist/media-chrome-button.js
dist/media-chrome-html-element.js
dist/media-chrome-range.js
dist/media-container.js
dist/media-control-bar.js
dist/media-controller.js
dist/media-current-time-display.js
dist/media-duration-display.js
dist/media-fullscreen-button.js
dist/media-mute-button.js
dist/media-pip-button.js
dist/media-play-button.js
dist/media-playback-rate-button.js
dist/media-poster.js
dist/media-progress-range.js
dist/media-seek-backward-button.js
dist/media-seek-forward-button.js
dist/media-settings-popup.js
dist/media-text-display.js
dist/media-thumbnail-preview-element.js
dist/media-time-range.js
dist/media-title-element.js
dist/media-ui-events.js
dist/media-volume-range.js
dist/utils/server-safe-globals.js
dist/utils/stringUtils.js
dist/utils/time.js
package.json
README.md
```


- [x] a few places we were using `document` instead of the server safe `document`
- [x] custom element constructor should not manipulate DOM (some browsers are more strict about this than others, react-dom is strict about this)

https://html.spec.whatwg.org/multipage/scripting.html#custom-element-conformance

> In general, work should be deferred to connectedCallback as much as possible—especially work involving fetching resources or rendering. However, note that connectedCallback can be called more than once, so any initialization work that is truly one-time will need a guard to prevent it from running twice.