### PR TITLE
Proposal: media-interaction-feedback element

### DIFF
--- a/examples/advanced.html
+++ b/examples/advanced.html
@@ -54,6 +54,7 @@
           <media-pip-button></media-pip-button>
           <media-fullscreen-button></media-fullscreen-button>
         </media-control-bar>
+        <media-interaction-feedback></media-interaction-feedback>
       </media-controller>
       <div class="examples">
         <a href="./">View more examples</a>

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -13,6 +13,7 @@ import MediaTimeDisplay from './media-time-display.js';
 import MediaCaptionsButton from './media-captions-button.js';
 import MediaSeekForwardButton from './media-seek-forward-button.js';
 import MediaFullscreenButton from './media-fullscreen-button.js';
+import MediaInteractionFeedback from './media-interaction-feedback.js';
 import MediaMuteButton from './media-mute-button.js';
 import MediaPipButton from './media-pip-button.js';
 import MediaPlayButton from './media-play-button.js';
@@ -61,6 +62,7 @@ export {
   MediaCaptionsButton,
   MediaSeekForwardButton,
   MediaFullscreenButton,
+  MediaInteractionFeedback,
   MediaMuteButton,
   MediaPipButton,
   MediaPlayButton,

--- a/src/js/media-interaction-feedback.js
+++ b/src/js/media-interaction-feedback.js
@@ -1,0 +1,110 @@
+import { defineCustomElement } from './utils/defineCustomElement.js';
+import { Window as window, Document as document } from './utils/server-safe-globals.js';
+import { MediaUIAttributes } from './constants.js';
+
+const template = document.createElement('template');
+const playIcon =
+  '<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path class="icon" d="M8 5v14l11-7z"/><path d="M0 0h24v24H0z" fill="none"/></svg>';
+const pauseIcon =
+  '<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path class="icon" d="M6 19h4V5H6v14zm8-14v14h4V5h-4z"/><path d="M0 0h24v24H0z" fill="none"/></svg>';
+
+template.innerHTML = `
+<style>
+:host {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1;
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+
+/*
+  Toggle between showing the play and pause icons
+  on the correct interactions
+*/
+:host([${MediaUIAttributes.MEDIA_PAUSED}]) slot[name=play] > *, 
+:host([${MediaUIAttributes.MEDIA_PAUSED}]) ::slotted([slot=play]) {
+  display: none;
+}
+
+:host(:not([${MediaUIAttributes.MEDIA_PAUSED}])) slot[name=pause] > *, 
+:host(:not([${MediaUIAttributes.MEDIA_PAUSED}])) ::slotted([slot=pause]) {
+  display: none;
+}
+
+/*
+  Visually hide the interaction when current time begins with 0.
+  This prevents the interaction from showing on initial load and
+  on initial play.
+*/
+:host([${MediaUIAttributes.MEDIA_CURRENT_TIME}^="0"]) slot[name=play] > *,
+:host([${MediaUIAttributes.MEDIA_CURRENT_TIME}^="0"]) ::slotted([slot=play]),
+:host([${MediaUIAttributes.MEDIA_CURRENT_TIME}^="0"]) slot[name=pause] > *,
+:host([${MediaUIAttributes.MEDIA_CURRENT_TIME}^="0"]) ::slotted([slot=pause]) {
+  visibility: hidden;
+}
+
+/*
+  Define the animation to follow when the slot is visible.
+*/
+:host([${MediaUIAttributes.MEDIA_PAUSED}]) slot[name=pause] > *, 
+:host([${MediaUIAttributes.MEDIA_PAUSED}]) ::slotted([slot=pause]),
+:host(:not([${MediaUIAttributes.MEDIA_PAUSED}])) slot[name=play] > *, 
+:host(:not([${MediaUIAttributes.MEDIA_PAUSED}])) ::slotted([slot=play]) {
+  animation: fadeAndScale ease 0.682418s;
+  animation-fill-mode: forwards;
+}
+
+svg, img, ::slotted(svg), ::slotted(img) {
+  width: var(--media-interaction-feedback-icon-width, 75px);
+  height: var(--media-interaction-feedback-icon-height);
+  transform: var(--media-interaction-feedback-icon-transform);
+  transition: var(--media-interaction-feedback-icon-transition);
+  fill: var(--media-icon-color, #eee);
+  vertical-align: middle;
+}
+
+@keyframes fadeAndScale {
+  0% {
+    transform: scale(0.8);
+    opacity: 0;
+  }
+  50% {
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1.1);
+    opacity: 0;
+  }
+}
+</style>
+
+<slot name="play">${playIcon}</slot>
+<slot name="pause">${pauseIcon}</slot>
+`;
+
+class MediaInteractionFeedback extends window.HTMLElement {
+  static get observedAttributes() {
+    return [MediaUIAttributes.MEDIA_CONTROLLER, MediaUIAttributes.MEDIA_PAUSED, MediaUIAttributes.MEDIA_CURRENT_TIME];
+  }
+
+  constructor() {
+    super();
+
+    this.attachShadow({ mode: 'open' });
+    this.shadowRoot.appendChild(template.content.cloneNode(true));
+  }
+
+  connectedCallback() {
+    this.setAttribute(MediaUIAttributes.MEDIA_CHROME_ATTRIBUTES, this.constructor.observedAttributes.join(' '));
+  }
+}
+
+defineCustomElement('media-interaction-feedback', MediaInteractionFeedback);
+
+export default MediaInteractionFeedback;

--- a/src/js/media-interaction-feedback.js
+++ b/src/js/media-interaction-feedback.js
@@ -99,10 +99,6 @@ class MediaInteractionFeedback extends window.HTMLElement {
     this.attachShadow({ mode: 'open' });
     this.shadowRoot.appendChild(template.content.cloneNode(true));
   }
-
-  connectedCallback() {
-    this.setAttribute(MediaUIAttributes.MEDIA_CHROME_ATTRIBUTES, this.constructor.observedAttributes.join(' '));
-  }
 }
 
 defineCustomElement('media-interaction-feedback', MediaInteractionFeedback);


### PR DESCRIPTION
## Pull request type

Feature

## Proposed changes

This PR introduces a new `media-interaction-feedback` element.

The element exists outside of the `media-control-bar`. It overlays the video and provides the user with additional feedback on the state of the media based on their most recent interaction with the player. The current supported feedback is for `play` and `pause` interactions, but the element could be extended to support additional interactions (volume change, 30sec seek etc.)

Screen recording: https://capture.dropbox.com/DFgmhZ9qc4G6oq12

![image](https://user-images.githubusercontent.com/1256071/135871817-6a2927da-b4f9-411d-8ca7-b9f74c4814b5.png)


## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

This PR started as an experiment for me to learn how to create new elements for `media-chrome`. It introduces a common video player behavior, but I won't be heartbroken if it needs refactoring, renamed, or if it's ultimately decided that it doesn't belong in core. :) I'm mostly looking for feedback on the code for when I eventually write about/record videos related to this project.

I noticed during development that `media-chrome` doesn't currently track first play. I've found that event to be helpful in my day – as it relates to this repo, the feedback indicator feels awkward to display on the first play, so I leveraged some css selectors to hide the feedback indicator if the `media-current-time` attribute's value begins with `0`

I also grabbed and combined a PR template from a few existing public repos in the world, if it's helpful we can bring it here too.