### PR TITLE
ci: fix canary version w/ SHA hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "start": "yarn dev",
     "test": "web-test-runner --coverage --config test/web-test-runner.config.js",
     "publish-patch": "yarn run build && np patch --no-tests --any-branch",
-    "publish-canary": "yarn run build && npm version $(semver $(npm pkg get version | sed 's/\"//g') -i prerelease --preid canary)+$(git rev-parse --short HEAD) --git-tag-version false && npm publish --tag canary"
+    "publish-canary": "yarn run build && npm version $(semver $(npm view media-chrome versions --json | jq -r '.[-1]' | sed -r 's/-[a-z0-9]{7}$//g') -i prerelease --preid canary)-$(git rev-parse --short HEAD) --git-tag-version false && npm publish --tag canary"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
`npm view media-chrome versions --json | jq -r '.[-1]'` gets the last published version of all.

`npm view media-chrome@canary version` would only get from the `cananry` channel so that wouldn't work after a new release.

`sed -r 's/-[a-z0-9]{7}$//g'` strips the hash from the version because it would mess up the semver canary prerelease.

--- 

confirmed `jq` is installed in GH action 
https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md