### PR TITLE
Experimenting with an aspect-ratio attribute

### DIFF
--- a/examples/fluid.html
+++ b/examples/fluid.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta name="viewport" content="width=device-width">
+  <title>Media Chrome Standard Video Usage Example</title>
+  <script type="module" src="../dist/index.js"></script>
+  <style>
+    .examples {
+      margin-top: 20px;
+    }
+
+    .player-container {
+      width: 75%;
+      max-width: 750px;
+      margin: 0 auto;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Media Chrome Fluid (responsive) Layout</h1>
+    <div class="player-container">
+      <media-controller aspect-ratio="16:9">
+        <video
+          slot="media"
+          src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/high.mp4"
+          preload="none"
+          muted
+          crossorigin
+        >
+          <track label="thumbnails" default kind="metadata" src="https://image.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/storyboard.vtt"></track>
+        </video>
+        <media-control-bar>
+          <media-play-button></media-play-button>
+          <media-seek-backward-button></media-seek-backward-button>
+          <media-seek-forward-button></media-seek-forward-button>
+          <media-mute-button></media-mute-button>
+          <media-volume-range></media-volume-range>
+          <media-time-range></media-time-range>
+          <media-time-display show-duration remaining></media-time-display>
+          <media-playback-rate-button></media-playback-rate-button>
+          <media-pip-button></media-pip-button>
+          <media-fullscreen-button></media-fullscreen-button>
+        </media-control-bar>
+      </media-controller>
+    </div>
+    <div class="examples">
+      <a href="./">View more examples</a>
+    </div>
+  </main>
+</body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -13,23 +13,24 @@
     <li><a href="standard.html">Standard</a></li>
     <li><a href="basic.html">Basic usage</a></li>
     <li><a href="standalone-controls.html">Standalone controls</a></li>
+    <li><a href="fluid.html">Fluid (responsive) container</a></li>
   </ul>
-  
+
   <h2>Example themes</h2>
   <ul>
     <li><a href="themes/youtube-theme.html">Youtube Theme</a></li>
     <li><a href="themes/netflix-theme.html">Netflix Theme</a></li>
   </ul>
-  
+
   <h2>Media element examples</h2>
   <ul>
     <li><a href="media-elements/hls.html">HLS Media Element</a></li>
     <li><a href="media-elements/dash.html">DASH Media Element</a></li>
     <li><a href="media-elements/youtube.html">Youtube Media Element</a></li>
   </ul>
-  
+
   <h2>Control element examples</h2>
-  
+
   <h3>Core</h3>
   <ul>
     <li><a href="control-elements/media-play-button.html">Play button</a></li>
@@ -45,7 +46,7 @@
     <li><a href="control-elements/media-fullscreen-button.html">Fullscreen button</a></li>
     <li><a href="control-elements/media-pip-button.html">Picture-in-picture button</a></li>
   </ul>
-  
+
   <h3>Extras</h3>
   <ul>
     <li><a href="control-elements/media-clip-selector.html">Clip selector</a></li>

--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -30,13 +30,14 @@ template.innerHTML = `
     }
 
     /* Video specific styles */
-    :host(:not([audio]):not([aspect-ratio])) {
+    :host(:not([audio])) {
       height: 480px;
       width: 720px;
     }
 
     :host([aspect-ratio]) {
       width: 100%;
+      height: 0;
     }
 
     /* Safari needs this to actually make the element fill the window */
@@ -260,7 +261,7 @@ class MediaContainer extends window.HTMLElement {
   updateAspectRatio(ratioString) {
     const [width, height] = ratioString.split(':');
 
-    const styleEl = this.shadow.querySelector('style.aspect-ratio');
+    const styleEl = this.shadowRoot.querySelector('style.aspect-ratio');
 
     if (height && width) {
       styleEl.innerHTML = `:host { padding-top: ${height/width * 100}%; }`;


### PR DESCRIPTION
I ran into issues trying to use `media-chrome` in a responsive environment and found myself hacking around the same responsive workflow each time. Instead of offloading all that work to individuals, we can take care of that directly in `media-container` by allowing an `aspect-ratio` attribute.

This probably needs some more defensiveness, but wanted to go ahead and open it up to get feedback on the approach.