### PR TITLE
Make MC sizing based on video element size

### DIFF
--- a/examples/advanced.html
+++ b/examples/advanced.html
@@ -5,6 +5,11 @@
     <title>Media Chrome Advanced Video Usage Example</title>
     <script type="module" src="../dist/index.js"></script>
     <style>
+      video {
+        width: 720px;
+        aspect-ratio: 16 / 9;
+      }
+
       .examples {
         margin-top: 20px;
       }

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -4,6 +4,16 @@
     <meta name="viewport" content="width=device-width" />
     <title>Media Chrome Basic Audio and Video Usage Example</title>
     <script type="module" src="../dist/index.js"></script>
+    <style>
+      video {
+        width: 720px;
+        aspect-ratio: 16 / 9;
+      }
+
+      .examples {
+        margin-top: 20px;
+      }
+    </style>
   </head>
   <body>
     <main>
@@ -46,6 +56,9 @@
           <media-fullscreen-button></media-fullscreen-button>
         </media-control-bar>
       </media-controller>
+      <div class="examples">
+        <a href="./">View more examples</a>
+      </div>
     </main>
   </body>
 </html>

--- a/examples/media-elements/dash.html
+++ b/examples/media-elements/dash.html
@@ -5,6 +5,11 @@
     <title>Media Chrome DASH Media Example</title>
     <script type="module" src="https://unpkg.com/dash-video-element@0"></script>
     <script type="module" src="../../dist/index.js"></script>
+    <style>
+      .examples {
+        margin-top: 20px;
+      }
+    </style>
   </head>
   <body>
     <main>
@@ -22,6 +27,9 @@
           <media-fullscreen-button></media-fullscreen-button>
         </media-control-bar>
       </media-controller>
+      <div class="examples">
+        <a href="../">View more examples</a>
+      </div>
     </main>
   </body>
 </html>

--- a/examples/media-elements/hls.html
+++ b/examples/media-elements/hls.html
@@ -5,6 +5,18 @@
     <title>Media Chrome HLS Media Example</title>
     <script type="module" src="https://unpkg.com/hls-video-element@0"></script>
     <script type="module" src="../../dist/index.js"></script>
+    <style>
+      hls-video {
+        display: inline-block;
+        width: 720px;
+        aspect-ratio: 16 / 9;
+        background-color: #000;
+      }
+
+      .examples {
+        margin-top: 20px;
+      }
+    </style>
   </head>
   <body>
     <main>
@@ -29,6 +41,9 @@
           <media-fullscreen-button></media-fullscreen-button>
         </media-control-bar>
       </media-controller>
+      <div class="examples">
+        <a href="../">View more examples</a>
+      </div>
     </main>
   </body>
 </html>

--- a/examples/media-elements/jwplayer.html
+++ b/examples/media-elements/jwplayer.html
@@ -8,6 +8,13 @@
         margin-top: 20px;
       }
 
+      jwplayer-video {
+        display: inline-block;
+        width: 720px;
+        aspect-ratio: 16 / 9;
+        background-color: #000;
+      }
+
       media-airplay-button[media-airplay-unavailable] {
         display: none;
       }
@@ -58,6 +65,9 @@
           <media-fullscreen-button></media-fullscreen-button>
         </media-control-bar>
       </media-controller>
+      <div class="examples">
+        <a href="../">View more examples</a>
+      </div>
     </main>
   </body>
 </html>

--- a/examples/media-elements/mux-video.html
+++ b/examples/media-elements/mux-video.html
@@ -8,6 +8,11 @@
       src="https://unpkg.com/@mux-elements/mux-video"
     ></script>
     <script type="module" src="../../dist/index.js"></script>
+    <style>
+      .examples {
+        margin-top: 20px;
+      }
+    </style>
   </head>
   <body>
     <main>
@@ -42,6 +47,9 @@
           <media-fullscreen-button></media-fullscreen-button>
         </media-control-bar>
       </media-controller>
+      <div class="examples">
+        <a href="../">View more examples</a>
+      </div>
     </main>
   </body>
 </html>

