### PR TITLE
feat: add exports package.json field

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,11 @@
   "version": "0.10.4",
   "description": "Custom elements (web components) for making audio and video player controls that look great in your website or app.",
   "main": "dist/index.js",
-  "type": "module",
+  "exports": {
+    "require": "./dist/cjs/index.js",
+    "import": "./dist/index.js",
+    "default": "./dist/index.js"
+  },
   "files": [
     "dist/*",
     "README.md",


### PR DESCRIPTION
This means that folks using CJS and a new enough node/bundler will
automatically get the CJS builds without requiring them to know that
there is a CJS build and doing a deep import.

The default remains the ESM build.

~This was originally a PR against https://github.com/muxinc/media-chrome/pull/195 but didn't make it in.~

~This makes this module a hybrid module with the main being a cjs file.~

~We should also update the react build to generate a cjs subfolder and have a package.json that splits imports between the esm and cjs files. (Also, if we generate it to the root rather than dist, the require/import could be `media-chrome/react` rather than `media-chrome/dist/react`~