### PR TITLE
Add max/min css vars for the thumb previews

### DIFF
--- a/docs/styling.md
+++ b/docs/styling.md
@@ -59,9 +59,13 @@ Our current styling architecture is still quite nascent and is very likely to un
 
 - `<media-time-range/>` ([docs](./media-time-range.md))
 
-| Name                          | CSS Property          | Default Value | Description                            | Notes                                                                         |
-| ----------------------------- | --------------------- | ------------- | -------------------------------------- | ----------------------------------------------------------------------------- |
-| `--media-time-buffered-color` | `<linear-color-stop>` | `#777`        | background color of the buffered range | This is a `<linear-color-stop>` part of the `linear-gradient()` CSS function. |
+| Name                                   | CSS Property          | Default Value | Description                            | Notes                                                                                      |
+| -------------------------------------- | --------------------- | ------------- | -------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `--media-time-buffered-color`          | `<linear-color-stop>` | `#777`        | background color of the buffered range | This is a `<linear-color-stop>` part of the `linear-gradient()` CSS function.              |
+| `--media-thumbnail-preview-min-width`  | `width`               | `120px`       | minimum thumbnail preview width        | The maximum CSS properties have priority over the minimum. Only `px` values are supported. |
+| `--media-thumbnail-preview-max-width`  | `width`               | `200px`       | maximum thumbnail preview width        | The maximum CSS properties have priority over the minimum. Only `px` values are supported. |
+| `--media-thumbnail-preview-min-height` | `height`              | `80px`        | minimum thumbnail preview height       | The maximum CSS properties have priority over the minimum. Only `px` values are supported. |
+| `--media-thumbnail-preview-max-height` | `height`              | `160px`       | maximum thumbnail preview height       | The maximum CSS properties have priority over the minimum. Only `px` values are supported. |
 
 ## Text Displays
 

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -59,13 +59,15 @@ Our current styling architecture is still quite nascent and is very likely to un
 
 - `<media-time-range/>` ([docs](./media-time-range.md))
 
-| Name                                   | CSS Property          | Default Value | Description                            | Notes                                                                                      |
-| -------------------------------------- | --------------------- | ------------- | -------------------------------------- | ------------------------------------------------------------------------------------------ |
-| `--media-time-buffered-color`          | `<linear-color-stop>` | `#777`        | background color of the buffered range | This is a `<linear-color-stop>` part of the `linear-gradient()` CSS function.              |
-| `--media-thumbnail-preview-min-width`  | `width`               | `120px`       | minimum thumbnail preview width        | The maximum CSS properties have priority over the minimum. Only `px` values are supported. |
-| `--media-thumbnail-preview-max-width`  | `width`               | `200px`       | maximum thumbnail preview width        | The maximum CSS properties have priority over the minimum. Only `px` values are supported. |
-| `--media-thumbnail-preview-min-height` | `height`              | `80px`        | minimum thumbnail preview height       | The maximum CSS properties have priority over the minimum. Only `px` values are supported. |
-| `--media-thumbnail-preview-max-height` | `height`              | `160px`       | maximum thumbnail preview height       | The maximum CSS properties have priority over the minimum. Only `px` values are supported. |
+| Name                                      | CSS Property          | Default Value    | Description                            | Notes                                                                                      |
+| ----------------------------------------- | --------------------- | ---------------- | -------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `--media-time-buffered-color`             | `<linear-color-stop>` | `#777`           | background color of the buffered range | This is a `<linear-color-stop>` part of the `linear-gradient()` CSS function.              |
+| `--media-thumbnail-preview-border`        | `border`              | `2px solid #fff` | border of the thumbnail preview        |                                                                                            |
+| `--media-thumbnail-preview-border-radius` | `border-radius`       | `2px`            | border radius of the thumbnail preview |                                                                                            |
+| `--media-thumbnail-preview-min-width`     | `width`               | `120px`          | minimum thumbnail preview width        | The maximum CSS properties have priority over the minimum. Only `px` values are supported. |
+| `--media-thumbnail-preview-max-width`     | `width`               | `200px`          | maximum thumbnail preview width        | The maximum CSS properties have priority over the minimum. Only `px` values are supported. |
+| `--media-thumbnail-preview-min-height`    | `height`              | `80px`           | minimum thumbnail preview height       | The maximum CSS properties have priority over the minimum. Only `px` values are supported. |
+| `--media-thumbnail-preview-max-height`    | `height`              | `160px`          | maximum thumbnail preview height       | The maximum CSS properties have priority over the minimum. Only `px` values are supported. |
 
 ## Text Displays
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -12,6 +12,7 @@
       <li><a href="basic.html">Basic example</a></li>
       <li><a href="advanced.html">Advanced example</a></li>
       <li><a href="mobile.html">Mobile example</a></li>
+      <li><a href="vertical.html">Vertical video example</a></li>
       <li><a href="standalone-controls.html">Standalone controls</a></li>
       <li>
         <a href="slots-demo.html"

