### PR TITLE
feat: re-enable media click to play toggle

### DIFF
--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -232,11 +232,11 @@ class MediaContainer extends window.HTMLElement {
         new window.CustomEvent(eventName, { composed: true, bubbles: true })
       );
     };
+    media.addEventListener('click', this._mediaClickPlayToggle, false);
   }
 
   handleMediaUpdated(media) {
     const resolveMediaPromise = (media) => {
-      // media.addEventListener('click', this._mediaClickPlayToggle, false);
 
       return Promise.resolve(media);
     };
@@ -267,7 +267,7 @@ class MediaContainer extends window.HTMLElement {
   }
 
   mediaUnsetCallback(media) {
-    // media.removeEventListener('click', this._mediaClickPlayToggle);
+    media.removeEventListener('click', this._mediaClickPlayToggle);
   }
 
   connectedCallback() {


### PR DESCRIPTION
This enables clicking on the media element to toggle playback. This
works on both desktop and mobile/touch devices. Eventually, we'd probably want
to make mobile/touch devices to toggle controls showing on taps (except
for the first one).

One thing that's worth noting, in the mobile example, if during
playback, you click the play toggle, the controls will stay showing.
This is actually an existing issue relating to us keeping controls
showing when focus is on a control bar control (like the
`media-play-button`).