### PR TITLE
fix: hide gesture-layer when in audio mode

### DIFF
--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -44,6 +44,15 @@ template.innerHTML = `
     }
 
     /*
+     * when in audio mode, hide the gesture-layer which causes media-controller to be taller than the control bar
+     *
+     */
+    :host([audio]) [part~=layer][part~=gesture-layer] {
+      height: 0;
+      display: block;
+    }
+
+    /*
      * if gestures are disabled, don't accept pointer-events
      */
     :host(:not([audio])[gestures-disabled]) ::slotted([slot=gestures-chrome]),


### PR DESCRIPTION
The gestures layer, depending on configuration, may add an extra 5
pixels above or below the control bar, which is unwanted. Instead, when
we're playing back audio, we should hide the gestures display, which
involves making it a block element so that we can set the height of it
to zero.

Setting the MC's background color to red, we can see that there's some extra pixels above or on the side.
![Screen Shot 2022-06-13 at 17 41 19](https://user-images.githubusercontent.com/535884/173450413-cdbe9dbc-7323-4034-9f93-b2a86d6c35b2.png)
![Screen Shot 2022-06-13 at 17 41 08](https://user-images.githubusercontent.com/535884/173450416-ead48e7b-6fc4-429e-843d-d725d5433973.png)
One thought I had been to set the layers's display to be `inline-block`, but that causes some extra sizing issues:
![Screen Shot 2022-06-13 at 17 41 45](https://user-images.githubusercontent.com/535884/173450692-84bd99e5-c2cf-4524-b7bc-5e3fe57f12d8.png)

So, decided to go with a more surgical approach and only target the issue at hand, which works like a charm:
![Screen Shot 2022-06-13 at 17 41 27](https://user-images.githubusercontent.com/535884/173450762-05101f65-f54f-44d6-a845-77e14d467900.png)

