### PR TITLE
feat: export MediaTheme w/ overrideable render

### DIFF
--- a/examples/themes/netflix-theme.html
+++ b/examples/themes/netflix-theme.html
@@ -4,126 +4,33 @@
     <meta name="viewport" content="width=device-width" />
     <title>Media Chrome Netflix Theme Example</title>
     <script type="module" src="../../dist/index.js"></script>
+    <script type="module" src="../../src/js/themes/media-theme-netflix.js"></script>
   </head>
   <body>
     <style>
       body {
-        width: 100vw;
-        height: 100vh;
         margin: 0px;
       }
 
-      .media-theme-netflix {
+      media-theme-netflix {
         width: 100vw;
         height: 100vh;
-      }
-
-      .media-theme-netflix * {
-        font-size: 16px;
-        font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
-        color: #ddd;
-
-        --media-range-thumb-background: rgba(255, 0, 0, 1);
-        --media-range-track-height: 4px;
-        --media-range-track-transition: height 0.2s ease;
-        --media-range-track-background-color: #555;
-        --media-range-bar-color: rgb(229, 9, 20);
-        --media-control-hover-background: none;
-        --media-control-background: none;
-
-        --media-button-icon-width: 50px;
-        --media-button-icon-height: 50px;
-        --media-button-icon-transform: scale(1);
-        --media-button-icon-transition: transform 0.2s ease;
-      }
-
-      .media-theme-netflix *:hover {
-        --media-button-icon-transform: scale(1.2);
-        --media-button-icon-transition: transform 0.2s ease;
-      }
-
-      .media-theme-netflix media-control-bar {
-        align-items: center;
-      }
-
-      .media-theme-netflix media-time-range {
-        height: auto;
-        --media-range-thumb-height: 20px;
-        --media-range-thumb-width: 20px;
-        --media-range-thumb-border-radius: 20px;
-        --media-time-buffered-color: #777;
-      }
-
-      .media-theme-netflix media-time-range:hover {
-        --media-range-track-height: 9px;
-      }
-
-      .media-theme-netflix
-        :is(media-play-button, media-seek-backward-button, media-seek-forward-button, media-mute-button, media-fullscreen-button) {
-        height: 80px;
       }
     </style>
 
     <main aria-label="Media Chrome Netflix Theme Example">
-      <media-controller class="media-theme-netflix">
+      <media-theme-netflix>
         <video
           slot="media"
           src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/high.mp4"
           muted
           preload="none"
         ></video>
-        <media-control-bar>
-          <media-time-range></media-time-range>
-        </media-control-bar>
-        <media-control-bar>
-          <media-play-button></media-play-button>
-          <media-seek-backward-button></media-seek-backward-button>
-          <media-seek-forward-button></media-seek-forward-button>
-          <media-mute-button></media-mute-button>
-          <media-volume-range></media-volume-range>
-          <media-text-display style="margin-left: auto; margin-right: auto"
-            ><b>My Title</b> <span>P2:E4 Episode 4</span></media-text-display
-          >
-          <media-fullscreen-button>
-            <svg aria-hidden="true" slot="enter" viewBox="0 0 28 28">
-              <g transform="translate(2, 6)">
-                <polygon
-                  points="8 0 6 0 5.04614258 0 0 0 0 5 2 5 2 2 8 2"
-                ></polygon>
-                <polygon
-                  transform="translate(4, 13.5) scale(1, -1) translate(-4, -13.5) "
-                  points="8 11 6 11 5.04614258 11 0 11 0 16 2 16 2 13 8 13"
-                ></polygon>
-                <polygon
-                  transform="translate(20, 2.5) scale(-1, 1) translate(-20, -2.5) "
-                  points="24 0 22 0 21.0461426 0 16 0 16 5 18 5 18 2 24 2"
-                ></polygon>
-                <polygon
-                  transform="translate(20, 13.5) scale(-1, -1) translate(-20, -13.5) "
-                  points="24 11 22 11 21.0461426 11 16 11 16 16 18 16 18 13 24 13"
-                ></polygon>
-              </g>
-            </svg>
-            <svg aria-hidden="true" slot="exit" viewBox="0 0 28 28">
-              <g transform="translate(3, 6)">
-                <polygon
-                  transform="translate(19.000000, 3.000000) scale(-1, 1) translate(-19.000000, -3.000000) "
-                  points="22 0 20 0 20 4 16 4 16 6 22 6"
-                ></polygon>
-                <polygon
-                  transform="translate(19.000000, 13.000000) scale(-1, -1) translate(-19.000000, -13.000000) "
-                  points="22 10 20 10 20 14 16 14 16 16 22 16"
-                ></polygon>
-                <polygon points="6 0 4 0 4 4 0 4 0 6 6 6"></polygon>
-                <polygon
-                  transform="translate(3.000000, 13.000000) scale(1, -1) translate(-3.000000, -13.000000) "
-                  points="6 10 4 10 4 14 0 14 0 16 6 16"
-                ></polygon>
-              </g>
-            </svg>
-          </media-fullscreen-button>
-        </media-control-bar>
-      </media-controller>
+        <h3 slot="title">
+          <b>My Title</b>
+          <span>P2:E4 Episode 4</span>
+        </h3>
+      </media-theme-netflix>
     </main>
   </body>
 </html>

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -25,6 +25,7 @@ import MediaTimeRange from './media-time-range.js';
 import MediaLoadingIndicator from './media-loading-indicator.js';
 import MediaTitleElement from './media-title-element.js';
 import MediaVolumeRange from './media-volume-range.js';
+import MediaTheme from './themes/media-theme.js';
 import { Window as window } from './utils/server-safe-globals.js';
 
 // Alias <media-controller> as <media-chrome>
@@ -75,4 +76,5 @@ export {
   MediaTitleElement,
   MediaLoadingIndicator,
   MediaVolumeRange,
+  MediaTheme,
 };

--- a/src/js/themes/media-theme-netflix.js
+++ b/src/js/themes/media-theme-netflix.js
@@ -11,30 +11,30 @@ import MediaTheme from './media-theme.js';
 
 const template = `
 <style>
-  body {
-    font-family: "Helvetica Neue", sans-serif;
+  :host {
+    display: inline-block;
   }
 
   media-controller {
     width: 100%;
-    /* Keep the buttons from overflowing */
-    min-width: 420px;
-    height: 720px;
+    height: 100%;
 
-    --media-range-thumb-background: rgba(255,0,0, 1);
+    --media-range-thumb-background: rgba(255, 0, 0, 1);
     --media-range-track-height: 4px;
-    --media-range-track-transition: height .2s ease;
+    --media-range-track-transition: height 0.2s ease;
     --media-range-track-background-color: #555;
     --media-range-bar-color: rgb(229, 9, 20);
+    --media-control-hover-background: none;
+    --media-control-background: none;
 
     --media-button-icon-width: 50px;
     --media-button-icon-height: 50px;
+    --media-button-icon-transform: scale(1);
+    --media-button-icon-transition: transform 0.2s ease;
   }
 
   media-time-range {
-    width: 100%;
-    height: 25px;
-    margin-bottom: 10px;
+    height: auto;
     --media-range-thumb-height: 20px;
     --media-range-thumb-width: 20px;
     --media-range-thumb-border-radius: 20px;
@@ -46,37 +46,13 @@ const template = `
   }
 
   media-control-bar {
-    background: none;
-    justify-content: space-between;
-    -webkit-box-align: center;
-    -ms-align-items: center;
+    width: 100%;
     align-items: center;
-    display: flex;
-    -webkit-box-pack: justify;
-    flex-wrap: nowrap;
   }
 
