### PR TITLE
Update Focus Styles for Cross-Browser behavior

### DIFF
--- a/src/js/media-chrome-button.js
+++ b/src/js/media-chrome-button.js
@@ -37,9 +37,16 @@ template.innerHTML = `
     Only show outline when keyboard focusing.
     https://drafts.csswg.org/selectors-4/#the-focus-visible-pseudo
   */
-  :host-context([media-keyboard-control]):host(:focus),
-  :host-context([media-keyboard-control]):host(:focus-within) {
+  :host(:focus-visible) {
     box-shadow: inset 0 0 0 2px rgba(27, 127, 204, 0.9);
+    outline: 0;
+  }
+  /*
+   * hide default focus ring, particularly when using mouse
+   */
+  :host(:where(:focus)) {
+    box-shadow: none;
+    outline: 0;
   }
 
   :host(:hover) {

--- a/src/js/media-chrome-range.js
+++ b/src/js/media-chrome-range.js
@@ -101,9 +101,17 @@ template.innerHTML = `
       ${trackStyles}
     }
 
-    /* Eventually want to move towards different styles for focus-visible
-       https://github.com/WICG/focus-visible/blob/master/src/focus-visible.js
-       Youtube appears to do this by de-focusing a button after a button click */
+    /*
+     * set input to focus-visible, unless host-context is available (in chrome)
+     * in which case we can have the focus ring be on the host itself
+     */
+    :host-context([media-keyboard-control]):host(:focus),
+    :host-context([media-keyboard-control]):host(:focus-within) {
+      box-shadow: inset 0 0 0 2px rgba(27, 127, 204, 0.9);
+    }
+    :host-context([media-keyboard-control]) input[type=range]:focus-visible {
+      box-shadow: none;
+    }
     input[type=range]:focus-visible {
       box-shadow: inset 0 0 0 2px rgba(27, 127, 204, 0.9);
     }

--- a/src/js/media-chrome-range.js
+++ b/src/js/media-chrome-range.js
@@ -55,15 +55,6 @@ template.innerHTML = `
       pointer-events: auto;
     }
 
-    /*
-      Only show outline when keyboard focusing.
-      https://drafts.csswg.org/selectors-4/#the-focus-visible-pseudo
-    */
-    :host-context([media-keyboard-control]):host(:focus),
-    :host-context([media-keyboard-control]):host(:focus-within) {
-      box-shadow: inset 0 0 0 2px rgba(27, 127, 204, 0.9);
-    }
-
     :host(:hover) {
       background: var(--media-control-hover-background, rgba(50,50,60, 0.7));
     }
@@ -113,6 +104,9 @@ template.innerHTML = `
     /* Eventually want to move towards different styles for focus-visible
        https://github.com/WICG/focus-visible/blob/master/src/focus-visible.js
        Youtube appears to do this by de-focusing a button after a button click */
+    input[type=range]:focus-visible {
+      box-shadow: inset 0 0 0 2px rgba(27, 127, 204, 0.9);
+    }
     input[type=range]:focus {
       outline: 0;
     }

--- a/src/js/media-text-display.js
+++ b/src/js/media-text-display.js
@@ -27,6 +27,22 @@ template.innerHTML = `
       pointer-events: auto;
     }
 
+    /*
+      Only show outline when keyboard focusing.
+      https://drafts.csswg.org/selectors-4/#the-focus-visible-pseudo
+    */
+    :host(:focus-visible) {
+      box-shadow: inset 0 0 0 2px rgba(27, 127, 204, 0.9);
+      outline: 0;
+    }
+    /*
+     * hide default focus ring, particularly when using mouse
+     */
+    :host(:where(:focus)) {
+      box-shadow: none;
+      outline: 0;
+    }
+
     #container {
       /* NOTE: We don't currently have more generic sizing vars */
       height: var(--media-text-content-height, auto);


### PR DESCRIPTION
`:host-context` isn't available outside of Chrome and chromium browsers, and Gekco and Webkit have stated that they won't add it in.
So, we should remove it and use other methods of styling.
Unfortunately, because `chrome-range` actually focuses the `input` element inside it, we can't actually `focus-visible` or `focus-within` on the `:host` (this seems like a bug or a limitation of shadow dom that seems like it should be working). Instead, we just let the `input` element show a focus ring appropriately.
For the chrome-button and text-display, we want to update it so that the default focus ring isn't showing. Only ours is showing.

Going from:
![Screen Shot 2022-06-06 at 16 38 43](https://user-images.githubusercontent.com/535884/172246581-d27f5c25-35bc-4c23-8dba-916eac998c1b.png)
![Screen Shot 2022-06-06 at 16 39 19](https://user-images.githubusercontent.com/535884/172246579-211d94fb-a144-4333-900a-97bc16c581ee.png)

To:
![Screen Shot 2022-06-06 at 16 49 34](https://user-images.githubusercontent.com/535884/172246702-7a279326-c91f-44d9-a458-c8b537f14e3c.png)
![Screen Shot 2022-06-06 at 16 49 43](https://user-images.githubusercontent.com/535884/172246699-cb690df1-9f84-427a-8aa3-f9c48a385ca0.png)

The input range's outline is a bit cramped, but it's the same on all browsers now, where-as before we had it on Chrome but not other browsers.


~~In addition, it seems like our build-tooling doesn't like [`@supports selectors`](https://drafts.csswg.org/css-conditional-4/#at-supports-ext) because we could've added a check for `host-context` to make chrome have the slightly nicer styles. For now, I think it's better to have consistency across browsers.~~Got something working for that in a7045eb