### PR TITLE
feat/loading-indicator

### DIFF
--- a/examples/advanced.html
+++ b/examples/advanced.html
@@ -40,19 +40,6 @@
       </media-control-bar>
     </media-controller>
     <div class="examples">
-      <button id="loadingBtn">Toggle Loading</button>
-      <script>
-        const loadingBtn = document.querySelector('#loadingBtn');
-        const loadingEl = document.querySelector('media-loading-indicator');
-        loadingBtn.addEventListener('click', () => {
-          const nextState = !loadingEl.hasAttribute('media-loading');
-          if (nextState) {
-            loadingEl.setAttribute('media-loading', '');
-          } else {
-            loadingEl.removeAttribute('media-loading');
-          }
-        })
-      </script>
       <a href="./">View more examples</a>
     </div>
   </main>

--- a/examples/advanced.html
+++ b/examples/advanced.html
@@ -33,12 +33,26 @@
         <media-time-range></media-time-range>
         <media-time-display show-duration remaining></media-time-display>
         <media-captions-button></media-captions-button>
+        <media-loading-indicator media-loading></media-loading-indicator>
         <media-playback-rate-button></media-playback-rate-button>
         <media-pip-button></media-pip-button>
         <media-fullscreen-button></media-fullscreen-button>
       </media-control-bar>
     </media-controller>
     <div class="examples">
+      <button id="loadingBtn">Toggle Loading</button>
+      <script>
+        const loadingBtn = document.querySelector('#loadingBtn');
+        const loadingEl = document.querySelector('media-loading-indicator');
+        loadingBtn.addEventListener('click', () => {
+          const nextState = !loadingEl.hasAttribute('media-loading');
+          if (nextState) {
+            loadingEl.setAttribute('media-loading', '');
+          } else {
+            loadingEl.removeAttribute('media-loading');
+          }
+        })
+      </script>
       <a href="./">View more examples</a>
     </div>
   </main>

--- a/examples/advanced.html
+++ b/examples/advanced.html
@@ -8,6 +8,10 @@
     .examples {
       margin-top: 20px;
     }
+
+    media-loading-indicator {
+      --media-loading-icon-width: 100px;
+    }
   </style>
 </head>
 <body>
@@ -25,7 +29,7 @@
         <track label="English" kind="captions" srclang="en" src="./vtt/en-cc.vtt"></track>
       </video>
       <div slot="centered-chrome" no-auto-hide>
-        <media-loading-indicator media-loading style="--media-loading-icon-width: 100px;"></media-loading-indicator>
+        <media-loading-indicator media-loading></media-loading-indicator>
       </div>
       <media-control-bar>
         <media-play-button></media-play-button>

--- a/examples/advanced.html
+++ b/examples/advanced.html
@@ -24,6 +24,9 @@
         <track label="thumbnails" default kind="metadata" src="https://image.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/storyboard.vtt"></track>
         <track label="English" kind="captions" srclang="en" src="./vtt/en-cc.vtt"></track>
       </video>
+      <div slot="centered-chrome" no-auto-hide>
+        <media-loading-indicator media-loading style="--media-loading-icon-width: 100px;"></media-loading-indicator>
+      </div>
       <media-control-bar>
         <media-play-button></media-play-button>
         <media-seek-backward-button></media-seek-backward-button>
@@ -33,7 +36,6 @@
         <media-time-range></media-time-range>
         <media-time-display show-duration remaining></media-time-display>
         <media-captions-button></media-captions-button>
-        <media-loading-indicator></media-loading-indicator>
         <media-playback-rate-button></media-playback-rate-button>
         <media-pip-button></media-pip-button>
         <media-fullscreen-button></media-fullscreen-button>

--- a/examples/advanced.html
+++ b/examples/advanced.html
@@ -33,7 +33,7 @@
         <media-time-range></media-time-range>
         <media-time-display show-duration remaining></media-time-display>
         <media-captions-button></media-captions-button>
