### PR TITLE
fix: make media-time-display not wrap when small

### DIFF
--- a/src/js/media-time-display.js
+++ b/src/js/media-time-display.js
@@ -5,7 +5,7 @@ import { MediaUIAttributes } from './constants.js';
 import { nouns } from './labels/labels.js';
 // Todo: Use data locals: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString
 
-const DEFAULT_TIMES_SEP = ' / ';
+const DEFAULT_TIMES_SEP = '&nbsp;/&nbsp;';
 
 const formatTimesLabel = (el, { timesSep = DEFAULT_TIMES_SEP } = {}) => {
   const showRemaining = el.getAttribute('remaining') != null;
@@ -52,12 +52,6 @@ const updateAriaValueText = (el) => {
 };
 
 class MediaTimeDisplay extends MediaTextDisplay {
-  constructor() {
-    super();
-
-    this.shadowRoot.styleSheets[0].addRule(':host', 'white-space: nowrap');
-  }
-
   static get observedAttributes() {
     return [
       ...super.observedAttributes,

--- a/src/js/media-time-display.js
+++ b/src/js/media-time-display.js
@@ -52,6 +52,12 @@ const updateAriaValueText = (el) => {
 };
 
 class MediaTimeDisplay extends MediaTextDisplay {
+  constructor() {
+    super();
+
+    this.shadowRoot.styleSheets[0].addRule(':host', 'white-space: nowrap');
+  }
+
   static get observedAttributes() {
     return [
       ...super.observedAttributes,


### PR DESCRIPTION
media-time-display shows both the current or remaining time and the
duration separated by a slash. Around the slash, there are spaces, so,
when the control bar is small, this causes the element to wrap onto
multiple lines. This can cause unexpected styling issues with the
control bar.

The expectation of this element is to stay on one-line like the other
time displays.

While we could add this into media-text-display, it's already used for
non time displays in the examples, though, internally in media-chrome,
media-text-display is only used in the time displays.

Before:
![localhost_8000_examples_advanced html](https://user-images.githubusercontent.com/535884/163879010-2096627f-d263-4454-bf1f-aec223e0a2f3.png)

After
![localhost_8000_examples_advanced html (1)](https://user-images.githubusercontent.com/535884/163879016-96199940-c957-4230-947b-f4797e4256a7.png)
: