### PR TITLE
Fix isFullscreen check for deep shadow nesting

### DIFF
--- a/examples/advanced.html
+++ b/examples/advanced.html
@@ -5,13 +5,15 @@
     <title>Media Chrome Advanced Video Usage Example</title>
     <script type="module" src="../dist/index.js"></script>
     <style>
-      video {
-        width: 720px;
-        aspect-ratio: 16 / 9;
+      /** add styles to prevent CLS (Cumulative Layout Shift) */
+      media-controller:not([audio]) {
+        display: block;         /* expands the container if preload=none */
+        max-width: 720px;       /* allows the container to shrink if small */
+        aspect-ratio: 16 / 9;   /* set container aspect ratio if preload=none */
       }
 
-      .examples {
-        margin-top: 20px;
+      video {
+        width: 100%;      /* prevents video to expand beyond its container */
       }
 
       media-airplay-button[media-airplay-unavailable] {
@@ -26,6 +28,9 @@
         display: none;
       }
 
+      .examples {
+        margin-top: 20px;
+      }
     </style>
   </head>
   <body>

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -5,9 +5,15 @@
     <title>Media Chrome Basic Audio and Video Usage Example</title>
     <script type="module" src="../dist/index.js"></script>
     <style>
+      /** add styles to prevent CLS (Cumulative Layout Shift) */
+      media-controller:not([audio]) {
+        display: block;         /* expands the container if preload=none */
+        max-width: 720px;       /* allows the container to shrink if small */
+        aspect-ratio: 16 / 9;   /* set container aspect ratio if preload=none */
+      }
+
       video {
-        width: 720px;
-        aspect-ratio: 16 / 9;
+        width: 100%;      /* prevents video to expand beyond its container */
       }
 
       .examples {

--- a/examples/media-elements/hls.html
+++ b/examples/media-elements/hls.html
@@ -6,10 +6,15 @@
     <script type="module" src="https://unpkg.com/hls-video-element@0"></script>
     <script type="module" src="../../dist/index.js"></script>
     <style>
+      /** add styles to prevent CLS (Cumulative Layout Shift) */
+      media-controller:not([audio]) {
+        display: block;         /* expands the container if preload=none */
+        max-width: 720px;       /* allows the container to shrink if small */
+        aspect-ratio: 16 / 9;   /* set container aspect ratio if preload=none */
+      }
+
       hls-video {
-        display: inline-block;
-        width: 720px;
-        aspect-ratio: 16 / 9;
+        width: 100%;      /* prevents video to expand beyond its container */
         background-color: #000;
       }
 

--- a/examples/media-elements/jwplayer.html
+++ b/examples/media-elements/jwplayer.html
@@ -4,14 +4,15 @@
     <meta name="viewport" content="width=device-width" />
     <title>Media Chrome JW Player Media Example</title>
     <style>
-      .examples {
-        margin-top: 20px;
+      /** add styles to prevent CLS (Cumulative Layout Shift) */
+      media-controller:not([audio]) {
+        display: block;         /* expands the container if preload=none */
+        max-width: 720px;       /* allows the container to shrink if small */
+        aspect-ratio: 16 / 9;   /* set container aspect ratio if preload=none */
       }
 
       jwplayer-video {
-        display: inline-block;
-        width: 720px;
-        aspect-ratio: 16 / 9;
+        width: 100%;      /* prevents video to expand beyond its container */
         background-color: #000;
       }
 
@@ -27,6 +28,9 @@
         display: none;
       }
 
+      .examples {
+        margin-top: 20px;
+      }
     </style>
     <script type="module" src="https://unpkg.com/jwplayer-video-element@0.0.4/dist/jwplayer-video-element.js"></script>
     <script type="module" src="../../dist/index.js"></script>

--- a/examples/media-elements/mux-video.html
+++ b/examples/media-elements/mux-video.html
@@ -20,6 +20,7 @@
       <media-controller>
         <mux-video
           slot="media"
+          preload="auto"
           playback-id="DS00Spx1CV902MCtPj5WknGlR102V5HFkDe"
           metadata-video-id="video-id-12345"
           metadata-video-title="Mad Max: Fury Road Trailer"

--- a/examples/media-elements/wistia.html
+++ b/examples/media-elements/wistia.html
@@ -4,14 +4,15 @@
     <meta name="viewport" content="width=device-width" />
     <title>Media Chrome Wistia Media Example</title>
     <style>
-      .examples {
-        margin-top: 20px;
+      /** add styles to prevent CLS (Cumulative Layout Shift) */
+      media-controller:not([audio]) {
+        display: block;         /* expands the container if preload=none */
+        max-width: 720px;       /* allows the container to shrink if small */
+        aspect-ratio: 16 / 9;   /* set container aspect ratio if preload=none */
       }
 
       wistia-video {
-        display: inline-block;
-        width: 720px;
-        aspect-ratio: 16 / 9;
+        width: 100%;      /* prevents video to expand beyond its container */
         background-color: #000;
       }
 
@@ -27,6 +28,9 @@
         display: none;
       }
 
+      .examples {
+        margin-top: 20px;
+      }
     </style>
     <script type="module" src="https://unpkg.com/wistia-video-element@0.0.4/dist/wistia-video-element.js"></script>
     <script type="module" src="../../dist/index.js"></script>

--- a/examples/media-elements/youtube.html
+++ b/examples/media-elements/youtube.html
@@ -9,10 +9,15 @@
     ></script>
     <script type="module" src="../../dist/index.js"></script>
     <style>
+      /** add styles to prevent CLS (Cumulative Layout Shift) */
+      media-controller:not([audio]) {
+        display: block;         /* expands the container if preload=none */
+        max-width: 720px;       /* allows the container to shrink if small */
+        aspect-ratio: 16 / 9;   /* set container aspect ratio if preload=none */
+      }
+
       youtube-video {
-        display: inline-block;
-        width: 720px;
-        aspect-ratio: 16 / 9;
+        width: 100%;      /* prevents video to expand beyond its container */
         background-color: #000;
       }
 

--- a/examples/mobile.html
+++ b/examples/mobile.html
@@ -11,9 +11,15 @@
         margin: 0px;
       }
 
+      /** add styles to prevent CLS (Cumulative Layout Shift) */
+      media-controller:not([audio]) {
+        display: block;         /* expands the container if preload=none */
+        max-width: 320px;       /* allows the container to shrink if small */
+        aspect-ratio: 16 / 9;   /* set container aspect ratio if preload=none */
+      }
+
       video {
-        width: 320px;
-        aspect-ratio: 16 / 9;
+        width: 100%;      /* prevents video to expand beyond its container */
       }
 
       .examples {

--- a/examples/slots-demo.html
+++ b/examples/slots-demo.html
@@ -24,9 +24,15 @@
       padding: 10px;
     }
 
+    /** add styles to prevent CLS (Cumulative Layout Shift) */
+    media-controller:not([audio]) {
+      display: block;         /* expands the container if preload=none */
+      max-width: 960px;       /* allows the container to shrink if small */
+      aspect-ratio: 16 / 9;   /* set container aspect ratio if preload=none */
+    }
+
     video {
-      max-width: 960px;
-      aspect-ratio: 16 / 9;
+      width: 100%;      /* prevents video to expand beyond its container */
     }
 
     media-control-bar {

--- a/examples/standalone-controls.html
+++ b/examples/standalone-controls.html
@@ -5,9 +5,15 @@
     <title>Media Chrome Standalone Controls Example</title>
     <script type="module" src="../dist/index.js"></script>
     <style>
+      /** add styles to prevent CLS (Cumulative Layout Shift) */
+      media-controller:not([audio]) {
+        display: block;         /* expands the container if preload=none */
+        max-width: 640px;       /* allows the container to shrink if small */
+        aspect-ratio: 16 / 9;   /* set container aspect ratio if preload=none */
+      }
+
       video {
-        width: 640px;
-        height: 360px;
+        width: 100%;      /* prevents video to expand beyond its container */
       }
 
       .examples {

--- a/examples/state-change-events-demo.html
+++ b/examples/state-change-events-demo.html
@@ -9,9 +9,15 @@
         margin-top: 20px;
       }
 
+      /** add styles to prevent CLS (Cumulative Layout Shift) */
+      media-controller:not([audio]) {
+        display: block;         /* expands the container if preload=none */
+        max-width: 720px;       /* allows the container to shrink if small */
+        aspect-ratio: 16 / 9;   /* set container aspect ratio if preload=none */
+      }
+
       video {
-        width: 720px;
-        aspect-ratio: 16 / 9;
+        width: 100%;      /* prevents video to expand beyond its container */
       }
 
       media-airplay-button[media-airplay-unavailable] {
@@ -29,15 +35,6 @@
       #states-list {
         margin-left: 10px;
         table-layout: fixed;
-        flex-grow: 0;
-        width: 100%;
-      }
-      #states-list td:nth-child(1),
-      #states-list td:nth-child(3) {
-        width: 25%;
-      }
-      #states-list td:nth-child(2) {
-        width: 50%;
       }
 
       #states-list td,
@@ -52,12 +49,11 @@
 
       .player-states {
         display: flex;
-        flex-direction: row;
         align-items: start;
       }
 
-      .player-states > media-controller {
-        flex-shrink: 0;
+      .player-states > * {
+        flex: 1;
       }
     </style>
   </head>

--- a/examples/themes/demuxed-2021-theme.html
+++ b/examples/themes/demuxed-2021-theme.html
@@ -16,9 +16,15 @@
         display: none;
       }
 
+      /** add styles to prevent CLS (Cumulative Layout Shift) */
+      media-controller:not([audio]) {
+        display: block;         /* expands the container if preload=none */
+        max-width: 720px;       /* allows the container to shrink if small */
+        aspect-ratio: 16 / 9;   /* set container aspect ratio if preload=none */
+      }
+
       video {
-        width: 720px;
-        aspect-ratio: 16 / 9;
+        width: 100%;      /* prevents video to expand beyond its container */
       }
 
       media-control-bar > * {

--- a/examples/themes/youtube-theme.html
+++ b/examples/themes/youtube-theme.html
@@ -12,9 +12,15 @@
         margin-top: 20px;
       }
 
+      /** add styles to prevent CLS (Cumulative Layout Shift) */
+      media-controller:not([audio]) {
+        display: block;         /* expands the container if preload=none */
+        max-width: 720px;       /* allows the container to shrink if small */
+        aspect-ratio: 16 / 9;   /* set container aspect ratio if preload=none */
+      }
+
       video {
-        width: 720px;
-        aspect-ratio: 16 / 9;
+        width: 100%;      /* prevents video to expand beyond its container */
       }
 
       .media-theme-youtube * {

--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -299,13 +299,15 @@ class MediaController extends MediaContainer {
           getVolumeLevel(this)
         );
       },
-      [fullscreenApi.event]: () => {
-        // If media-chrome is in the shadow dom this.getRootNode().host will
-        // be the fullscreen element otherwise this controller will be.
-        let fullscreenEl = document[fullscreenApi.element];
+      [fullscreenApi.event]: (e) => {
+        // Safari doesn't support ShadowRoot.fullscreenElement and document.fullscreenElement
+        // could be several ancestors up the tree. Use event.target instead.
+        const isSomeElementFullscreen = !!document[fullscreenApi.element];
+        const fullscreenEl = isSomeElementFullscreen && e?.target;
+        const isFullScreen = containsComposedNode(this, fullscreenEl);
         this.propagateMediaState(
           MediaUIAttributes.MEDIA_IS_FULLSCREEN,
-          fullscreenEl === (this.getRootNode().host ?? this)
+          isFullScreen
         );
       },
       'enterpictureinpicture,leavepictureinpicture': (e) => {

--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -15,7 +15,7 @@ import {
 } from './utils/server-safe-globals.js';
 import { fullscreenApi } from './utils/fullscreenApi.js';
 import { constToCamel } from './utils/stringUtils.js';
-import { containsWithShadow } from './utils/element-utils.js';
+import { containsComposedNode } from './utils/element-utils.js';
 
 import {
   MediaUIEvents,
@@ -319,7 +319,7 @@ class MediaController extends MediaContainer {
           const pipElement =
             this.getRootNode().pictureInPictureElement ??
             document.pictureInPictureElement;
-          isPip = this.media && containsWithShadow(this.media, pipElement);
+          isPip = this.media && containsComposedNode(this.media, pipElement);
         }
         this.propagateMediaState(MediaUIAttributes.MEDIA_IS_PIP, isPip);
       },

--- a/src/js/utils/element-utils.js
+++ b/src/js/utils/element-utils.js
@@ -15,10 +15,8 @@ export const getAllSlotted = (el, name) => {
 
 export const getSlotted = (el, name) => getAllSlotted(el, name)[0];
 
-export const containsWithShadow = (refNode, otherNode) => {
-  if (!refNode || !otherNode) return false;
-  if (refNode.contains(otherNode)) return true;
-  return [refNode, ...refNode.querySelectorAll("*")].some((el) => {
-    return containsWithShadow(el.shadowRoot, otherNode);
-  });
-}
+export const containsComposedNode = (rootNode, childNode) => {
+  if (!rootNode || !childNode) return false;
+  if (rootNode.contains(childNode)) return true;
+  return containsComposedNode(rootNode, childNode.getRootNode().host);
+};


### PR DESCRIPTION
This change fixes an issue where if the media-controller was contained in multi-level shadow DOM the isFullscreen check would fail. 

Safari doesn't support ShadowRoot.fullscreenElement, the solution here uses document.fullscreenElement to check if any element in the document is fullscreen and then event.target to check if the target is contained or is itself the media-controller.

This PR also improves the contains utility function `containsComposedNode` to be more efficient.

