### PR TITLE
Add custom elements manifest analyzer + plugin

### DIFF
--- a/custom-elements-manifest.config.js
+++ b/custom-elements-manifest.config.js
@@ -1,0 +1,131 @@
+import fs from 'fs';
+import {
+  getDeclarationInFile,
+  hasIgnoreJSDoc,
+  isCustomElementsDefineCall,
+} from '@custom-elements-manifest/analyzer/src/utils/ast-helpers.js';
+import { resolveModuleOrPackageSpecifier } from '@custom-elements-manifest/analyzer/src/utils/index.js';
+
+export function camelCase(name) {
+  return name.replace(/[-_]([a-z])/g, ($0, $1) => $1.toUpperCase());
+}
+
+const packageData = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+const { name, description, version, author, homepage, license } = packageData;
+
+export default {
+  globs: ['src/js/media-*', 'src/js/extras'],
+  outdir: 'dist',
+  plugins: [
+    // Append package data
+    {
+      name: 'mediachrome-package-data',
+      packageLinkPhase({ customElementsManifest }) {
+        customElementsManifest.package = {
+          name,
+          description,
+          version,
+          author,
+          homepage,
+          license,
+        };
+      },
+    },
+    defineCustomElementCallsPlugin(),
+  ],
+};
+
+/**
+ * defineCustomElementCalls
+ * Adapted from https://github.com/open-wc/custom-elements-manifest/blob/master/packages/analyzer/src/features/analyse-phase/custom-elements-define-calls.js
+ *
+ * Analyzes calls for:
+ * @example defineCustomElement()
+ */
+export function defineCustomElementCallsPlugin() {
+  let counter;
+  return {
+    name: 'mediachrome-defineCustomElement',
+    analyzePhase({ ts, node, moduleDoc, context }) {
+      if (node?.kind === ts.SyntaxKind.SourceFile) {
+        counter = 0;
+      }
+
+      if (hasIgnoreJSDoc(node)) return;
+
+      /**
+       * @example defineCustomElement('my-el', MyEl);
+       */
+      if (isDefineCustomElementCall(node, ts)) {
+        const classArg = node.parent.arguments[1];
+        // let isAnonymousClass = classArg?.kind === ts.SyntaxKind.ClassExpression;
+        let isUnnamed = classArg?.name === undefined;
+
+        // if (isAnonymousClass) {
+        //   const klass = createClass(classArg, moduleDoc, context);
+
+        //   if (isUnnamed) {
+        //     klass.name = `anonymous_${counter}`;
+        //   }
+        //   moduleDoc.declarations.push(klass);
+        // }
+
+        let elementClass;
+
+        /**
+         * @example defineCustomElement('m-e', class extends HTMLElement{})
+         *                                            ^
+         */
+        if (isUnnamed) {
+          elementClass = `anonymous_${counter}`;
+          counter = counter + 1;
+        }
+
+        /**
+         * @example defineCustomElement('m-e', MyElement)
+         *                                       ^^^^^^^^^
+         */
+        if (node?.parent?.arguments?.[1]?.text) {
+          elementClass = node.parent.arguments[1].text;
+        }
+
+        /**
+         * @example defineCustomElement('m-e', class MyElement extends HTMLElement{})
+         *                                             ^^^^^^^^^
+         */
+        if (classArg?.name) {
+          elementClass = classArg?.name?.getText();
+        }
+
+        const elementTag = node.parent.arguments[0].text;
+
+        const klass = getDeclarationInFile(elementClass, node?.getSourceFile());
+
+        if (hasIgnoreJSDoc(klass)) return;
+
+        const definitionDoc = {
+          kind: 'custom-element-definition',
+          name: elementTag,
+          declaration: {
+            name: elementClass,
+            ...resolveModuleOrPackageSpecifier(
+              moduleDoc,
+              context,
+              elementClass
+            ),
+          },
+        };
+
+        moduleDoc.exports = [...(moduleDoc.exports || []), definitionDoc];
+      }
+    },
+  };
+}
+
+/**
+ * @example defineCustomElement('my-el', MyEl);
+ */
+const isDefineCustomElementCall = (node, ts) => {
+  return node?.getText() === 'defineCustomElement' &&
+    node?.parent?.kind === ts.SyntaxKind.CallExpression;
+}

--- a/package.json
+++ b/package.json
@@ -2,8 +2,9 @@
   "name": "media-chrome",
   "version": "0.5.3",
   "description": "Custom elements (web components) for making audio and video player controls that look great in your website or app.",
-  "main": "dist/index.js",
   "type": "module",
