### PR TITLE
fix: use mouseleave instead of mouseout

### DIFF
--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -330,7 +330,7 @@ class MediaContainer extends window.HTMLElement {
     });
 
     // Immediately hide if mouse leaves the container
-    this.addEventListener('mouseout', (e) => {
+    this.addEventListener('mouseleave', (e) => {
       if (this.autohide < 0) return;
       this.setAttribute('user-inactive', 'user-inactive');
       const evt = new window.CustomEvent(


### PR DESCRIPTION
With mouseout, we would get an event each time we cross an element
boundary, meaning we could end up marking the player as inactive as a
user is mousing around in the player. Instead, we should use mouseleave
that would only trigger when we leave the entire element including its
children.