### PR TITLE
Add loading indicator example and docs

### DIFF
--- a/docs/media-loading-indicator.md
+++ b/docs/media-loading-indicator.md
@@ -1,0 +1,30 @@
+# `<media-loading-indicator/>`
+
+Shows a loading indicator when the media is buffering.
+
+- [Source](../src/js/media-loading-indicator.js)
+- [Example](https://media-chrome.mux.dev/examples/control-elements/media-loading-indicator.html) ([Example Source](../examples/control-elements/media-loading-indicator.html))
+
+# Attributes
+
+| Name            | Type     | Default Value | Description                                                                                 |
+| --------------- | -------- | ------------- | ------------------------------------------------------------------------------------------- |
+| `loading-delay` | `number` | `500`         | The amount of time in ms the media has to be buffering before the loading indicator is shown. |
+
+# Slots
+
+| Name      | Default Type | Description                                                 |
+| --------- | ------------ | ----------------------------------------------------------- |
+| `loading` | `svg`        | The element shown for when the media is in a buffering state. |
+
+### Example
+
+```html
+<media-loading-indicator>
+  <svg slot="loading"><!-- your SVG --></svg>
+</media-loading-indicator>
+```
+
+# Styling
+
+See our [styling docs](./styling.md#Indicators)

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -69,6 +69,18 @@ Our current styling architecture is still quite nascent and is very likely to un
 | `--media-control-background`  | `background-color` | `rgba(20,20,30, 0.7)` | background color of the component                               | Applies to other components as well ([See notes below \*\*](#notes)) |
 | `--media-text-content-height` | `height`           | `24px`                | height of the underlying text container for text-based elements | Also applies to `<media-captions-button>` ([See §Buttons](#Buttons)) |
 
+## Indicators
+
+### Elements
+
+- `<media-loading-indicator/>` ([docs](./media-loading-indicator.md))
+
+| Name                           | CSS Property       | Default Value         | Description  | Notes |
+| -----------------------------  | ------------------ | --------------------- | ------------ | ----- |
+| `--media-loading-icon-width`   | `width` | `44px` | width of the loading icon      |       |
+| `--media-loading-icon-height`  | `height` | `auto` | height of the loading icon      |       |
+| `--media-icon-color`  | `fill` | `#fff` | color of the loading icon      | Only applies to `<img>` and `<svg>`      |
+
 # Notes
 
 \* Unlike most Media Chrome buttons, the `<media-playback-rate-button/>` button displays text (and not an icon/svg), so many [button styles](#buttons) don't apply to it and some [text display styles](#text-displays) do apply to it (unlike most buttons).

--- a/examples/control-elements/media-loading-indicator.html
+++ b/examples/control-elements/media-loading-indicator.html
@@ -13,11 +13,11 @@
 
 <h1>&lt;media-loading-indicator&gt;</h1>
 
-<h3>Default (not loading)</h3>
+<h3>Default (hidden by default, media is not buffering)</h3>
 
 <media-loading-indicator></media-loading-indicator>
 
-<h3>Is loading</h3>
+<h3>Is loading (media is buffering)</h3>
 
 <media-loading-indicator is-loading></media-loading-indicator>
 

--- a/examples/control-elements/media-loading-indicator.html
+++ b/examples/control-elements/media-loading-indicator.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta name="viewport" content="width=device-width">
+  <script type="module" src="../../dist/media-loading-indicator.js"></script>
+  <style>
+    media-loading-indicator {
+      --media-icon-color: #f0f;
+    }
+  </style>
+</head>
+<body>
+
+<h1>&lt;media-loading-indicator&gt;</h1>
+
+<h3>Default (not loading)</h3>
+
+<media-loading-indicator></media-loading-indicator>
+
+<h3>Is loading</h3>
+
+<media-loading-indicator is-loading></media-loading-indicator>
+
+<h3>Alternate content</h3>
+<media-loading-indicator is-loading>
+  <svg slot="loading" viewBox="-12 -15 48 60"><path d="M0 0h4v10H0z"><animateTransform attributeType="xml" attributeName="transform" type="translate" values="0 0; 0 20; 0 0" begin="0" dur="0.6s" repeatCount="indefinite"/></path><path d="M10 0h4v10h-4z"><animateTransform attributeType="xml" attributeName="transform" type="translate" values="0 0; 0 20; 0 0" begin="0.2s" dur="0.6s" repeatCount="indefinite"/></path><path d="M20 0h4v10h-4z"><animateTransform attributeType="xml" attributeName="transform" type="translate" values="0 0; 0 20; 0 0" begin="0.4s" dur="0.6s" repeatCount="indefinite"/></path></svg>
+</media-loading-indicator>
+
+</body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -45,6 +45,7 @@
     <li><a href="control-elements/media-current-time-display.html">Current time display</a></li>
     <li><a href="control-elements/media-time-display.html">Time display</a></li>
     <li><a href="control-elements/media-duration-display.html">Duration display</a></li>
+    <li><a href="control-elements/media-loading-indicator.html">Loading indicator</a></li>
     <li><a href="control-elements/media-seek-backward-button.html">Seek backward button</a></li>
     <li><a href="control-elements/media-seek-forward-button.html">Seek forward button</a></li>
     <li><a href="control-elements/media-fullscreen-button.html">Fullscreen button</a></li>


### PR DESCRIPTION
This change adds an example and the docs for the `<media-loading-indicator>` element.
The code is already merged to main:
https://github.com/muxinc/media-chrome/commit/abc07f6a198c1fc7d630caf8ed0c63dcc7872c3b