### PR TITLE
feat/availability-states: Add support for availability detection and state management. Update advanced and mobile examples for demo purposes.

### DIFF
--- a/examples/advanced.html
+++ b/examples/advanced.html
@@ -12,6 +12,15 @@
       media-loading-indicator {
         --media-loading-icon-width: 100px;
       }
+
+      media-airplay-button[media-airplay-unavailable] {
+        display: none;
+      }
+
+      media-volume-range[media-volume-unavailable] {
+        display: none;
+      }
+
     </style>
   </head>
   <body>
@@ -53,6 +62,7 @@
           <media-playback-rate-button></media-playback-rate-button>
           <media-pip-button></media-pip-button>
           <media-fullscreen-button></media-fullscreen-button>
+          <media-airplay-button></media-airplay-button>
         </media-control-bar>
       </media-controller>
       <div class="examples">

--- a/examples/advanced.html
+++ b/examples/advanced.html
@@ -21,6 +21,10 @@
         display: none;
       }
 
+      media-pip-button[media-pip-unavailable] {
+        display: none;
+      }
+
     </style>
   </head>
   <body>

--- a/examples/mobile.html
+++ b/examples/mobile.html
@@ -15,6 +15,14 @@
         margin-top: 20px;
       }
 
+      media-airplay-button[media-airplay-unavailable] {
+        display: none;
+      }
+
+      media-volume-range[media-volume-unavailable] {
+        display: none;
+      }
+
       /* Breaking these up into two selectors to demonstrate how this could work with a new custom "contaienr" element (CJP) */
       media-controller .centered-controls-overlay {
         align-self: stretch;
@@ -99,6 +107,7 @@
           <media-playback-rate-button></media-playback-rate-button>
           <media-pip-button></media-pip-button>
           <media-fullscreen-button></media-fullscreen-button>
+          <media-airplay-button></media-button-button>
         </media-control-bar>
       </media-controller>
       <div class="examples">

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -23,13 +23,18 @@ export const MediaUIEvents = {
 };
 
 export const MediaUIAttributes = {
+  MEDIA_AIRPLAY_UNAVAILABLE: 'media-airplay-unavailable',
   MEDIA_PAUSED: 'media-paused',
   MEDIA_MUTED: 'media-muted',
   MEDIA_VOLUME_LEVEL: 'media-volume-level',
   MEDIA_VOLUME: 'media-volume',
+  MEDIA_VOLUME_UNAVAILABLE: 'media-volume-unavailable',
   MEDIA_IS_PIP: 'media-is-pip',
   MEDIA_CAPTIONS_LIST: 'media-captions-list',
   MEDIA_SUBTITLES_LIST: 'media-subtitles-list',
+  // Include this for styling convenience or exclude since it
+  // can be derived from MEDIA_CAPTIONS_LIST && MEDIA_SUBTITLES_LIST? (CJP)
+  MEDIA_CAPTIONS_UNAVAILABLE: 'media-captions-unavailable',
   MEDIA_CAPTIONS_SHOWING: 'media-captions-showing',
   MEDIA_SUBTITLES_SHOWING: 'media-subtitles-showing',
   MEDIA_IS_FULLSCREEN: 'media-is-fullscreen',
@@ -63,4 +68,9 @@ export const ReadyStates = {
   HAVE_CURRENT_DATA: 2,
   HAVE_FUTURE_DATA: 3,
   HAVE_ENOUGH_DATA: 4,
+};
+
+export const AvailabilityStates = {
+  UNAVAILABLE: 'unavailable',
+  UNSUPPORTED: 'unsupported',
 };

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -24,6 +24,7 @@ export const MediaUIEvents = {
 
 export const MediaUIAttributes = {
   MEDIA_AIRPLAY_UNAVAILABLE: 'media-airplay-unavailable',
+  MEDIA_PIP_UNAVAILABLE: 'media-pip-unavailable',
   MEDIA_PAUSED: 'media-paused',
   MEDIA_MUTED: 'media-muted',
   MEDIA_VOLUME_LEVEL: 'media-volume-level',

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -33,9 +33,6 @@ export const MediaUIAttributes = {
   MEDIA_IS_PIP: 'media-is-pip',
   MEDIA_CAPTIONS_LIST: 'media-captions-list',
   MEDIA_SUBTITLES_LIST: 'media-subtitles-list',
-  // Include this for styling convenience or exclude since it
-  // can be derived from MEDIA_CAPTIONS_LIST && MEDIA_SUBTITLES_LIST? (CJP)
-  MEDIA_CAPTIONS_UNAVAILABLE: 'media-captions-unavailable',
   MEDIA_CAPTIONS_SHOWING: 'media-captions-showing',
   MEDIA_SUBTITLES_SHOWING: 'media-subtitles-showing',
   MEDIA_IS_FULLSCREEN: 'media-is-fullscreen',

--- a/src/js/media-airplay-button.js
+++ b/src/js/media-airplay-button.js
@@ -9,7 +9,6 @@ import { verbs } from './labels/labels.js';
 const airplayIcon = `<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 18"><defs><style>.cls-1{fill:var(--media-icon-color, #eee);}</style></defs><title>Mux Player SVG Icons_v2</title><path class="cls-1" d="M10.19,11.22a.25.25,0,0,0-.38,0L4.35,17.59a.25.25,0,0,0,.19.41H15.46a.25.25,0,0,0,.19-.41Z"/><path class="cls-1" d="M19,0H1A1,1,0,0,0,0,1V14a1,1,0,0,0,1,1H3.94L5,13.75H1.25V1.25h17.5v12.5H15L16.06,15H19a1,1,0,0,0,1-1V1A1,1,0,0,0,19,0Z"/></svg>`;
 
 const slotTemplate = document.createElement('template');
-// Followup task: determine how/where we want to handle checks and style updates for (1) unsupported & (2) unavailable
 slotTemplate.innerHTML = `
   <style>
   </style>
@@ -19,7 +18,10 @@ slotTemplate.innerHTML = `
 
 class MediaAirplayButton extends MediaChromeButton {
   static get observedAttributes() {
-    return [...super.observedAttributes];
+    return [
+      ...super.observedAttributes,
+      MediaUIAttributes.MEDIA_AIRPLAY_UNAVAILABLE,
+    ];
   }
 
   constructor(options = {}) {

--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -943,9 +943,9 @@ const monitorForMediaStateReceivers = (
 };
 
 let testMediaEl;
-export const getTestMediaEl = (nodeName = 'video') => {
+export const getTestMediaEl = () => {
   if (testMediaEl) return testMediaEl;
-  testMediaEl = document?.createElement?.(nodeName);
+  testMediaEl = document?.createElement?.('video');
   return testMediaEl;
 };
 
@@ -954,7 +954,7 @@ export const hasVolumeSupportAsync = async (mediaEl = getTestMediaEl()) => {
   const prevVolume = mediaEl.volume;
   mediaEl.volume = prevVolume / 2 + 0.1;
   return Promise.resolve().then(() => {
-    mediaEl.volume !== prevVolume;
+    return mediaEl.volume !== prevVolume;
   });
 };
 
@@ -966,6 +966,7 @@ const pipSupported = hasPipSupport();
 let volumeSupported;
 const volumeSupportPromise = hasVolumeSupportAsync().then((supported) => {
   volumeSupported = supported;
+  return volumeSupported;
 });
 
 const airplaySupported = !!window.WebKitPlaybackTargetAvailabilityEvent;

--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -61,6 +61,7 @@ class MediaController extends MediaContainer {
       volumeSupportPromise.then(() => {
         if (!volumeSupported) {
           this._volumeUnavailable = AvailabilityStates.UNSUPPORTED;
+          this.propagateMediaState(MediaUIAttributes.MEDIA_VOLUME_UNAVAILABLE, this.volumeUnavailable);
         }
       });
     }
@@ -953,8 +954,10 @@ export const hasVolumeSupportAsync = async (mediaEl = getTestMediaEl()) => {
   if (!mediaEl) return false;
   const prevVolume = mediaEl.volume;
   mediaEl.volume = prevVolume / 2 + 0.1;
-  return Promise.resolve().then(() => {
-    return mediaEl.volume !== prevVolume;
+  return new Promise((resolve, _reject) => {
+    setTimeout(() => {
+      resolve(mediaEl.volume !== prevVolume);
+    }, 0)
   });
 };
 

--- a/src/js/media-pip-button.js
+++ b/src/js/media-pip-button.js
@@ -37,7 +37,7 @@ const updateAriaLabel = (el) => {
 
 class MediaPipButton extends MediaChromeButton {
   static get observedAttributes() {
-    return [...super.observedAttributes, MediaUIAttributes.MEDIA_IS_PIP];
+    return [...super.observedAttributes, MediaUIAttributes.MEDIA_IS_PIP, MediaUIAttributes.MEDIA_PIP_UNAVAILABLE];
   }
 
   constructor(options = {}) {

--- a/src/js/media-volume-range.js
+++ b/src/js/media-volume-range.js
@@ -23,6 +23,7 @@ class MediaVolumeRange extends MediaChromeRange {
       ...super.observedAttributes,
       MediaUIAttributes.MEDIA_VOLUME,
       MediaUIAttributes.MEDIA_MUTED,
+      MediaUIAttributes.MEDIA_VOLUME_UNAVAILABLE,
     ];
   }
 


### PR DESCRIPTION
This PR adds basic support for availability/support detection, as discussed in #134 
Currently implemented generic volume and airplay detection, with pending attributes for closed captions. Note there are still some decisions "around the edges" that have yet to be resolved.

Issuing this now to facilitate the conversation, start preliminary review, and potentially merge with the possibility of followup PRs to pin down any outstanding discussion points.