+  "main": "dist/index.js",
+  "customElements": "dist/custom-elements.json",
   "files": [
     "dist/*",
     "README.md",
@@ -14,7 +15,8 @@
     "clean": "rimraf dist",
     "build:esm": "esbuild src/js/*.js src/js/*/*.js --target=es2019 --format=esm --outdir=dist --minify --sourcemap",
     "build:react": "node ./scripts/react/build.js",
-    "build": "yarn build:esm && yarn build:react",
+    "build:manifest": "cem analyze",
+    "build": "yarn build:esm && yarn build:react && yarn build:manifest",
     "dev": "node ./scripts/esbuild.js",
     "start": "yarn dev",
     "test": "web-test-runner --coverage --config test/web-test-runner.config.js",
@@ -40,6 +42,7 @@
   },
   "homepage": "https://github.com/muxinc/media-chrome#readme",
   "devDependencies": {
+    "@custom-elements-manifest/analyzer": "^0.5.7",
     "@open-wc/testing": "^3.0.1",
     "@web/test-runner": "^0.13.20",
     "esbuild": "^0.14.23",

--- a/src/js/media-airplay-button.js
+++ b/src/js/media-airplay-button.js
@@ -16,6 +16,13 @@ slotTemplate.innerHTML = `
   <slot name="airplay">${airplayIcon}</slot>
 `;
 
+/**
+ * @attr {(unavailable|unsupported)} media-airplay-unavailable
+ *
+ * @slot airplay
+ *
+ * @event {CustomEvent} mediaairplayrequest
+ */
 class MediaAirplayButton extends MediaChromeButton {
   static get observedAttributes() {
     return [

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,6 +23,20 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@custom-elements-manifest/analyzer@^0.5.7":
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/@custom-elements-manifest/analyzer/-/analyzer-0.5.7.tgz#8ae74ede984f9a8f8717f4d938cb542c72af8db8"
+  integrity sha512-pKQM0dAUPAaoAWJvPSpFtxAc1/pi0xb8wKYSUJbCBYwWA5L8vf/UowDaV0m9G3CtbiqkHI/4eKzFAqE14iY6vg==
+  dependencies:
+    "@web/config-loader" "0.1.3"
+    chokidar "3.5.2"
+    command-line-args "5.1.2"
+    comment-parser "1.2.4"
+    custom-elements-manifest "1.0.0"
+    debounce "1.2.1"
+    globby "11.0.4"
+    typescript "~4.3.2"
+
 "@esm-bundle/chai@^4.3.4":
   version "4.3.4"
   resolved "https://registry.npmjs.org/@esm-bundle/chai/-/chai-4.3.4.tgz"
@@ -491,7 +505,7 @@
   dependencies:
     errorstacks "^2.2.0"
 
-"@web/config-loader@^0.1.3":
+"@web/config-loader@0.1.3", "@web/config-loader@^0.1.3":
   version "0.1.3"
   resolved "https://registry.npmjs.org/@web/config-loader/-/config-loader-0.1.3.tgz"
   integrity sha512-XVKH79pk4d3EHRhofete8eAnqto1e8mCRAqPV00KLNFzCWSe8sWmLnqKCqkPNARC6nksMaGrATnA5sPDRllMpQ==
@@ -771,6 +785,11 @@ array-back@^4.0.1:
   resolved "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz"
   integrity sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==
 
+array-back@^6.1.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/array-back/-/array-back-6.2.2.tgz#f567d99e9af88a6d3d2f9dfcc21db6f9ba9fd157"
+  integrity sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==
+
 array-union@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz"
@@ -990,7 +1009,7 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
-chokidar@^3.4.3:
+chokidar@3.5.2, chokidar@^3.4.3:
   version "3.5.2"
   resolved "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz"
   integrity sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==
@@ -1123,6 +1142,16 @@ color-name@~1.1.4:
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+command-line-args@5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/command-line-args/-/command-line-args-5.1.2.tgz#25908e573d2214bc23a8437e3df853b02dffa425"
+  integrity sha512-fytTsbndLbl+pPWtS0CxLV3BEWw9wJayB8NnU2cbQqVPsNdYezQeT+uIQv009m+GShnMNyuoBrRo8DTmuTfSCA==
+  dependencies:
+    array-back "^6.1.2"
+    find-replace "^3.0.0"
+    lodash.camelcase "^4.3.0"
+    typical "^4.0.0"
+
 command-line-args@^5.1.1:
   version "5.2.0"
   resolved "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.0.tgz"
@@ -1142,6 +1171,11 @@ command-line-usage@^6.1.1:
     chalk "^2.4.2"
     table-layout "^1.0.1"
     typical "^5.2.0"
+
+comment-parser@1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.2.4.tgz#489f3ee55dfd184a6e4bffb31baba284453cb760"
+  integrity sha512-pm0b+qv+CkWNriSTMsfnjChF9kH0kxz55y44Wo5le9qLxMj5xDQAaEd9ZN1ovSuk9CsrncWaFwgpOMg7ClJwkw==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -1212,12 +1246,17 @@ crypto-random-string@^2.0.0:
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
   integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
 
+custom-elements-manifest@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/custom-elements-manifest/-/custom-elements-manifest-1.0.0.tgz#b35c2129076a1dc9f95d720c6f7b5b71a857274b"
+  integrity sha512-j59k0ExGCKA8T6Mzaq+7axc+KVHwpEphEERU7VZ99260npu/p/9kd+Db+I3cGKxHkM5y6q5gnlXn00mzRQkX2A==
+
 date-fns@^1.27.2:
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
-debounce@^1.2.0:
+debounce@1.2.1, debounce@^1.2.0:
   version "1.2.1"
   resolved "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz"
   integrity sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==
@@ -1775,7 +1814,7 @@ global-dirs@^3.0.0:
   dependencies:
     ini "2.0.0"
 
-globby@^11.0.1:
+globby@11.0.4, globby@^11.0.1:
   version "11.0.4"
   resolved "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz"
   integrity sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==
@@ -3934,6 +3973,11 @@ typedarray-to-buffer@^3.1.5:
   integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
   dependencies:
     is-typedarray "^1.0.0"
+
+typescript@~4.3.2:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
+  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
 
 typical@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
This change is the start for adding a custom elements manifest.
Related to https://github.com/muxinc/media-chrome/discussions/158

A little downside of Media Chrome using constant variables is that the analyzer can't pick the attributes and events up automatically. An alternative is to use special JSDoc syntax to get these picked up.
https://custom-elements-manifest.open-wc.org/analyzer/getting-started/#supported-jsdoc

I added one example for the Airplay button.

The custom function `defineCustomElement()` in Media Chrome was causing issues too, luckily this could be automated with a plugin. The analyzer expects `customElements.define('my-el')`.