--- a/examples/vertical.html
+++ b/examples/vertical.html
@@ -5,6 +5,17 @@
     <title>Media Chrome Vertical Video Usage Example</title>
     <script type="module" src="../dist/index.js"></script>
     <style>
+      /** add styles to prevent CLS (Cumulative Layout Shift) */
+      media-controller:not([audio]) {
+        display: block;         /* expands the container if preload=none */
+        max-width: 360px;       /* allows the container to shrink if small */
+        aspect-ratio: 9 / 16;   /* set container aspect ratio if preload=none */
+      }
+
+      video {
+        width: 100%;      /* prevents video to expand beyond its container */
+      }
+
       .examples {
         margin-top: 20px;
       }
@@ -54,17 +65,10 @@
         </div>
         <media-control-bar>
           <media-play-button></media-play-button>
-          <media-seek-backward-button seek-offset="15"></media-seek-backward-button>
-          <media-seek-forward-button seek-offset="15"></media-seek-forward-button>
           <media-mute-button></media-mute-button>
-          <media-volume-range></media-volume-range>
           <media-time-range></media-time-range>
-          <media-time-display show-duration remaining></media-time-display>
-          <media-captions-button default-showing></media-captions-button>
-          <media-playback-rate-button></media-playback-rate-button>
-          <media-pip-button></media-pip-button>
+          <media-time-display remaining></media-time-display>
           <media-fullscreen-button></media-fullscreen-button>
-          <media-airplay-button></media-airplay-button>
         </media-control-bar>
       </media-controller>
       <div class="examples">

--- a/examples/vertical.html
+++ b/examples/vertical.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width" />
+    <title>Media Chrome Vertical Video Usage Example</title>
+    <script type="module" src="../dist/index.js"></script>
+    <style>
+      .examples {
+        margin-top: 20px;
+      }
+
+      media-loading-indicator {
+        --media-loading-icon-width: 100px;
+      }
+
+      media-airplay-button[media-airplay-unavailable] {
+        display: none;
+      }
+
+      media-volume-range[media-volume-unavailable] {
+        display: none;
+      }
+
+      media-pip-button[media-pip-unavailable] {
+        display: none;
+      }
+
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Media Chrome Vertical Video Usage Example</h1>
+      <media-controller>
+        <video
+          slot="media"
+          src="https://stream.mux.com/1EFcsL5JET00t00mBv01t00xt00T4QeNQtsXx2cKY6DLd7RM/high.mp4"
+          preload="none"
+          muted
+          crossorigin
+        >
+          <track
+            label="thumbnails"
+            default
+            kind="metadata"
+            src="https://image.mux.com/1EFcsL5JET00t00mBv01t00xt00T4QeNQtsXx2cKY6DLd7RM/storyboard.vtt"
+          />
+        </video>
+        <media-poster-image
+          slot="poster"
+          src="https://image.mux.com/1EFcsL5JET00t00mBv01t00xt00T4QeNQtsXx2cKY6DLd7RM/thumbnail.jpg"
+        ></media-poster-image>
+        <div slot="centered-chrome" no-auto-hide>
+          <media-loading-indicator media-loading></media-loading-indicator>
+        </div>
+        <media-control-bar>
+          <media-play-button></media-play-button>
+          <media-seek-backward-button seek-offset="15"></media-seek-backward-button>
+          <media-seek-forward-button seek-offset="15"></media-seek-forward-button>
+          <media-mute-button></media-mute-button>
+          <media-volume-range></media-volume-range>
+          <media-time-range></media-time-range>
+          <media-time-display show-duration remaining></media-time-display>
+          <media-captions-button default-showing></media-captions-button>
+          <media-playback-rate-button></media-playback-rate-button>
+          <media-pip-button></media-pip-button>
+          <media-fullscreen-button></media-fullscreen-button>
+          <media-airplay-button></media-airplay-button>
+        </media-control-bar>
+      </media-controller>
+      <div class="examples">
+        <a href="./">View more examples</a>
+      </div>
+    </main>
+  </body>
+</html>

--- a/src/js/media-thumbnail-preview.js
+++ b/src/js/media-thumbnail-preview.js
@@ -22,6 +22,7 @@ template.innerHTML = `
     }
 
     img {
+      display: block;
       object-fit: none;
     }
   </style>

--- a/src/js/media-time-range.js
+++ b/src/js/media-time-range.js
@@ -41,8 +41,8 @@ template.innerHTML = `
       transform-origin: 50% 100%;
       position: absolute;
       bottom: calc(100% + 5px);
-      border: 2px solid #fff;
-      border-radius: 2px;
+      border: var(--media-thumbnail-preview-border, 2px solid #fff);
+      border-radius: var(--media-thumbnail-preview-border-radius, 2px);
       background-color: #000;
     }
 

