### PR TITLE
Remove stalled event for loading indicator

### DIFF
--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -261,7 +261,7 @@ class MediaController extends MediaContainer {
       'ratechange': () => {
         this.propagateMediaState(MediaUIAttributes.MEDIA_PLAYBACK_RATE, this.media.playbackRate);
       },
-      'waiting,stalled,playing': () => {
+      'waiting,playing': () => {
         const isLoading = this.media?.readyState < 3;
         this.propagateMediaState(MediaUIAttributes.MEDIA_LOADING, isLoading);
       }


### PR DESCRIPTION
From @heff's comment https://github.com/muxinc/media-chrome/pull/127#discussion_r792955048