### PR TITLE
ci: add canary command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,21 @@
 name: CI
 
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: yarn install --frozen-lockfile
       - run: yarn test
       - run: yarn build
+      - run: yarn publish-canary
+        if: ${{ github.ref == 'refs/heads/main' }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+          # this line is required for the setup-node action to be able to run the npm publish below.
+          registry-url: 'https://registry.npmjs.org'
       - run: yarn install --frozen-lockfile
       - run: yarn test
       - run: yarn build

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "dev": "node ./scripts/esbuild.js",
     "start": "yarn dev",
     "test": "web-test-runner --coverage --config test/web-test-runner.config.js",
-    "publish-patch": "yarn run build && np patch --no-tests --any-branch"
+    "publish-patch": "yarn run build && np patch --no-tests --any-branch",
+    "publish-canary": "yarn run build && np $(semver $(npm pkg get version | sed 's/\"//g') -i prerelease --preid canary)+$(git rev-parse --short HEAD) --tag canary --no-release-draft --any-branch"
   },
   "repository": {
     "type": "git",
@@ -49,6 +50,7 @@
     "prettier": "^2.5.1",
     "react": "^17.0.2",
     "rimraf": "^3.0.2",
+    "semver": "^7.3.7",
     "sinon": "^11.1.2"
   },
   "dependencies": {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3557,6 +3557,13 @@ semver@^7.3.4:
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.3.7:
+  version "7.3.7"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
+  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
+  dependencies:
+    lru-cache "^6.0.0"
+
 setprototypeof@1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz"


### PR DESCRIPTION
Discussed in https://github.com/muxinc/media-chrome/discussions/239
Adds auto publish on the main branch with canary versions (`0.6.9-canary.0+17dac0e`) on the NPM `canary` release channel.

![SCR-20220609-hvt](https://user-images.githubusercontent.com/360826/172912605-7ecb8c29-2a7b-4617-9b44-6e86550fc0fe.png)

