### PR TITLE
Add youtube-video-element as dependency

### DIFF
--- a/examples/media-elements/youtube.html
+++ b/examples/media-elements/youtube.html
@@ -3,7 +3,7 @@
 <head>
   <meta name="viewport" content="width=device-width">
   <title>Media Chrome Youtube Media Example</title>
-  <script type="module" src="https://unpkg.com/youtube-video-element@0"></script>
+  <script type="module" src="../../dist/youtube-video-element.js"></script>
   <script type="module" src="../../dist/index.js"></script>
 </head>
 <body>

--- a/package.json
+++ b/package.json
@@ -44,5 +44,7 @@
     "sinon": "^11.1.2",
     "snowpack": "^3.8.3"
   },
-  "dependencies": {}
+  "dependencies": {
+    "youtube-video-element": "^0.0.5"
+  }
 }

--- a/snowpack.dev.config.cjs
+++ b/snowpack.dev.config.cjs
@@ -6,6 +6,7 @@ module.exports = {
   extends: './snowpack.common.config.cjs',
   mount: {
     'src/js': { url: '/dist' },
+    'node_modules/youtube-video-element/dist': { url: '/dist' },
     // Mount "public" to the root URL path ("/*") and serve files with zero transformations:
     examples: { url: '/examples', static: true, resolve: false },
   },

--- a/snowpack.prod.config.cjs
+++ b/snowpack.prod.config.cjs
@@ -6,6 +6,7 @@ module.exports = {
   extends: './snowpack.common.config.cjs',
   mount: {
     'src/js': { url: '/' },
+    'node_modules/youtube-video-element/dist': { url: '/' },
   },
   optimize: {
     bundle: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5709,3 +5709,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+youtube-video-element@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/youtube-video-element/-/youtube-video-element-0.0.5.tgz#ba66c92bf2bd8452fe15bc68840351a3e920cba1"
+  integrity sha512-Bp/+X+gdAB84eVYQD2mv98DLsgKN5OASRWpJkMyMyLrpBiANB3kY4/zjx1LOHKjxNhLLo1XcMj3r6gcF6LYShQ==


### PR DESCRIPTION
Not sure if we want to add this but it makes it a lot easier to debug mux-chrome with a NPM linked youtube-video-element.