### PR TITLE
Add support for media swapping in chained slots

### DIFF
--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -193,6 +193,26 @@ class MediaContainer extends window.HTMLElement {
 
     const observer = new MutationObserver(mutationCallback);
     observer.observe(this, { childList: true, subtree: true });
+
+    // Handles the case when the slotted media element is a slot element itself.
+    // e.g. chaining media slots for media themes.
+    let currentMedia = this.media;
+    let chainedSlot = this.querySelector(':scope > slot[slot=media]');
+    if (chainedSlot) {
+      chainedSlot.addEventListener('slotchange', () => {
+        const slotEls = chainedSlot.assignedElements({ flatten: true });
+        if (!slotEls.length) {
+          this.mediaUnsetCallback(currentMedia);
+          return;
+        }
+        if (this.media) {
+          currentMedia = this.media
+          this.handleMediaUpdated(this.media).then((media) =>
+            this.mediaSetCallback(media)
+          );
+        }
+      });
+    }
   }
 
   static get observedAttributes() {

--- a/test/unit/media-theme.spec.js
+++ b/test/unit/media-theme.spec.js
@@ -1,0 +1,56 @@
+import { spy } from 'sinon';
+import { fixture, assert, waitUntil } from '@open-wc/testing';
+import { MediaUIAttributes, MediaUIEvents } from '../../src/js/constants';
+import '../../src/js/index.js';
+import '../../src/js/themes/media-theme-netflix.js';
+
+describe('<media-theme/>', () => {
+  it('can change media between media themes and media controllers', async () => {
+    const theme1 = await fixture(`
+      <media-theme-netflix>
+        <video slot="media" muted src="https://stream.mux.com/O6LdRc0112FEJXH00bGsN9Q31yu5EIVHTgjTKRkKtEq1k/low.mp4"></video>
+      </media-theme-netflix>
+    `);
+
+    const media = theme1.querySelector('[slot="media"]');
+    await media.play();
+
+    assert(
+      theme1.shadowRoot
+        .querySelector('media-controller')
+        .hasAttribute('media-current-time')
+    );
+
+    const theme2 = await fixture(`
+      <media-theme-netflix></media-theme-netflix>
+    `);
+
+    theme2.append(media);
+
+    await waitUntil(() =>
+      theme1.shadowRoot
+        .querySelector('media-controller')
+        .hasAttribute('media-paused')
+    );
+
+    assert(
+      theme1.shadowRoot
+        .querySelector('media-controller')
+        .hasAttribute('media-paused'),
+      'should be reset to paused state on mediaUnsetCallback'
+    );
+
+    await waitUntil(() =>
+      theme2.shadowRoot
+        .querySelector('media-controller')
+        .hasAttribute('media-current-time')
+    );
+
+    assert(
+      theme2.shadowRoot
+        .querySelector('media-controller')
+        .hasAttribute('media-current-time'),
+      'should have a media-current-time attribute on mediaSetCallback'
+    );
+  });
+});


### PR DESCRIPTION
This change adds support for swapping out slotted media slots aka `<slot name="media" slot="media"></slot>` which might come in useful when you'd like to switch a Media Theme but keep the same video element.

See the bug without this change here (click the Switch Theme button):
https://elements-demo-vanilla-git-fork-luwes-media-theme-mux-mux.vercel.app/mux-player.html