### PR TITLE
Add webkitEnterFullScreen for safari iphone (ios)

### DIFF
--- a/src/js/utils/fullscreenApi.js
+++ b/src/js/utils/fullscreenApi.js
@@ -9,7 +9,7 @@ export const fullscreenApi = {
 };
 
 if (document.fullscreenElement === undefined) {
-  fullscreenApi.enter = "webkitRequestFullScreen";
+  fullscreenApi.enter = document.webkitExitFullscreen != null ? "webkitEnterFullScreen" : "webkitRequestFullScreen";
   fullscreenApi.exit = document.webkitExitFullscreen != null ? "webkitExitFullscreen" : "webkitCancelFullScreen";
   fullscreenApi.event = "webkitfullscreenchange";
   fullscreenApi.element = "webkitFullscreenElement";


### PR DESCRIPTION
Hi,

Using an iphone app with a webview, I was not able to enter fullscreen. 

This pull request correct that behavior.

For testing which function name to use, "document.webkitExitFullscreen" exist but "document.webkitEnterFullScreen" do not.
Thus, I use "document.webkitExitFullscreen" to test the correct function name to enter fullscreen; "webkitEnterFullScreen" is the good one for iphone safari.

Take a look at https://developers.google.com/web/fundamentals/media/mobile-web-video-playback#toggle_fullscreen_on_button_click

And caniuse says RequestFullScreen is only available for ipad (with webkit prefix) not iphone: https://caniuse.com/?search=RequestFullScreen

Voilà.