-        <media-loading-indicator media-loading></media-loading-indicator>
+        <media-loading-indicator></media-loading-indicator>
         <media-playback-rate-button></media-playback-rate-button>
         <media-pip-button></media-pip-button>
         <media-fullscreen-button></media-fullscreen-button>

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -39,6 +39,7 @@ export const MediaUIAttributes = {
     MEDIA_PREVIEW_COORDS: 'media-preview-coords',
     MEDIA_CHROME_ATTRIBUTES: 'media-chrome-attributes',
     MEDIA_CONTROLLER: 'media-controller',
+    MEDIA_LOADING: 'media-loading',
 };
 
 export const TextTrackKinds = {
@@ -53,4 +54,12 @@ export const TextTrackModes = {
     DISABLED: 'disabled',
     HIDDEN: 'hidden',
     SHOWING: 'showing',
+};
+
+export const ReadyStates = {
+    HAVE_NOTHING: 0,
+    HAVE_METADATA: 1,
+    HAVE_CURRENT_DATA: 2,
+    HAVE_FUTURE_DATA: 3,
+    HAVE_ENOUGH_DATA: 4,
 };

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -20,6 +20,7 @@ import MediaProgressRange from './media-progress-range.js';
 import MediaSeekBackwardButton from './media-seek-backward-button.js';
 import MediaThumbnailPreview from './media-thumbnail-preview.js';
 import MediaTimeRange from './media-time-range.js';
+import MediaLoadingIndicator from './media-loading-indicator.js';
 import MediaTitleElement from './media-title-element.js';
 import MediaVolumeRange from './media-volume-range.js';
 import { Window as window } from './utils/server-safe-globals.js';
@@ -66,5 +67,6 @@ export {
   MediaThumbnailPreview as MediaThumbnailPreviewElement,
   MediaTimeRange,
   MediaTitleElement,
+  MediaLoadingIndicator,
   MediaVolumeRange,
 }

--- a/src/js/labels/labels.js
+++ b/src/js/labels/labels.js
@@ -8,6 +8,7 @@ export const nouns = {
   PLAYBACK_RATE: ({ playbackRate = 1 } = {}) =>
     `current playback rate ${playbackRate}`,
   PLAYBACK_TIME: () => `playback time`,
+  MEDIA_LOADING: () => `media loading`,
 };
 
 /** @type {{ [k: string]: (x?: Partial<{ seekOffset: number; playbackRate: number; }>) => string; }} */

--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -91,7 +91,7 @@ template.innerHTML = `
       align-self: stretch;
     }
 
-    :host([user-inactive]:not([${MediaUIAttributes.MEDIA_PAUSED}]):not([audio])) ::slotted(:not([slot=media])) {
+    :host([user-inactive]:not([${MediaUIAttributes.MEDIA_PAUSED}]):not([audio])) ::slotted(:not([slot=media]):not([no-auto-hide])) {
       opacity: 0;
       transition: opacity 1s;
     }

--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -238,6 +238,10 @@ class MediaController extends MediaContainer {
       },
       'ratechange': () => {
         this.propagateMediaState(MediaUIAttributes.MEDIA_PLAYBACK_RATE, this.media.playbackRate);
+      },
+      'waiting,stalled,playing': () => {
+        const isLoading = !this.media?.paused && this.media?.readyState < 3;
+        this.propagateMediaState(MediaUIAttributes.MEDIA_LOADING, isLoading);
       }
     };
 

--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -240,7 +240,7 @@ class MediaController extends MediaContainer {
         this.propagateMediaState(MediaUIAttributes.MEDIA_PLAYBACK_RATE, this.media.playbackRate);
       },
       'waiting,stalled,playing': () => {
-        const isLoading = !this.media?.paused && this.media?.readyState < 3;
+        const isLoading = this.media?.readyState < 3;
         this.propagateMediaState(MediaUIAttributes.MEDIA_LOADING, isLoading);
       }
     };

--- a/src/js/media-loading-indicator.js
+++ b/src/js/media-loading-indicator.js
@@ -9,7 +9,7 @@ const template = document.createElement('template');
 const loadingIndicatorIcon = `
 <svg version="1.1" id="L9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
   viewBox="0 0 100 100" enable-background="new 0 0 0 0" xml:space="preserve">
-    <path fill="#fff" d="M73,50c0-12.7-10.3-23-23-23S27,37.3,27,50 M30.9,50c0-10.5,8.5-19.1,19.1-19.1S69.1,39.5,69.1,50">
+    <path d="M73,50c0-12.7-10.3-23-23-23S27,37.3,27,50 M30.9,50c0-10.5,8.5-19.1,19.1-19.1S69.1,39.5,69.1,50">
       <animateTransform 
          attributeName="transform" 
          attributeType="XML" 
@@ -25,99 +25,32 @@ const loadingIndicatorIcon = `
 template.innerHTML = `
 <style>
 :host {
-  position: relative;
   display: inline-block;
   vertical-align: middle;
   box-sizing: border-box;
-  background-color: var(--media-control-background, rgba(20,20,30, 0.7));
-
-  /* Default width and height can be overridden externally */
-  padding: 10px;
-  
-
-  /* Vertically center any text */
-  font-size: 14px;
-  line-height: 1;
-  font-weight: bold;
-
-  /* Min icon size is 24x24 */
-  min-height: 24px;
-  min-width: 24px;
-
-  transition: background-color 0.15s linear;
 }
 
-/*
-  Only show outline when keyboard focusing.
-  https://drafts.csswg.org/selectors-4/#the-focus-visible-pseudo
-*/
-:host-context([media-keyboard-control]):host(:focus),
-:host-context([media-keyboard-control]):host(:focus-within) {
-  box-shadow: inset 0 0 0 2px rgba(27, 127, 204, 0.9);
+#status {
+  color: rgba(0,0,0,0);
+  width: 0px;
+  height: 0px;
 }
-
-:host(:hover) {
-  background-color: var(--media-control-hover-background, rgba(50,50,70, 0.7));
+:host(:not([${MediaUIAttributes.MEDIA_LOADING}])) slot[name=loading] > *, 
+:host(:not([${MediaUIAttributes.MEDIA_LOADING}])) ::slotted([slot=loading]),
+:host(:not([${MediaUIAttributes.MEDIA_LOADING}])) #status {
+  display: none;
 }
-
-/* Undo the default button styles and fill the parent element */
-.button {
-  width: 100%;
-  vertical-align: middle;
-  border: none;
-  margin: 0;
-  padding: 0;
-  text-decoration: none;
-  background: transparent;
-  color: #ffffff;
-  font-family: sans-serif;
-  font-size: 14px;
-  line-height: 24px;
-  font-weight: bold;
-  font-family: Arial, sans-serif;
-  cursor: pointer;
-  text-align: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-}
-
-.button:hover {}
-.button:focus {
-  outline: 0;
-}
-.button:active {}
 
 svg, img, ::slotted(svg), ::slotted(img) {
-  width: var(--media-button-icon-width, 24px);
-  height: var(--media-button-icon-height);
-  transform: var(--media-button-icon-transform);
-  transition: var(--media-button-icon-transition);
-  fill: var(--media-icon-color, #eee);
+  width: var(--media-loading-icon-width, 24px);
+  height: var(--media-loading-icon-height);
+  fill: var(--media-icon-color, #fff);
   vertical-align: middle;
 }
 </style>
 
-<div class="button"></div>
-`;
-
-
-const slotTemplate = document.createElement('template');
-slotTemplate.innerHTML = `
-  <style>
-  #status {
-    color: rgba(0,0,0,0);
-    width: 0px;
-    height: 0px;
-  }
-  :host(:not([${MediaUIAttributes.MEDIA_LOADING}])) slot[name=loading] > *, 
-  :host(:not([${MediaUIAttributes.MEDIA_LOADING}])) ::slotted([slot=loading]),
-  :host(:not([${MediaUIAttributes.MEDIA_LOADING}])) #status {
-    display: none;
-  }
-  </style>
-
-  <slot name="loading">${loadingIndicatorIcon}</slot>
-  <div id="status" role="status" aria-live="polite">${nouns.MEDIA_LOADING()}</div>
+<slot name="loading">${loadingIndicatorIcon}</slot>
+<div id="status" role="status" aria-live="polite">${nouns.MEDIA_LOADING()}</div>
 `;
 
 class MediaLoadingIndicator extends window.HTMLElement {
@@ -126,18 +59,11 @@ class MediaLoadingIndicator extends window.HTMLElement {
     return [MediaUIAttributes.MEDIA_CONTROLLER, MediaUIAttributes.MEDIA_PAUSED, MediaUIAttributes.MEDIA_LOADING, 'loading-delay'];
   }
   
-  constructor(options={}) {
+  constructor() {
     super();
 
     const shadow = this.attachShadow({ mode: 'open' });
-
     const indicatorHTML = template.content.cloneNode(true);
-    this.nativeEl = indicatorHTML.querySelector('div');
-
-    // Slots
-    const indicatorSlotTemplate = options.slotTemplate ?? slotTemplate;
-    this.nativeEl.appendChild(indicatorSlotTemplate.content.cloneNode(true));
-
     shadow.appendChild(indicatorHTML);
   }
   

--- a/src/js/media-loading-indicator.js
+++ b/src/js/media-loading-indicator.js
@@ -1,0 +1,176 @@
+import { MediaUIAttributes } from './constants.js';
+import { nouns } from './labels/labels.js';
+import { defineCustomElement } from './utils/defineCustomElement.js';
+import { Window as window, Document as document } from './utils/server-safe-globals.js';
+// Todo: Use data locals: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString
+
+const template = document.createElement('template');
+
+const loadingIndicatorIcon = `
+<svg version="1.1" id="L9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+  viewBox="0 0 100 100" enable-background="new 0 0 0 0" xml:space="preserve">
+    <path fill="#fff" d="M73,50c0-12.7-10.3-23-23-23S27,37.3,27,50 M30.9,50c0-10.5,8.5-19.1,19.1-19.1S69.1,39.5,69.1,50">
+      <animateTransform 
+         attributeName="transform" 
+         attributeType="XML" 
+         type="rotate"
+         dur="1s" 
+         from="0 50 50"
+         to="360 50 50" 
+         repeatCount="indefinite" />
+  </path>
+</svg>
+`
+
+template.innerHTML = `
+<style>
+:host {
+  position: relative;
+  display: inline-block;
+  vertical-align: middle;
+  box-sizing: border-box;
+  background-color: var(--media-control-background, rgba(20,20,30, 0.7));
+
+  /* Default width and height can be overridden externally */
+  padding: 10px;
+  
+
+  /* Vertically center any text */
+  font-size: 14px;
+  line-height: 1;
+  font-weight: bold;
+
+  /* Min icon size is 24x24 */
+  min-height: 24px;
+  min-width: 24px;
+
+  transition: background-color 0.15s linear;
+}
+
+/*
+  Only show outline when keyboard focusing.
+  https://drafts.csswg.org/selectors-4/#the-focus-visible-pseudo
+*/
+:host-context([media-keyboard-control]):host(:focus),
+:host-context([media-keyboard-control]):host(:focus-within) {
+  box-shadow: inset 0 0 0 2px rgba(27, 127, 204, 0.9);
+}
+
+:host(:hover) {
+  background-color: var(--media-control-hover-background, rgba(50,50,70, 0.7));
+}
+
+/* Undo the default button styles and fill the parent element */
+.button {
+  width: 100%;
+  vertical-align: middle;
+  border: none;
+  margin: 0;
+  padding: 0;
+  text-decoration: none;
+  background: transparent;
+  color: #ffffff;
+  font-family: sans-serif;
+  font-size: 14px;
+  line-height: 24px;
+  font-weight: bold;
+  font-family: Arial, sans-serif;
+  cursor: pointer;
+  text-align: center;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+}
+
+.button:hover {}
+.button:focus {
+  outline: 0;
+}
+.button:active {}
+
+svg, img, ::slotted(svg), ::slotted(img) {
+  width: var(--media-button-icon-width, 24px);
+  height: var(--media-button-icon-height);
+  transform: var(--media-button-icon-transform);
+  transition: var(--media-button-icon-transition);
+  fill: var(--media-icon-color, #eee);
+  vertical-align: middle;
+}
+</style>
+
+<div class="button"></div>
+`;
+
+
+const slotTemplate = document.createElement('template');
+slotTemplate.innerHTML = `
+  <style>
+  #status {
+    color: rgba(0,0,0,0);
+    width: 0px;
+    height: 0px;
+  }
+  :host(:not([${MediaUIAttributes.MEDIA_LOADING}])) slot[name=loading] > *, 
+  :host(:not([${MediaUIAttributes.MEDIA_LOADING}])) ::slotted([slot=loading]),
+  :host(:not([${MediaUIAttributes.MEDIA_LOADING}])) #status {
+    display: none;
+  }
+  </style>
+
+  <slot name="loading">${loadingIndicatorIcon}</slot>
+  <div id="status" role="status" aria-live="polite">${nouns.MEDIA_LOADING()}</div>
+`;
+
+class MediaLoadingIndicator extends window.HTMLElement {
+  
+  static get observedAttributes() {
+    return [MediaUIAttributes.MEDIA_CONTROLLER, MediaUIAttributes.MEDIA_PAUSED, MediaUIAttributes.MEDIA_LOADING, 'loading-delay'];
+  }
+  
+  constructor(options={}) {
+    super();
+
+    const shadow = this.attachShadow({ mode: 'open' });
+
+    const indicatorHTML = template.content.cloneNode(true);
+    this.nativeEl = indicatorHTML.querySelector('div');
+
+    // Slots
+    const indicatorSlotTemplate = options.slotTemplate ?? slotTemplate;
+    this.nativeEl.appendChild(indicatorSlotTemplate.content.cloneNode(true));
+
+    shadow.appendChild(indicatorHTML);
+  }
+  
+  attributeChangedCallback(attrName, oldValue, newValue) {
+    if (attrName === MediaUIAttributes.MEDIA_CONTROLLER) {
+      if (oldValue) {
+        const mediaControllerEl = document.getElementById(oldValue);
+        mediaControllerEl?.unassociateElement?.(this);
+      }
+      if (newValue) {
+        const mediaControllerEl = document.getElementById(newValue);
+        mediaControllerEl?.associateElement?.(this);
+      }
+    }
+  }
+
+  connectedCallback() {
+    const mediaControllerId = this.getAttribute(MediaUIAttributes.MEDIA_CONTROLLER);
+    if (mediaControllerId) {
+      const mediaControllerEl = document.getElementById(mediaControllerId);
+      mediaControllerEl?.associateElement?.(this);
+    }
+  }
+
+  disconnectedCallback() {
+    const mediaControllerSelector = this.getAttribute(MediaUIAttributes.MEDIA_CONTROLLER);
+    if (mediaControllerSelector) {
+      const mediaControllerEl = document.getElementById(mediaControllerId);
+      mediaControllerEl?.unassociateElement?.(this);
+    }
+  }
+}
+
+defineCustomElement('media-loading-indicator', MediaLoadingIndicator);
+
+export default MediaLoadingIndicator;

--- a/src/js/media-loading-indicator.js
+++ b/src/js/media-loading-indicator.js
@@ -45,7 +45,7 @@ template.innerHTML = `
 }
 
 svg, img, ::slotted(svg), ::slotted(img) {
-  width: var(--media-loading-icon-width, 50px);
+  width: var(--media-loading-icon-width, 44px);
   height: var(--media-loading-icon-height);
   fill: var(--media-icon-color, #fff);
   vertical-align: middle;

--- a/src/js/media-loading-indicator.js
+++ b/src/js/media-loading-indicator.js
@@ -86,7 +86,7 @@ class MediaLoadingIndicator extends window.HTMLElement {
         this.removeAttribute('is-loading');
       } else if (newValue != undefined) {
         const loadingDelay =
-          +this.getAttribute('loading-delay') ?? DEFAULT_LOADING_DELAY;
+          +(this.getAttribute('loading-delay') ?? DEFAULT_LOADING_DELAY);
         this.loadingDelayHandle = setTimeout(() => {
           this.setAttribute('is-loading', '');
           this.loadingDelayHandle = undefined;

--- a/src/js/media-loading-indicator.js
+++ b/src/js/media-loading-indicator.js
@@ -38,8 +38,17 @@ template.innerHTML = `
   height: 0px;
 }
 
+:host slot[name=loading] > *,
+:host ::slotted([slot=loading]) {
+  opacity: 1;
+  transition: opacity 0.15s;
+}
+
 :host(:not([is-loading])) slot[name=loading] > *, 
-:host(:not([is-loading])) ::slotted([slot=loading]),
+:host(:not([is-loading])) ::slotted([slot=loading]) {
+  opacity: 0;
+}
+
 :host(:not([is-loading])) #status {
   display: none;
 }

--- a/src/js/media-loading-indicator.js
+++ b/src/js/media-loading-indicator.js
@@ -10,17 +10,16 @@ import {
 const template = document.createElement('template');
 
 const loadingIndicatorIcon = `
-<svg version="1.1" id="L9" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-  viewBox="0 0 100 100" enable-background="new 0 0 0 0" xml:space="preserve">
-    <path d="M73,50c0-12.7-10.3-23-23-23S27,37.3,27,50 M30.9,50c0-10.5,8.5-19.1,19.1-19.1S69.1,39.5,69.1,50">
-      <animateTransform 
-         attributeName="transform" 
-         attributeType="XML" 
-         type="rotate"
-         dur="1s" 
-         from="0 50 50"
-         to="360 50 50" 
-         repeatCount="indefinite" />
+<svg viewBox="0 0 100 100">
+  <path d="M73,50c0-12.7-10.3-23-23-23S27,37.3,27,50 M30.9,50c0-10.5,8.5-19.1,19.1-19.1S69.1,39.5,69.1,50">
+    <animateTransform
+       attributeName="transform"
+       attributeType="XML"
+       type="rotate"
+       dur="1s"
+       from="0 50 50"
+       to="360 50 50"
+       repeatCount="indefinite" />
   </path>
 </svg>
 `;

--- a/src/js/media-loading-indicator.js
+++ b/src/js/media-loading-indicator.js
@@ -77,14 +77,20 @@ class MediaLoadingIndicator extends window.HTMLElement {
   }
 
   attributeChangedCallback(attrName, oldValue, newValue) {
-    if (attrName === MediaUIAttributes.MEDIA_LOADING) {
-      if (newValue == undefined) {
+    if (
+      attrName === MediaUIAttributes.MEDIA_LOADING ||
+      attrName === MediaUIAttributes.MEDIA_PAUSED
+    ) {
+      const isPaused = this.getAttribute(MediaUIAttributes.MEDIA_PAUSED) != undefined;
+      const isMediaLoading = this.getAttribute(MediaUIAttributes.MEDIA_LOADING) != undefined;
+      const isLoading = !isPaused && isMediaLoading;
+      if (!isLoading) {
         if (this.loadingDelayHandle) {
           clearTimeout(this.loadingDelayHandle);
           this.loadingDelayHandle = undefined;
         }
         this.removeAttribute('is-loading');
-      } else if (newValue != undefined) {
+      } else if (!this.loadingDelayHandle && isLoading) {
         const loadingDelay =
           +(this.getAttribute('loading-delay') ?? DEFAULT_LOADING_DELAY);
         this.loadingDelayHandle = setTimeout(() => {
@@ -92,8 +98,7 @@ class MediaLoadingIndicator extends window.HTMLElement {
           this.loadingDelayHandle = undefined;
         }, loadingDelay);
       }
-    }
-    if (attrName === MediaUIAttributes.MEDIA_CONTROLLER) {
+    } else if (attrName === MediaUIAttributes.MEDIA_CONTROLLER) {
       if (oldValue) {
         const mediaControllerEl = document.getElementById(oldValue);
         mediaControllerEl?.unassociateElement?.(this);


### PR DESCRIPTION
Fixes #80 

A rejig of @cjpillsbury 's `<media-loading-indicator>`.

- Fixed a small bug with the `loading-delay` always being `0s`
- Added a snippet to propagate the `media-loading` state from controller to component.

I have a slight concern that depending on `waiting` and `stalling` is not robust enough.
Are these events always fired? Many iframe players don't expose these events.

Something that could also work is deriving this loading state from the playing state and whether the playhead is moving or not. Any thoughts on this?