-  media-control-bar > * {
-    background: none;
-    display: flex;
-    flex: 0 1 auto;
-    width: 60px;
-    min-width: 60px;
-    height: 80px;
-    padding-bottom: 20px;
-    margin: 0 3px;
-
+  media-control-bar *:hover {
     --media-button-icon-transform: scale(1.2);
-    --media-button-icon-transition: transform .2s ease;
-  }
-
-  /* For some reason media-control-bar > *:hover doesn't work...
-  while media-control-bar > *:focus-within does. 
-  And also media-control-bar > *:not(:hover)
-  Really annoying. Need to submit a bug.  */
-  media-control-bar > *:not(:hover) {
-    --media-button-icon-transform: scale(1);
-    --media-button-icon-transition: transform .2s ease;
+    --media-button-icon-transition: transform 0.2s ease;
   }
 
   media-play-button,
@@ -90,76 +66,72 @@ const template = `
   media-fullscreen-button {
     margin-right: 10px;
   }
-  
-  media-control-bar > *:focus,
-  media-control-bar > *:focus-within {
-    outline: 0;
-  }
 
-  media-volume-range {
-    width: 100px;
+  .control-bar-title {
+    margin: 0 auto;
+    padding-right: 15%;
   }
-
-  .videoTitle {
-    flex-grow: 1;
-    height: 80px;
-    line-height: 64px;
-    vertical-align: middle;
-    overflow: hidden;
-    padding: 0 10px;
-    min-width: 0;
-  }
-
-  .videoTitleText {
-    width: 100%;
-    vertical-align: middle;
-    text-overflow: ellipsis;
-    overflow: hidden;
-    white-space: nowrap;
-  }
-
-  .videoTitleText h4 {
-    margin: 0;
-    display: inline-block;
-    white-space: nowrap;
-  }
-
-  .videoTitle span {
-    display: inline;
-    font-weight: 200;
-    margin-left: 5px;
-  }
-
 </style>
 
 <media-controller>
-
   <slot name="media" slot="media"></slot>
 
-  <media-time-range></media-time-range>
+  <media-control-bar>
+    <media-time-range></media-time-range>
+  </media-control-bar>
   <media-control-bar>
     <media-play-button></media-play-button>
     <media-seek-backward-button></media-seek-backward-button>
     <media-seek-forward-button></media-seek-forward-button>
     <media-mute-button></media-mute-button>
     <media-volume-range></media-volume-range>
-    <div class="videoTitle">
-      <div class="videoTitleText">
-        <h4>My Title</h4><span>P2:E4 Episode 4</span>
-      </div>
-    </div>
+    <media-text-display class="control-bar-title">
+      <slot name="title"></slot>
+    </media-text-display>
     <media-fullscreen-button>
-      <svg slot="enter" viewBox="0 0 28 28"><g transform="translate(2, 6)"><polygon points="8 0 6 0 5.04614258 0 0 0 0 5 2 5 2 2 8 2"></polygon><polygon transform="translate(4, 13.5) scale(1, -1) translate(-4, -13.5) " points="8 11 6 11 5.04614258 11 0 11 0 16 2 16 2 13 8 13"></polygon><polygon transform="translate(20, 2.5) scale(-1, 1) translate(-20, -2.5) " points="24 0 22 0 21.0461426 0 16 0 16 5 18 5 18 2 24 2"></polygon><polygon transform="translate(20, 13.5) scale(-1, -1) translate(-20, -13.5) " points="24 11 22 11 21.0461426 11 16 11 16 16 18 16 18 13 24 13"></polygon></g></svg>
-      <svg slot="exit" viewBox="0 0 28 28"><g transform="translate(3, 6)"><polygon transform="translate(19.000000, 3.000000) scale(-1, 1) translate(-19.000000, -3.000000) " points="22 0 20 0 20 4 16 4 16 6 22 6"></polygon><polygon transform="translate(19.000000, 13.000000) scale(-1, -1) translate(-19.000000, -13.000000) " points="22 10 20 10 20 14 16 14 16 16 22 16"></polygon><polygon points="6 0 4 0 4 4 0 4 0 6 6 6"></polygon><polygon transform="translate(3.000000, 13.000000) scale(1, -1) translate(-3.000000, -13.000000) " points="6 10 4 10 4 14 0 14 0 16 6 16"></polygon></g></svg>
+      <svg aria-hidden="true" slot="enter" viewBox="0 0 28 28">
+        <g transform="translate(2, 6)">
+          <polygon
+            points="8 0 6 0 5.04614258 0 0 0 0 5 2 5 2 2 8 2"
+          ></polygon>
+          <polygon
+            transform="translate(4, 13.5) scale(1, -1) translate(-4, -13.5) "
+            points="8 11 6 11 5.04614258 11 0 11 0 16 2 16 2 13 8 13"
+          ></polygon>
+          <polygon
+            transform="translate(20, 2.5) scale(-1, 1) translate(-20, -2.5) "
+            points="24 0 22 0 21.0461426 0 16 0 16 5 18 5 18 2 24 2"
+          ></polygon>
+          <polygon
+            transform="translate(20, 13.5) scale(-1, -1) translate(-20, -13.5) "
+            points="24 11 22 11 21.0461426 11 16 11 16 16 18 16 18 13 24 13"
+          ></polygon>
+        </g>
+      </svg>
+      <svg aria-hidden="true" slot="exit" viewBox="0 0 28 28">
+        <g transform="translate(3, 6)">
+          <polygon
+            transform="translate(19.000000, 3.000000) scale(-1, 1) translate(-19.000000, -3.000000) "
+            points="22 0 20 0 20 4 16 4 16 6 22 6"
+          ></polygon>
+          <polygon
+            transform="translate(19.000000, 13.000000) scale(-1, -1) translate(-19.000000, -13.000000) "
+            points="22 10 20 10 20 14 16 14 16 16 22 16"
+          ></polygon>
+          <polygon points="6 0 4 0 4 4 0 4 0 6 6 6"></polygon>
+          <polygon
+            transform="translate(3.000000, 13.000000) scale(1, -1) translate(-3.000000, -13.000000) "
+            points="6 10 4 10 4 14 0 14 0 16 6 16"
+          ></polygon>
+        </g>
+      </svg>
     </media-fullscreen-button>
   </media-control-bar>
 </media-controller>
 `;
 
 class MediaThemeNetflix extends MediaTheme {
-  constructor(options = {}) {
-    super(template, { /* allow ...defaultOptions, */ ...options });
-  }
+  static template = template;
 }
 
 if (!customElements.get('media-theme-netflix')) {

--- a/src/js/themes/media-theme.js
+++ b/src/js/themes/media-theme.js
@@ -1,28 +1,26 @@
 class MediaTheme extends HTMLElement {
-  constructor(template = ``, options = {}) {
+  static template = '';
+
+  constructor() {
     super();
+    this.attachShadow({ mode: 'open' });
+  }
 
-    options = Object.assign(
-      {
-        // Default options
-      },
-      options
-    );
+  connectedCallback() {
+    this.render();
+  }
 
-    // Expose the template publicaly for other uses
-    this.template = template;
+  render() {
+    this.shadowRoot.textContent = '';
 
-    // Not sure if this is best practice or if we should just
-    // innerHTML the template string in the shadow dom
-    const templateEl = document.createElement('template');
-    templateEl.innerHTML = template;
+    const template = document.createElement('template');
+    template.innerHTML = this.constructor.template;
 
     // Clone the template in the shadow dom
-    const shadow = this.attachShadow({ mode: 'open' });
-    shadow.appendChild(templateEl.content.cloneNode(true));
+    this.shadowRoot.append(template.content.cloneNode(true));
 
     // Expose the media controller if API access is needed
-    this.mediaController = shadow.querySelector('media-controller');
+    this.mediaController = this.shadowRoot.querySelector('media-controller');
   }
 }
 

--- a/src/js/themes/media-theme.js
+++ b/src/js/themes/media-theme.js
@@ -18,9 +18,11 @@ class MediaTheme extends HTMLElement {
 
     // Clone the template in the shadow dom
     this.shadowRoot.append(template.content.cloneNode(true));
+  }
 
+  get mediaController() {
     // Expose the media controller if API access is needed
-    this.mediaController = this.shadowRoot.querySelector('media-controller');
+    return this.shadowRoot.querySelector('media-controller');
   }
 }
 


### PR DESCRIPTION
This change exports the base MediaTheme class and adds a render method that can be overridden.

In the simplest case theme devs just provide a string template to their class that extends MediaTheme.

This change also fixes up the Netflix media theme and uses that in the examples. Good for testing.


```js
class MediaTheme extends HTMLElement {
  static template = '';

  constructor() {
    super();
    this.attachShadow({ mode: 'open' });
  }

  connectedCallback() {
    this.render();
  }

  render() {
    this.shadowRoot.textContent = '';

    const template = document.createElement('template');
    template.innerHTML = this.constructor.template;

    // Clone the template in the shadow dom
    this.shadowRoot.append(template.content.cloneNode(true));

    // Expose the media controller if API access is needed
    this.mediaController = this.shadowRoot.querySelector('media-controller');
  }
}

if (!customElements.get('media-theme')) {
  customElements.define('media-theme', MediaTheme);
}

export default MediaTheme;
```


https://media-chrome-git-fork-luwes-media-theme-base-mux.vercel.app/examples/themes/netflix-theme.html

```js
const template = `
<style>...</style>
<media-controller>
  <slot name="media" slot="media"></slot>
  ...
</media-controller>
`;


class MediaThemeNetflix extends MediaTheme {
  static template = template;
}

if (!customElements.get('media-theme-netflix')) {
  customElements.define('media-theme-netflix', MediaThemeNetflix);
}

export default MediaThemeNetflix;
```