### PR TITLE
improv/thumbnails-different-dims: Update thumbnail and time range to …

### DIFF
--- a/examples/media-elements/mux-video.html
+++ b/examples/media-elements/mux-video.html
@@ -19,10 +19,15 @@
           metadata-video-id="video-id-12345"
           metadata-video-title="Mad Max: Fury Road Trailer"
           metadata-viewer-user-id="user-id-6789"
-          stream-type="vod"
-          autoplay
+          stream-type="on-demand"
           muted
         >
+          <track
+            label="thumbnails"
+            default
+            kind="metadata"
+            src="https://image.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/storyboard.vtt"
+          />
         </mux-video>
         <media-control-bar>
           <media-play-button></media-play-button>

--- a/src/js/media-thumbnail-preview.js
+++ b/src/js/media-thumbnail-preview.js
@@ -16,17 +16,13 @@ const template = document.createElement('template');
 template.innerHTML = `
   <style>
     :host {
-      box-sizing: border-box;
       background-color: #000;
-      width: 284px;
-      height: 160px;
-      overflow: hidden;
+      height: auto;
+      width: auto;
     }
 
     img {
-      position: absolute;
-      left: 0;
-      top: 0;
+      object-fit: none;
     }
   </style>
   <img crossorigin loading="eager" decoding="async" />
@@ -99,18 +95,15 @@ class MediaThumbnailPreviewElement extends window.HTMLElement {
       MediaUIAttributes.MEDIA_PREVIEW_IMAGE
     );
     if (!(mediaPreviewCoordsStr && mediaPreviewImage)) return;
-    // const { offsetWidth } = this;
-    const offsetWidth = this.offsetWidth;
     const img = this.shadowRoot.querySelector('img');
-    const [x, y, w, _h] = mediaPreviewCoordsStr
+    const [x, y, w, h] = mediaPreviewCoordsStr
       .split(/\s+/)
       .map((coord) => +coord);
     const src = mediaPreviewImage;
-    const scale = offsetWidth / w || 1;
 
     const resize = () => {
-      img.style.width = `${scale * img.naturalWidth}px`;
-      img.style.height = `${scale * img.naturalHeight}px`;
+      img.style.height = `${h}px`;
+      img.style['aspect-ratio'] = `${w} / ${h}`;
     };
 
     if (img.src !== src) {
@@ -120,8 +113,7 @@ class MediaThumbnailPreviewElement extends window.HTMLElement {
     }
 
     resize();
-    img.style.left = `-${scale * x}px`;
-    img.style.top = `-${scale * y}px`;
+    img.style['object-position'] = `-${x}px -${y}px`
   }
 }
 

--- a/src/js/media-time-range.js
+++ b/src/js/media-time-range.js
@@ -26,21 +26,16 @@ template.innerHTML = `
   <style>
     #thumbnailContainer {
       display: none;
-      position: absolute;
-      top: 0;
     }
 
     media-thumbnail-preview {
+      /* Scale the thumbnail preview to 50% and reposition appropriately to not take up too much real-estate. */
+      transform: scale(0.5) translateY(50%) translateX(-100%);
       position: absolute;
-      bottom: 10px;
+      bottom: calc(100% + 5px);
       border: 2px solid #fff;
       border-radius: 2px;
       background-color: #000;
-      width: 160px;
-      height: 90px;
-
-      /* Negative offset of half to center on the handle */
-      margin-left: -80px;
     }
 
     /* Can't get this working. Trying a downward triangle. */


### PR DESCRIPTION
…handle different dims for thumbnails instead of hard-coded assumptions. Update mux-video example to demo and cleanup attrs.

Playback ID for portrait aspect-ratio content/thumbnails: dMTG3n6VfNyhRPM02mXY5AhPSk9E34bFqyqVm02gAAHD00

Note that this currently relies on different styling to handle relative positioning within the thumbnail image and resizing the thumbnail to a reasonable size for most content (using scale). While this is an improvement on the current implementation, which assumed more specific dimensions and didn't actually reliably fit the thumbnail content, there are cases where extremely large or non-standard proportions will take up a notably larger amount of space. We may want to do a followup to support configurable (re)scaling via e.g. css variable(s), but I think this could be treated as a followup PR to handle the more complex position + scale mathematical relationships.