### PR TITLE
fix/media-time-range-end: make sure media-time-range max aligns to cu…

### DIFF
--- a/src/js/media-time-range.js
+++ b/src/js/media-time-range.js
@@ -127,7 +127,8 @@ class MediaTimeRange extends MediaChromeRange {
       this.updateBar();
     }
     if (attrName === MediaUIAttributes.MEDIA_DURATION) {
-      this.range.max = +newValue;
+      // Since our range's step is 1, floor the max value to ensure reasonable rendering
+      this.range.max = Math.floor(+newValue);
       updateAriaValueText(this);
       this.updateBar();
     }


### PR DESCRIPTION
…rrent step precision.

Fixes a bug visible on e.g. https://codesandbox.io/s/mux-video-plus-media-chrome-html-forked-f4d99?file=/index.html where the seek slider's thumb never reaches the end, even when playback completes. This is due to a mismatch of the step precision vs. the max value.

Testing:
Can test by using the playback id from the code sandbox example above, `"2fqR887GZAKdeIbBIUdrLEsU01rn2fVc9VjWG022I4bTA"` in our `mux-video` example page and confirm playback plays to the end.
NOTE: This does mean that seeking to the end of playback via the seek slider will be within <1sec of the end of the media timeline and not the true end (this is actually fairly common practice in most players iirc).