### PR TITLE
fix: mouseout timerange for deeply nest shadowdom

### DIFF
--- a/examples/themes/netflix-theme.html
+++ b/examples/themes/netflix-theme.html
@@ -25,7 +25,15 @@
           src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/high.mp4"
           muted
           preload="none"
-        ></video>
+          crossorigin
+        >
+          <track
+            label="thumbnails"
+            default
+            kind="metadata"
+            src="https://image.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/storyboard.vtt"
+          />
+        </video>
         <h3 slot="title">
           <b>My Title</b>
           <span>P2:E4 Episode 4</span>

--- a/src/js/media-time-range.js
+++ b/src/js/media-time-range.js
@@ -313,7 +313,7 @@ class MediaTimeRange extends MediaChromeRange {
         trackMouse();
 
         let offRangeHandler = (evt) => {
-          if (evt.target != this && !this.contains(evt.target)) {
+          if (!evt.composedPath().includes(this)) {
             window.removeEventListener('mousemove', offRangeHandler);
             rangeEntered = false;
             stopTrackingMouse();


### PR DESCRIPTION
Fixes an issue where the off range logic was called too early for Media Chrome in a shadow dom of another element.