### PR TITLE
Change "standard" example to "advanced"

### DIFF
--- a/examples/advanced.html
+++ b/examples/advanced.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta name="viewport" content="width=device-width">
-  <title>Media Chrome Standard Video Usage Example</title>
+  <title>Media Chrome Advanced Video Usage Example</title>
   <script type="module" src="../dist/index.js"></script>
   <style>
     .examples {
@@ -12,7 +12,7 @@
 </head>
 <body>
   <main>
-    <h1>Media Chrome Standard Video Usage Example</h1>
+    <h1>Media Chrome Advanced Video Usage Example</h1>
     <media-controller>
       <video
         slot="media"

--- a/examples/index.html
+++ b/examples/index.html
@@ -8,17 +8,11 @@
 
   <h1>Explore the examples</h1>
 
-  <h2>Basic usage</h2>
+  <h2>Getting started</h2>
   <ul>
-    <li><a href="standard.html">Standard</a></li>
-    <li><a href="basic.html">Basic usage</a></li>
+    <li><a href="basic.html">Basic example</a></li>
+    <li><a href="advanced.html">Advanced example</a></li>
     <li><a href="standalone-controls.html">Standalone controls</a></li>
-  </ul>
-  
-  <h2>Example themes</h2>
-  <ul>
-    <li><a href="themes/youtube-theme.html">Youtube Theme</a></li>
-    <li><a href="themes/netflix-theme.html">Netflix Theme</a></li>
   </ul>
   
   <h2>Media element examples</h2>
@@ -28,7 +22,13 @@
     <li><a href="media-elements/youtube.html">Youtube Media Element</a></li>
   </ul>
   
-  <h2>Control element examples</h2>
+  <h2>Example themes</h2>
+  <ul>
+    <li><a href="themes/youtube-theme.html">Youtube Theme</a></li>
+    <li><a href="themes/netflix-theme.html">Netflix Theme</a></li>
+  </ul>
+
+  <h2>Individual control examples</h2>
   
   <h3>Core</h3>
   <ul>


### PR DESCRIPTION
Because having "standard" and "basic" is confusing.
By "advanced" I don't think we should get crazy advanced, but it should allow us to show off a little more.