### PR TITLE
Add a experimental expandable control-strip

### DIFF
--- a/examples/advanced.html
+++ b/examples/advanced.html
@@ -63,8 +63,10 @@
           <media-play-button></media-play-button>
           <media-seek-backward-button seek-offset="15"></media-seek-backward-button>
           <media-seek-forward-button seek-offset="15"></media-seek-forward-button>
-          <media-mute-button></media-mute-button>
-          <media-volume-range></media-volume-range>
+          <media-control-strip>
+            <media-mute-button slot="open-button"></media-mute-button>
+            <media-volume-range></media-volume-range>
+          </media-control-strip>
           <media-time-range></media-time-range>
           <media-time-display show-duration remaining></media-time-display>
           <media-captions-button default-showing></media-captions-button>

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -7,6 +7,7 @@ import MediaChromeButton from './media-chrome-button.js';
 import MediaController from './media-controller.js';
 import MediaChromeRange from './media-chrome-range.js';
 import MediaControlBar from './media-control-bar.js';
+import MediaControlStrip from './media-control-strip.js';
 import MediaCurrentTimeDisplay from './media-current-time-display.js';
 import MediaDurationDisplay from './media-duration-display.js';
 import MediaTimeDisplay from './media-time-display.js';
@@ -56,6 +57,7 @@ export {
   MediaController,
   MediaChromeRange,
   MediaControlBar,
+  MediaControlStrip,
   MediaCurrentTimeDisplay,
   MediaDurationDisplay,
   MediaTimeDisplay,

--- a/src/js/media-control-strip.js
+++ b/src/js/media-control-strip.js
@@ -1,0 +1,80 @@
+/**
+ * <media-control-strip>
+ * Expand or collapse some or all controls.
+ * @see https://en.wikipedia.org/wiki/Control_Strip
+ */
+import { MediaUIAttributes } from './constants.js';
+import { defineCustomElement } from './utils/defineCustomElement.js';
+import {
+  Window as window,
+  Document as document,
+} from './utils/server-safe-globals.js';
+
+const template = document.createElement('template');
+
+template.innerHTML = `
+  <style>
+    :host {
+      position: relative;
+      display: flex;
+    }
+
+    .strip {
+      overflow: hidden;
+      transition: var(--media-control-strip-transition-open, width .2s cubic-bezier(0,0,0.2,1));
+    }
+
+    :host([vertical]) .strip  {
+      position: absolute;
+      transform-origin: 0 0;
+      transform: rotate(-90deg);
+    }
+
+    :host(:not([open])) .strip {
+      width: 0;
+      transition: var(--media-control-strip-transition-close, width .2s cubic-bezier(0.4,0,1,1));
+    }
+  </style>
+
+  <slot name="open-button"></slot>
+  <div class="strip">
+    <slot></slot>
+  </div>
+`;
+
+class MediaControlStrip extends window.HTMLElement {
+  static get observedAttributes() {
+    return [MediaUIAttributes.MEDIA_CONTROLLER, 'open', 'vertical'];
+  }
+
+  constructor() {
+    super();
+
+    this.attachShadow({ mode: 'open' });
+    this.shadowRoot.appendChild(template.content.cloneNode(true));
+
+    const slotEl = this.shadowRoot.querySelector('.strip slot');
+    slotEl.addEventListener('slotchange', () => {
+      let width = 0;
+      slotEl.assignedElements().forEach((el) => {
+        width += el.offsetWidth;
+      });
+
+      // Set to an absolute width in pixels for the slide animation.
+      [...this.shadowRoot.styleSheets[0].cssRules].find(
+        (x) => x.selectorText.includes('.strip')
+      ).style.width = `${width}px`;
+    });
+
+    const openButtonEvent = this.getAttribute('open-button-event') ?? 'mouseover';
+    this.shadowRoot
+      .querySelector('[name="open-button"]')
+      .addEventListener(openButtonEvent, () => this.setAttribute('open', ''));
+
+    this.addEventListener('mouseleave', () => this.removeAttribute('open'));
+  }
+}
+
+defineCustomElement('media-control-strip', MediaControlStrip);
+
+export default MediaControlStrip;


### PR DESCRIPTION
Related to https://github.com/muxinc/media-chrome/discussions/123

This adds a new component to make it super easy to add an expandable part in the control bar like
https://en.wikipedia.org/wiki/Control_Strip

For the volume range but can also work like in the Apple Magic touch bar where part of the controls are hidden and there is a special expand button.

Still experimental and needs a few more attributes to make it work like the magic touch bar.
Also thoughts on accessibility are welcome.

https://media-chrome-git-fork-luwes-control-strip-mux.vercel.app/examples/advanced.html