### PR TITLE
Add media-has-played attribute

### DIFF
--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -24,6 +24,7 @@ export const MediaUIEvents = {
 
 export const MediaUIAttributes = {
   MEDIA_PAUSED: 'media-paused',
+  MEDIA_HAS_PLAYED: 'media-has-played',
   MEDIA_MUTED: 'media-muted',
   MEDIA_VOLUME_LEVEL: 'media-volume-level',
   MEDIA_VOLUME: 'media-volume',

--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -257,6 +257,9 @@ class MediaController extends MediaContainer {
       'play,pause': () => {
         this.propagateMediaState(MediaUIAttributes.MEDIA_PAUSED, this.paused);
       },
+      playing: () => {
+        this.propagateMediaState(MediaUIAttributes.MEDIA_HAS_PLAYED, !this.media?.paused);
+      }, 
       volumechange: () => {
         this.propagateMediaState(MediaUIAttributes.MEDIA_MUTED, this.muted);
         this.propagateMediaState(MediaUIAttributes.MEDIA_VOLUME, this.volume);


### PR DESCRIPTION
When working on a custom poster experience I really found myself missing the `videojs-has-started` class. In the Media Chrome world that felt like it could be a `media-has-played` attribute that's `true` forever after the `playing` event fires for the first time. This is proposing a new attribute, so normally I'd go through a discussion first, but since this was so tiny I figured it was ok to put out there for feedback. 

How should I be thinking about testing this?