### PR TITLE
fix: unhide controls on touch & autohide on timer

### DIFF
--- a/examples/advanced.html
+++ b/examples/advanced.html
@@ -43,6 +43,7 @@
           preload="none"
           muted
           crossorigin
+          playsinline
         >
           <track
             label="thumbnails"

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -43,6 +43,7 @@
 
       <media-controller>
         <video
+          playsinline
           slot="media"
           src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/high.mp4"
         ></video>

--- a/examples/mobile.html
+++ b/examples/mobile.html
@@ -91,6 +91,7 @@
           preload="none"
           muted
           crossorigin
+          playsinline
         >
           <track
             label="thumbnails"

--- a/examples/slots-demo.html
+++ b/examples/slots-demo.html
@@ -107,6 +107,7 @@
             muted
             preload="none"
             crossorigin
+            playsinline
           ></video>
           <div
             slot="poster"

--- a/examples/standalone-controls.html
+++ b/examples/standalone-controls.html
@@ -31,6 +31,7 @@
 
       <media-controller id="controller">
         <video
+          playsinline
           slot="media"
           src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/high.mp4"
         >

--- a/examples/state-change-events-demo.html
+++ b/examples/state-change-events-demo.html
@@ -68,6 +68,7 @@
             preload="none"
             muted
             crossorigin
+            playsinline
           >
             <track
               label="thumbnails"

--- a/examples/vertical.html
+++ b/examples/vertical.html
@@ -48,6 +48,7 @@
           preload="none"
           muted
           crossorigin
+          playsinline
         >
           <track
             label="thumbnails"

--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -344,10 +344,10 @@ class MediaContainer extends window.HTMLElement {
     // when we get a tap, we want to unhide
     this.addEventListener('pointerup', (e) => {
       if (e.pointerType === 'touch') {
-        if (this.hasAttribute('user-inactive')) {
-          scheduleInactive();
-        } else {
+        if ([this, this.media].includes(e.target) && !this.hasAttribute('user-inactive')) {
           setInactive();
+        } else {
+          scheduleInactive();
         }
       }
     });

--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -344,12 +344,19 @@ class MediaContainer extends window.HTMLElement {
     // when we get a tap, we want to unhide
     this.addEventListener('pointerup', (e) => {
       if (e.pointerType === 'touch') {
-        scheduleInactive();
+        if (this.hasAttribute('user-inactive')) {
+          scheduleInactive();
+        } else {
+          setInactive();
+        }
       }
     });
 
-    // pointermove doesn't happen with touch on taps
     this.addEventListener('pointermove', (e) => {
+      // pointermove doesn't happen with touch on taps on iOS, but does on android,
+      // so, only run pointermove for mouse
+      if (e.pointerType !== 'mouse') return;
+
       if (!containsComposedNode(this, e.target)) return;
 
       setActive();

--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -376,7 +376,7 @@ class MediaContainer extends window.HTMLElement {
 
     // Allow for focus styles only when using the keyboard to navigate
     this.addEventListener('keyup', (e) => {
-      this.setAttribute('media-keyboard-control', 'media-keyboard-control');
+      this.setAttribute('media-keyboard-control', '');
     });
     this.addEventListener('mouseup', (e) => {
       this.removeAttribute('media-keyboard-control');

--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -331,6 +331,13 @@ class MediaContainer extends window.HTMLElement {
       scheduleInactive();
     });
 
+    // when we get a tap, we want to unhide
+    this.addEventListener('pointerup', (e) => {
+      if (e.pointerType === 'touch') {
+        scheduleInactive();
+      }
+    });
+
     // Allow for focus styles only when using the keyboard to navigate
     this.addEventListener('keyup', (e) => {
       this.setAttribute('media-keyboard-control', 'media-keyboard-control');
@@ -339,13 +346,14 @@ class MediaContainer extends window.HTMLElement {
       this.removeAttribute('media-keyboard-control');
     });
 
-    this.addEventListener('mousemove', (e) => {
+    // pointermove doesn't happen with touch on taps
+    this.addEventListener('pointermove', (e) => {
       if (!containsComposedNode(this, e.target)) return;
 
       // Stay visible if hovered over control bar
       this.removeAttribute('user-inactive');
       const evt = new window.CustomEvent(
-        MediaStateChangeEvents.USER_INACTIVE, 
+        MediaStateChangeEvents.USER_INACTIVE,
         { composed: true, bubbles: true, detail: false }
       );
       this.dispatchEvent(evt);
@@ -362,7 +370,7 @@ class MediaContainer extends window.HTMLElement {
       if (this.autohide < 0) return;
       this.setAttribute('user-inactive', 'user-inactive');
       const evt = new window.CustomEvent(
-        MediaStateChangeEvents.USER_INACTIVE, 
+        MediaStateChangeEvents.USER_INACTIVE,
         { composed: true, bubbles: true, detail: true }
       );
       this.dispatchEvent(evt);


### PR DESCRIPTION
This keeps desktop behavior for mobile/touch devices. When
tapping, it'll unhide the controls and then setup the timer to autohide.

`mousemove` triggers even when a user only does a single tap.
`pointermove` doesn't occur with just a single tap, so, we switch
`mousemove` to `pointermove`. Then, we schedule the inactivity timeout
on `pointerup` when `pointerType` is `touch`, since other pointer types
are covered.