--- a/examples/media-elements/wistia.html
+++ b/examples/media-elements/wistia.html
@@ -8,6 +8,13 @@
         margin-top: 20px;
       }
 
+      wistia-video {
+        display: inline-block;
+        width: 720px;
+        aspect-ratio: 16 / 9;
+        background-color: #000;
+      }
+
       media-airplay-button[media-airplay-unavailable] {
         display: none;
       }
@@ -47,6 +54,9 @@
           <media-fullscreen-button></media-fullscreen-button>
         </media-control-bar>
       </media-controller>
+      <div class="examples">
+        <a href="../">View more examples</a>
+      </div>
     </main>
   </body>
 </html>

--- a/examples/media-elements/youtube.html
+++ b/examples/media-elements/youtube.html
@@ -8,6 +8,18 @@
       src="https://unpkg.com/youtube-video-element@0.0.6"
     ></script>
     <script type="module" src="../../dist/index.js"></script>
+    <style>
+      youtube-video {
+        display: inline-block;
+        width: 720px;
+        aspect-ratio: 16 / 9;
+        background-color: #000;
+      }
+
+      .examples {
+        margin-top: 20px;
+      }
+    </style>
   </head>
   <body>
     <main>
@@ -25,6 +37,9 @@
           <media-fullscreen-button></media-fullscreen-button>
         </media-control-bar>
       </media-controller>
+      <div class="examples">
+        <a href="../">View more examples</a>
+      </div>
     </main>
   </body>
 </html>

--- a/examples/mobile.html
+++ b/examples/mobile.html
@@ -11,6 +11,11 @@
         margin: 0px;
       }
 
+      video {
+        width: 320px;
+        aspect-ratio: 16 / 9;
+      }
+
       .examples {
         margin-top: 20px;
       }
@@ -39,11 +44,6 @@
         margin: 0 15%;
         --media-control-hover-background: none;
         --media-control-background: none;
-      }
-
-      media-controller {
-        max-width: 100vw;
-        max-height: 100vh;
       }
 
       *[slot='centered-chrome']

--- a/examples/slots-demo.html
+++ b/examples/slots-demo.html
@@ -24,12 +24,16 @@
       padding: 10px;
     }
 
+    video {
+      max-width: 960px;
+      aspect-ratio: 16 / 9;
+    }
+
     media-control-bar {
       background: none;
     }
 
     media-controller {
-      aspect-ratio: 16 / 9;
       --media-control-background: none;
     }
 
@@ -101,7 +105,7 @@
           <div
             slot="poster"
             class="first"
-            style="font-size: 128px"
+            style="font-size: 128px; line-height: initial;"
           >This is a poster.</div>
           <span slot="centered-chrome">
             <media-seek-backward-button></media-seek-backward-button>

--- a/examples/standalone-controls.html
+++ b/examples/standalone-controls.html
@@ -5,9 +5,13 @@
     <title>Media Chrome Standalone Controls Example</title>
     <script type="module" src="../dist/index.js"></script>
     <style>
-      media-controller {
+      video {
         width: 640px;
         height: 360px;
+      }
+
+      .examples {
+        margin-top: 20px;
       }
     </style>
   </head>
@@ -83,6 +87,10 @@
         <media-pip-button></media-pip-button>
         <media-fullscreen-button></media-fullscreen-button>
       </media-control-bar>
+
+      <div class="examples">
+        <a href="./">View more examples</a>
+      </div>
     </main>
   </body>
 </html>

--- a/examples/state-change-events-demo.html
+++ b/examples/state-change-events-demo.html
@@ -9,6 +9,11 @@
         margin-top: 20px;
       }
 
+      video {
+        width: 720px;
+        aspect-ratio: 16 / 9;
+      }
+
       media-airplay-button[media-airplay-unavailable] {
         display: none;
       }
@@ -22,6 +27,7 @@
       }
 
       #states-list {
+        margin-left: 10px;
         table-layout: fixed;
         flex-grow: 0;
         width: 100%;

