### PR TITLE
fix: cast availability

### DIFF
--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -426,9 +426,10 @@ class MediaController extends MediaContainer {
     }
 
     if (this._castUnavailable !== AvailabilityStates.UNSUPPORTED) {
-      const castSupportHandler = (event) => {
+      const castSupportHandler = () => {
         // Cast state: NO_DEVICES_AVAILABLE, NOT_CONNECTED, CONNECTING, CONNECTED
-        if (event?.detail.includes('CONNECT')) {
+        const castState = globalThis.CastableVideoElement?.castState;
+        if (castState?.includes('CONNECT')) {
           this._castUnavailable = undefined;
         } else {
           this._castUnavailable = AvailabilityStates.UNAVAILABLE;


### PR DESCRIPTION
requires:
https://github.com/muxinc/elements/pull/253
https://github.com/muxinc/castable-video/pull/9

the event handlers are re-run at init so we need to be explicit.
fixes an issue where the cast button would not show in the Next.js app

- [x] not auto show the cast button 