### PR TITLE
fix: reset playbackRate UI after loadstart

### DIFF
--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -391,7 +391,7 @@ class MediaController extends MediaContainer {
           serializeTimeRanges(this.media?.buffered)
         );
       },
-      ratechange: () => {
+      'ratechange,loadstart': () => {
         this.propagateMediaState(
           MediaUIAttributes.MEDIA_PLAYBACK_RATE,
           getPlaybackRate(this)


### PR DESCRIPTION
after changing sources the `playbackRate` is reset to the value of `defaultPlaybackRate` so the UI has to be reset as well.

https://www.w3.org/TR/2011/WD-html5-20110113/video.html#dom-media-load

