### PR TITLE
bugfix: fix hovering over an active controller with no poster

### DIFF
--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -39,7 +39,7 @@ template.innerHTML = `
       background: none;
     }
 
-    :host(:not([audio])) :is([part~=gestures-layer],[part~=media-layer],[part~=poster-layer])  {
+    :host(:not([audio])) :is([part~=gestures-layer],[part~=media-layer])  {
       pointer-events: auto;
     }
     


### PR DESCRIPTION
Noticed this while I was testing something unrelated, but currently hovering over a playing stream that _doesn't_ have a poster image is broken.