### PR TITLE
Add more selective css to prevent overwrites

### DIFF
--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -82,21 +82,24 @@ template.innerHTML = `
       height: 100% !important;
     }
 
-    /* Hide controls when inactive and not paused and not audio */
     ::slotted(:not([slot=media])) {
+      pointer-events: auto;
+    }
+
+    /* Only add these if auto hide is not disabled */
+    ::slotted(:not([slot=media]):not([no-auto-hide])) {
       opacity: 1;
       transition: opacity 0.25s;
-      visibility: visible;
-      pointer-events: auto;
+    }
+
+    /* Hide controls when inactive, not paused, not audio and auto hide not disabled */
+    :host([user-inactive]:not([${MediaUIAttributes.MEDIA_PAUSED}]):not([audio])) ::slotted(:not([slot=media]):not([no-auto-hide])) {
+      opacity: 0;
+      transition: opacity 1s;
     }
 
     ::slotted(media-control-bar)  {
       align-self: stretch;
-    }
-
-    :host([user-inactive]:not([${MediaUIAttributes.MEDIA_PAUSED}]):not([audio])) ::slotted(:not([slot=media]):not([no-auto-hide])) {
-      opacity: 0;
-      transition: opacity 1s;
     }
   </style>
 


### PR DESCRIPTION
This change only adds the opacity and transition CSS if the element does not have `no-auto-hide`.

This fixes an issue where these non auto hiding elements want to set opacity or transition themselves and it would get overwritten by the CSS in media-container.

Also removed `visibility: visible` in this change as it's unneeded I believe. it's the default.