--- a/examples/themes/demuxed-2021-theme.html
+++ b/examples/themes/demuxed-2021-theme.html
@@ -7,6 +7,20 @@
   </head>
   <body>
     <style>
+      .examples {
+        margin-top: 20px;
+      }
+
+      /* Hide custom elements that are not defined yet */
+      media-control-bar :not(:defined) {
+        display: none;
+      }
+
+      video {
+        width: 720px;
+        aspect-ratio: 16 / 9;
+      }
+
       media-control-bar > * {
         height: 42px;
         --media-control-background: #000;
@@ -620,6 +634,9 @@
           </media-fullscreen-button>
         </media-control-bar>
       </media-controller>
+      <div class="examples">
+        <a href="../">View more examples</a>
+      </div>
     </main>
   </body>
 </html>

--- a/examples/themes/spotify-theme.html
+++ b/examples/themes/spotify-theme.html
@@ -7,6 +7,7 @@
   <body>
     <style>
       .media-theme-spotify {
+        display: inline-block;
         min-width: 250px;
         max-width: 640px;
         color: #fff;

--- a/examples/themes/youtube-theme.html
+++ b/examples/themes/youtube-theme.html
@@ -8,6 +8,15 @@
   </head>
   <body>
     <style>
+      .examples {
+        margin-top: 20px;
+      }
+
+      video {
+        width: 720px;
+        aspect-ratio: 16 / 9;
+      }
+
       .media-theme-youtube * {
         font-size: 13px;
         font-family: Roboto, Arial, sans-serif;
@@ -119,7 +128,9 @@
           <media-fullscreen-button></media-fullscreen-button>
         </media-control-bar>
       </media-controller>
+      <div class="examples">
+        <a href="../">View more examples</a>
+      </div>
     </main>
-    <script></script>
   </body>
 </html>

--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -23,10 +23,11 @@ template.innerHTML = `
       box-sizing: border-box;
       position: relative;
       display: inline-block;
+      line-height: 0;
       background-color: #000;
     }
 
-    :host(:not([audio])) *[part~=layer] {
+    :host(:not([audio])) *[part~=layer]:not([part~=media-layer]) {
       position: absolute;
       top: 0;
       left: 0;
@@ -41,11 +42,6 @@ template.innerHTML = `
 
     :host(:not([audio])) :is([part~=gestures-layer],[part~=media-layer])  {
       pointer-events: auto;
-    }
-    
-    ::slotted([slot=poster]) {
-      width: 100%;
-      height: 100%;
     }
     
     :host(:not([audio])) *[part~=layer][part~=centered-layer] {
@@ -66,19 +62,8 @@ template.innerHTML = `
     }
 
     /* Video specific styles */
-    :host(:not([audio])) {
-      aspect-ratio: var(--media-aspect-ratio, auto 3 / 2);
-      width: 720px;
-    }
-
     :host(:not([audio])) .spacer {
       flex-grow: 1;
-    }
-
-    @supports not (aspect-ratio: 1 / 1) {
-      :host(:not([audio])) {
-        height: 480px;
-      }
     }
 
     /* Safari needs this to actually make the element fill the window */


### PR DESCRIPTION
Fixes #103

This change makes Media Chrome sizing based on the video element and behave the same.

It's a good thing I believe that the user is encouraged to set dimensions on Media Chrome because it will prevent cumulative layout shift. It's already too late for us to set default dimensions on Media Chrome internally because of the deferred nature of `<script type=module>`. A good example is to refresh the webpage a couple of times and see the difference between:

- https://media-chrome.mux.dev/examples/advanced.html
- https://media-chrome-git-fork-luwes-video-like-sizing-mux.vercel.app/examples/advanced.html

Look at the [View more examples](https://media-chrome.mux.dev/examples/) link or turn off javascript and compare.


Note that the default (with no video content) minimum video dimensions are 300x150 ~so some of the examples might look strange at the moment. These can fixed up by adding some simple CSS styles but I'll wait until we know for sure this is the way we like the sizing to behave.~ I added some CSS for these.

The `line-height: 0;` is there because it's an inline-block element, otherwise it would have a small bottom padding / gap.