### PR TITLE
Fix/default UI times

### DIFF
--- a/src/js/media-time-display.js
+++ b/src/js/media-time-display.js
@@ -10,8 +10,8 @@ const DEFAULT_TIMES_SEP = '&nbsp;/&nbsp;';
 const formatTimesLabel = (el, { timesSep = DEFAULT_TIMES_SEP } = {}) => {
   const showRemaining = el.getAttribute('remaining') != null;
   const showDuration = el.getAttribute('show-duration') != null;
-  const currentTime = el.mediaCurrentTime;
-  const endTime = el.mediaDuration ?? el.mediaSeekableEnd;
+  const currentTime = el.mediaCurrentTime ?? 0;
+  const endTime = el.mediaDuration ?? el.mediaSeekableEnd ?? 0;
 
   const timeLabel = showRemaining
     ? formatTime(0 - (endTime - currentTime))

--- a/src/js/media-time-range.js
+++ b/src/js/media-time-range.js
@@ -128,14 +128,14 @@ class MediaTimeRange extends MediaChromeRange {
     }
     if (attrName === MediaUIAttributes.MEDIA_DURATION) {
       // Since our range's step is 1, floor the max value to ensure reasonable rendering
-      this.range.max = Math.floor(this.mediaSeekableEnd ?? this.mediaDuration ?? 0);
+      this.range.max = Math.floor(this.mediaSeekableEnd ?? this.mediaDuration ?? 1000);
       updateAriaValueText(this);
       this.updateBar();
     }
     if (attrName === MediaUIAttributes.MEDIA_SEEKABLE) {
       this.range.min = this.mediaSeekableStart ?? 0;
       // Since our range's step is 1, floor the max value to ensure reasonable rendering
-      this.range.max = Math.floor(this.mediaSeekableEnd ?? this.mediaDuration ?? 0);
+      this.range.max = Math.floor(this.mediaSeekableEnd ?? this.mediaDuration ?? 1000);
       updateAriaValueText(this);
       this.updateBar();
     }


### PR DESCRIPTION
Since refactoring to support seekable ranges, we can no longer "default" the duration values. Per suggestion from @luwes , for now we can just assign default values for less confusing visualization.