--- a/src/js/media-time-range.js
+++ b/src/js/media-time-range.js
@@ -34,14 +34,15 @@ template.innerHTML = `
     }
 
     media-thumbnail-preview {
-      --thumb-min-width: var(--media-thumbnail-preview-min-width, 120px);
-      --thumb-max-width: var(--media-thumbnail-preview-max-width, 200px);
-      --thumb-min-height: var(--media-thumbnail-preview-min-height, 80px);
-      --thumb-max-height: var(--media-thumbnail-preview-max-height, 160px);
+      --thumb-preview-min-width: var(--media-thumbnail-preview-min-width, 120px);
+      --thumb-preview-max-width: var(--media-thumbnail-preview-max-width, 200px);
+      --thumb-preview-min-height: var(--media-thumbnail-preview-min-height, 80px);
+      --thumb-preview-max-height: var(--media-thumbnail-preview-max-height, 160px);
+      --thumb-preview-border: 2px solid #fff;
       transform-origin: 50% 100%;
       position: absolute;
       bottom: calc(100% + 5px);
-      border: var(--media-thumbnail-preview-border, 2px solid #fff);
+      border: var(--media-thumbnail-preview-border, var(--thumb-preview-border, 2px solid #fff));
       border-radius: var(--media-thumbnail-preview-border-radius, 2px);
       background-color: #000;
     }
@@ -228,16 +229,16 @@ class MediaTimeRange extends MediaChromeRange {
 
         const thumbStyle = getComputedStyle(this.thumbnailPreview);
         const thumbMinWidth = parseInt(
-          thumbStyle.getPropertyValue('--thumb-min-width')
+          thumbStyle.getPropertyValue('--thumb-preview-min-width')
         );
         const thumbMaxWidth = parseInt(
-          thumbStyle.getPropertyValue('--thumb-max-width')
+          thumbStyle.getPropertyValue('--thumb-preview-max-width')
         );
         const thumbMinHeight = parseInt(
-          thumbStyle.getPropertyValue('--thumb-min-height')
+          thumbStyle.getPropertyValue('--thumb-preview-min-height')
         );
         const thumbMaxHeight = parseInt(
-          thumbStyle.getPropertyValue('--thumb-max-height')
+          thumbStyle.getPropertyValue('--thumb-preview-max-height')
         );
 
         // Use client dimensions instead of offset dimensions to exclude borders.
@@ -260,11 +261,21 @@ class MediaTimeRange extends MediaChromeRange {
             : 1;
 
         this.thumbnailPreview.style.transform = `translateX(${thumbnailLeft}px) scale(${thumbScale})`;
+
+        let thumbBorderWidth = parseInt(
+          thumbStyle.getPropertyValue('--media-thumbnail-preview-border')
+        );
+        if (Number.isNaN(thumbBorderWidth)) {
+          thumbBorderWidth = parseInt(
+            thumbStyle.getPropertyValue('--thumb-preview-border')
+          );
+        }
+
         this.thumbnailPreview.style.borderWidth = `${Math.round(
-          2 / thumbScale
+          thumbBorderWidth / thumbScale
         )}px`;
         this.thumbnailPreview.style.borderRadius = `${Math.round(
-          2 / thumbScale
+          thumbBorderWidth / thumbScale
         )}px`;
 
         const detail = mousePercent * duration;

--- a/src/js/media-time-range.js
+++ b/src/js/media-time-range.js
@@ -35,7 +35,7 @@ template.innerHTML = `
 
     media-thumbnail-preview {
       --thumb-preview-min-width: var(--media-thumbnail-preview-min-width, 120px);
-      --thumb-preview-max-width: var(--media-thumbnail-preview-max-width, 200px);
+      --thumb-preview-max-width: var(--media-thumbnail-preview-max-width, 180px);
       --thumb-preview-min-height: var(--media-thumbnail-preview-min-height, 80px);
       --thumb-preview-max-height: var(--media-thumbnail-preview-max-height, 160px);
       --thumb-preview-border: 2px solid #fff;


### PR DESCRIPTION
Related to https://github.com/muxinc/media-chrome/pull/171

Adds a configurable max and min width for the thumb preview.
This uses a CSS transform: scale() to up and down scale to the max and min width via JS if needed. A small down side is that the border also scales with that, this is solved by setting each CSS property again with the scale factored in with JS.

Also changed the positioning via `style.left` to `style.transform = translate` because this should perform better.
https://www.paulirish.com/2012/why-moving-elements-with-translate-is-better-than-posabs-topleft/

### Fixes 2 small issues

- bottom black border in thumb preview
- fading out animation did not work because of the CSS display prop

### TODO

 - [ ] An improvement for future iterations is that the thumbnail preview should not go out of the player's bounds which it does currently. Not specific to this PR, this behavior is the same on main.

### Motivation

![SCR-20220306-pg7](https://user-images.githubusercontent.com/360826/156948925-b087d930-e2af-4b3e-a11e-c9e44238fe3e.jpeg)