### PR TITLE
Fix `.textTracks` undefined error

### DIFF
--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -278,7 +278,9 @@ class MediaController extends MediaContainer {
     Object.entries(this._textTrackMediaStatePropagators).forEach(([eventsStr, handler]) => {
       const events = eventsStr.split(',');
       events.forEach((event) => {
-        media.textTracks.addEventListener(event, handler);
+        if (media.textTracks) {
+          media.textTracks.addEventListener(event, handler);
+        }
       });
       handler();
     });
@@ -310,7 +312,9 @@ class MediaController extends MediaContainer {
     Object.entries(this._textTrackMediaStatePropagators).forEach(([eventsStr, handler]) => {
       const events = eventsStr.split(',');
       events.forEach((event) => {
-        media.textTracks.removeEventListener(event, handler);
+        if (media.textTracks) {
+          media.textTracks.removeEventListener(event, handler);
+        }
       });
       handler();
     });


### PR DESCRIPTION
Fix `media.textTracks` being undefined and trying to access `media.textTracks.addEventListener` or  `media.textTracks.removeEventListener`.

<img width="695" alt="Screen Shot 2021-12-22 at 8 51 01 PM" src="https://user-images.githubusercontent.com/360826/147180657-e50fa190-a0d2-4cd2-aa32-adc287de44c4.png">
