### PR TITLE
Create Sandbox on Postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "dev": "snowpack dev --config snowpack.dev.config.cjs",
     "start": "yarn dev",
     "test": "web-test-runner --coverage --config test/web-test-runner.config.js",
-    "publish-patch": "yarn run build && np patch --no-tests --any-branch"
+    "publish-patch": "yarn run build && np patch --no-tests --any-branch",
+    "postinstall": "mkdirp sandbox"
   },
   "repository": {
     "type": "git",
@@ -40,6 +41,7 @@
   "devDependencies": {
     "@open-wc/testing": "^3.0.1",
     "@web/test-runner": "^0.13.20",
+    "mkdirp": "^1.0.4",
     "np": "^7.6.0",
     "prettier": "^2.5.1",
     "rimraf": "^3.0.2",


### PR DESCRIPTION
This will make sure sandbox exists on a fresh/updated install of media-chrome for devs, based on assumptions in the current build configs.