### PR TITLE
Add fixes for PiP and Fullscreen

### DIFF
--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -90,14 +90,24 @@ class MediaController extends MediaContainer {
       // This current assumes that the media controller is the fullscreen element
       // which may be true in most cases but not all.
       // The prior version of media-chrome supported alt fullscreen elements
-      // and that's something we can work towards here
+      // and that's something we can work towards here.
+      //
+      // Generally the fullscreen and PiP API's have the exit methods and enabled
+      // flags on the `document`. The active element is accessed on the document
+      // or shadow root. Entering fullscreen or PiP is called on the element. i.e.
+      //
+      //   - Document.exitFullscreen()
+      //   - Document.fullscreenEnabled
+      //   - Document.fullscreenElement / ShadowRoot.fullscreenElement
+      //   - Element.requestFullscreen()
+      //
       MEDIA_ENTER_FULLSCREEN_REQUEST: () => {
         const docOrRoot = this.getRootNode();
         const media = this.media;
 
         if (docOrRoot.pictureInPictureElement) {
           // Should be async
-          docOrRoot.exitPictureInPicture();
+          document.exitPictureInPicture();
         }
 
         if (super[fullscreenApi.enter]) {
@@ -124,11 +134,11 @@ class MediaController extends MediaContainer {
         const docOrRoot = this.getRootNode();
         const media = this.media;
 
-        if (!docOrRoot.pictureInPictureEnabled) return;
+        if (!document.pictureInPictureEnabled) return;
 
         // Exit fullscreen if needed
         if (docOrRoot[fullscreenApi.element]) {
-          docOrRoot[fullscreenApi.exit]();
+          document[fullscreenApi.exit]();
         }
 
         media.requestPictureInPicture();
@@ -136,7 +146,10 @@ class MediaController extends MediaContainer {
       MEDIA_EXIT_PIP_REQUEST: () => {
         const docOrRoot = this.getRootNode();
 
-        if (docOrRoot.exitPictureInPicture) docOrRoot.exitPictureInPicture();
+        if (docOrRoot.pictureInPictureElement) {
+          // Should be async
+          document.exitPictureInPicture();
+        }
       },
       MEDIA_SEEK_REQUEST: (e) => {
         const media = this.media;

--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -126,9 +126,6 @@ class MediaController extends MediaContainer {
       },
       MEDIA_EXIT_FULLSCREEN_REQUEST: () => {
         document[fullscreenApi.exit]();
-
-        // Shadow root throws an error for this function
-        // this.getRootNode()[fullscreenApi.exit]();
       },
       MEDIA_ENTER_PIP_REQUEST: () => {
         const docOrRoot = this.getRootNode();

--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -15,6 +15,7 @@ import {
 } from './utils/server-safe-globals.js';
 import { fullscreenApi } from './utils/fullscreenApi.js';
 import { constToCamel } from './utils/stringUtils.js';
+import { containsWithShadow } from './utils/element-utils.js';
 
 import {
   MediaUIEvents,
@@ -666,9 +667,10 @@ class MediaController extends MediaContainer {
   }
 
   get isPip() {
-    return (
-      this.media && this.media == document.pictureInPictureElement
-    );
+    const pipElement =
+      this.getRootNode().pictureInPictureElement ??
+      document.pictureInPictureElement;
+    return this.media && containsWithShadow(this.media, pipElement);
   }
 
   requestPictureInPicture() {

--- a/src/js/utils/element-utils.js
+++ b/src/js/utils/element-utils.js
@@ -14,3 +14,11 @@ export const getAllSlotted = (el, name) => {
 };
 
 export const getSlotted = (el, name) => getAllSlotted(el, name)[0];
+
+export const containsWithShadow = (refNode, otherNode) => {
+  if (!refNode || !otherNode) return false;
+  if (refNode.contains(otherNode)) return true;
+  return [refNode, ...refNode.querySelectorAll("*")].some((el) => {
+    return containsWithShadow(el.shadowRoot, otherNode);
+  });
+}


### PR DESCRIPTION
This change adds some fixes for PiP and fullscreen when media-chrome itself is part of a shadow DOM.

`this.getRootNode();` would then point to the shadow root instead of the document which caused some issues.
Some properties and methods of both PiP and fullscreen always have to be accessed on the `document` according to the docs:

https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API
https://developer.mozilla.org/en-US/docs/Web/API/Picture-in-Picture_API

- [x] Test on mobile when preview is ready
- [x] Test no issues come up with youtube-video-element. This does not support PiP.