### PR TITLE
feat: improve time range behavior

### DIFF
--- a/docs/styling.md
+++ b/docs/styling.md
@@ -64,12 +64,12 @@ Our current styling architecture is still quite nascent and is very likely to un
 | Name                                      | CSS Property          | Default Value    | Description                            | Notes                                                                                      |
 | ----------------------------------------- | --------------------- | ---------------- | -------------------------------------- | ------------------------------------------------------------------------------------------ |
 | `--media-time-buffered-color`             | `<linear-color-stop>` | `#777`           | background color of the buffered range | This is a `<linear-color-stop>` part of the `linear-gradient()` CSS function.              |
-| `--media-thumbnail-preview-border`        | `border`              | `2px solid #fff` | border of the thumbnail preview        |                                                                                            |
-| `--media-thumbnail-preview-border-radius` | `border-radius`       | `2px`            | border radius of the thumbnail preview |                                                                                            |
-| `--media-thumbnail-preview-min-width`     | `width`               | `120px`          | minimum thumbnail preview width        | The maximum CSS properties have priority over the minimum. Only `px` values are supported. |
-| `--media-thumbnail-preview-max-width`     | `width`               | `200px`          | maximum thumbnail preview width        | The maximum CSS properties have priority over the minimum. Only `px` values are supported. |
-| `--media-thumbnail-preview-min-height`    | `height`              | `80px`           | minimum thumbnail preview height       | The maximum CSS properties have priority over the minimum. Only `px` values are supported. |
-| `--media-thumbnail-preview-max-height`    | `height`              | `160px`          | maximum thumbnail preview height       | The maximum CSS properties have priority over the minimum. Only `px` values are supported. |
+| `--media-preview-thumbnail-border`        | `border`              | `2px solid #fff` | border of the thumbnail preview        |                                                                                            |
+| `--media-preview-thumbnail-border-radius` | `border-radius`       | `2px`            | border radius of the thumbnail preview |                                                                                            |
+| `--media-preview-thumbnail-min-width`     | `width`               | `120px`          | minimum thumbnail preview width        | The maximum CSS properties have priority over the minimum. Only `px` values are supported. |
+| `--media-preview-thumbnail-max-width`     | `width`               | `200px`          | maximum thumbnail preview width        | The maximum CSS properties have priority over the minimum. Only `px` values are supported. |
+| `--media-preview-thumbnail-min-height`    | `height`              | `80px`           | minimum thumbnail preview height       | The maximum CSS properties have priority over the minimum. Only `px` values are supported. |
+| `--media-preview-thumbnail-max-height`    | `height`              | `160px`          | maximum thumbnail preview height       | The maximum CSS properties have priority over the minimum. Only `px` values are supported. |
 
 ## Text Displays
 

--- a/examples/advanced.html
+++ b/examples/advanced.html
@@ -40,7 +40,6 @@
         <video
           slot="media"
           src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/high.mp4"
-          preload="none"
           muted
           crossorigin
           playsinline

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -27,7 +27,7 @@
       <media-controller audio>
         <audio
           slot="media"
-          src="https://file-examples-com.github.io/uploads/2017/11/file_example_MP3_700KB.mp3"
+          src="https://api.playerx.io/ink.mp3"
         ></audio>
         <media-control-bar>
           <media-play-button></media-play-button>

--- a/examples/control-elements/media-preview-thumbnail.html
+++ b/examples/control-elements/media-preview-thumbnail.html
@@ -2,18 +2,18 @@
 <html>
   <head>
     <meta name="viewport" content="width=device-width" />
-    <script type="module" src="../../dist/media-thumbnail-preview.js"></script>
+    <script type="module" src="../../dist/media-preview-thumbnail.js"></script>
   </head>
   <body>
-    <h1>&lt;media-thumbnail-preview&gt;</h1>
+    <h1>&lt;media-preview-thumbnail&gt;</h1>
 
     <h3>Default (no src)</h3>
-    <media-thumbnail-preview></media-thumbnail-preview>
+    <media-preview-thumbnail></media-preview-thumbnail>
 
     <h3>With thumbnail and coords</h3>
-    <media-thumbnail-preview
+    <media-preview-thumbnail
       media-preview-image="https://image.mux.com/O6LdRc0112FEJXH00bGsN9Q31yu5EIVHTgjTKRkKtEq1k/storyboard.jpg"
       media-preview-coords="284 640 284 160"
-    ></media-thumbnail-preview>
+    ></media-preview-thumbnail>
   </body>
 </html>

--- a/examples/control-elements/media-thumbnail-preview.html
+++ b/examples/control-elements/media-thumbnail-preview.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width" />
+    <script type="module" src="../../dist/media-thumbnail-preview.js"></script>
+  </head>
+  <body>
+    <h1>&lt;media-thumbnail-preview&gt;</h1>
+
+    <h3>Default (no src)</h3>
+    <media-thumbnail-preview></media-thumbnail-preview>
+
+    <h3>With thumbnail and coords</h3>
+    <media-thumbnail-preview
+      media-preview-image="https://image.mux.com/O6LdRc0112FEJXH00bGsN9Q31yu5EIVHTgjTKRkKtEq1k/storyboard.jpg"
+      media-preview-coords="284 640 284 160"
+    ></media-thumbnail-preview>
+  </body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -113,6 +113,9 @@
       <li>
         <a href="control-elements/media-poster-image.html">Poster Image</a>
       </li>
+      <li>
+        <a href="control-elements/media-thumbnail-preview.html">Thumbnail Preview</a>
+      </li>
     </ul>
 
     <h3>Extras</h3>

--- a/examples/index.html
+++ b/examples/index.html
@@ -114,7 +114,7 @@
         <a href="control-elements/media-poster-image.html">Poster Image</a>
       </li>
       <li>
-        <a href="control-elements/media-thumbnail-preview.html">Thumbnail Preview</a>
+        <a href="control-elements/media-preview-thumbnail.html">Preview Thumbnail</a>
       </li>
     </ul>
 

--- a/examples/themes/demuxed-2021-theme.html
+++ b/examples/themes/demuxed-2021-theme.html
@@ -97,8 +97,9 @@
         <video
           slot="media"
           src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/high.mp4"
+          crossorigin
           muted
-          preload="none"
+          playsinline
         ></video>
         <media-control-bar slot="top-chrome" class="mobile-only">
           <media-mute-button></media-mute-button>

--- a/examples/themes/netflix-theme.html
+++ b/examples/themes/netflix-theme.html
@@ -23,9 +23,9 @@
         <video
           slot="media"
           src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/high.mp4"
-          muted
-          preload="none"
           crossorigin
+          muted
+          playsinline
         >
           <track
             label="thumbnails"

--- a/examples/themes/youtube-theme.html
+++ b/examples/themes/youtube-theme.html
@@ -32,8 +32,9 @@
           slot="media"
           src="https://stream.mux.com/O6LdRc0112FEJXH00bGsN9Q31yu5EIVHTgjTKRkKtEq1k/high.mp4"
           poster="https://image.mux.com/O6LdRc0112FEJXH00bGsN9Q31yu5EIVHTgjTKRkKtEq1k/thumbnail.jpg?time=56"
-          muted
           crossorigin
+          muted
+          playsinline
         >
           <track
             label="thumbnails"

--- a/examples/themes/youtube-theme.html
+++ b/examples/themes/youtube-theme.html
@@ -45,7 +45,7 @@
       </media-theme-youtube>
 
       <script>
-        document.querySelector('video').currentTime = 25;
+        // document.querySelector('video').currentTime = 25;
       </script>
 
       <div class="examples">

--- a/examples/themes/youtube-theme.html
+++ b/examples/themes/youtube-theme.html
@@ -4,6 +4,7 @@
     <meta name="viewport" content="width=device-width" />
     <title>Media Chrome Youtube Theme Example</title>
     <script type="module" src="../../dist/index.js"></script>
+    <script type="module" src="../../src/js/themes/media-theme-youtube.js"></script>
     <!-- <script type="module" src="https://unpkg.com/youtube-video-element@0"></script> -->
   </head>
   <body>
@@ -13,7 +14,7 @@
       }
 
       /** add styles to prevent CLS (Cumulative Layout Shift) */
-      media-controller:not([audio]) {
+      media-theme-youtube {
         display: block;         /* expands the container if preload=none */
         max-width: 720px;       /* allows the container to shrink if small */
         aspect-ratio: 16 / 9;   /* set container aspect ratio if preload=none */
@@ -22,118 +23,27 @@
       video {
         width: 100%;      /* prevents video to expand beyond its container */
       }
-
-      .media-theme-youtube * {
-        font-size: 13px;
-        font-family: Roboto, Arial, sans-serif;
-        color: #ddd;
-
-        --media-range-track-height: 3px;
-        --media-range-thumb-height: 13px;
-        --media-range-thumb-width: 13px;
-        --media-range-thumb-border-radius: 13px;
-
-        --media-icon-color: #ddd;
-      }
-
-      .media-theme-youtube *:hover {
-        color: #fff;
-        --media-icon-color: #fff;
-      }
-
-      .media-theme-youtube media-control-bar > *:hover {
-        background: transparent;
-      }
-
-      .media-theme-youtube media-play-button {
-        --media-button-icon-width: 30px;
-        padding: 6px 10px;
-      }
-
-      .media-theme-youtube media-time-range {
-        height: auto;
-
-        --media-range-track-transition: height 0.1s linear;
-        --media-range-track-background: #444;
-
-        --media-range-bar-color: rgb(229, 9, 20);
-        --media-progress-buffered-color: #999;
-
-        --media-range-thumb-border-radius: 13px;
-        --media-range-thumb-background: #f00;
-
-        --media-range-thumb-transition: transform 0.1s linear;
-        --media-range-thumb-transform: scale(0) translate(0%, 0%);
-      }
-
-      .media-theme-youtube media-time-range:hover {
-        --media-range-track-height: 5px;
-        --media-range-thumb-transform: scale(1) translate(0%, 0%);
-      }
-
-      .media-theme-youtube media-volume-range {
-        padding-left: 0px;
-
-        --media-range-track-background: #fff;
-        --media-range-bar-color: #fff;
-        --media-range-thumb-background: #fff;
-      }
-
-      .media-theme-youtube .control-spacer {
-        flex-grow: 1;
-      }
-
-      .media-theme-youtube media-mute-button + media-volume-range {
-        width: 0px;
-        overflow: hidden;
-        padding-right: 0px;
-
-        /* Set the internal width so it reveals, not grows */
-        --media-range-track-width: 60px;
-        transition: width 0.2s ease-in;
-      }
-
-      /* Expand volume control in all relevant states */
-      .media-theme-youtube media-mute-button:hover + media-volume-range,
-      .media-theme-youtube media-mute-button:focus + media-volume-range,
-      .media-theme-youtube media-mute-button:focus-within + media-volume-range,
-      .media-theme-youtube media-volume-range:hover,
-      .media-theme-youtube media-volume-range:focus,
-      .media-theme-youtube media-volume-range:focus-within {
-        width: 70px;
-      }
     </style>
     <main>
       <h1>Media Chrome Youtube Theme Example</h1>
-      <media-controller class="media-theme-youtube">
+
+      <media-theme-youtube>
         <video
           slot="media"
-          src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/high.mp4"
+          src="https://stream.mux.com/O6LdRc0112FEJXH00bGsN9Q31yu5EIVHTgjTKRkKtEq1k/high.mp4"
+          poster="https://image.mux.com/O6LdRc0112FEJXH00bGsN9Q31yu5EIVHTgjTKRkKtEq1k/thumbnail.jpg?time=56"
           muted
-          preload="none"
           crossorigin
         >
           <track
             label="thumbnails"
             default
             kind="metadata"
-            src="https://image.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/storyboard.vtt"
+            src="https://image.mux.com/O6LdRc0112FEJXH00bGsN9Q31yu5EIVHTgjTKRkKtEq1k/storyboard.vtt"
           />
         </video>
-        <media-control-bar>
-          <media-time-range></media-time-range>
-        </media-control-bar>
-        <media-control-bar>
-          <media-play-button></media-play-button>
-          <media-mute-button></media-mute-button>
-          <media-volume-range></media-volume-range>
-          <media-time-display show-duration></media-time-display>
-          <span class="control-spacer"></span>
-          <media-playback-rate-button></media-playback-rate-button>
-          <media-pip-button></media-pip-button>
-          <media-fullscreen-button></media-fullscreen-button>
-        </media-control-bar>
-      </media-controller>
+      </media-theme-youtube>
+
       <div class="examples">
         <a href="../">View more examples</a>
       </div>

--- a/examples/themes/youtube-theme.html
+++ b/examples/themes/youtube-theme.html
@@ -45,7 +45,40 @@
       </media-theme-youtube>
 
       <script>
-        // document.querySelector('video').currentTime = 25;
+        function cloneMediaFragment() {
+          // Check that the fragment is a Media Fragment (starts with t=)
+          if (window.location.hash && window.location.hash.match(/^#t=/)) {
+            // Find any video and audio tags on the page
+            document.querySelectorAll('video,audio').forEach(function (el) {
+              // Create a virtual element to use as a URI parser
+              var parser = document.createElement('a');
+              parser.href = el.currentSrc;
+              // Replace the hash
+              parser.hash = window.location.hash;
+              // Set the src of the video/audio tag to the full URL
+              el.src = parser.href;
+            });
+          }
+        }
+
+        document.addEventListener('DOMContentLoaded', function () {
+          cloneMediaFragment();
+          // When the media is paused, update the fragment of the page
+          document.querySelectorAll('video,audio').forEach(function (el) {
+            el.addEventListener('pause', function (event) {
+              // Update the media fragment to the current time
+              // Use replaceState to avoid triggering the "hashchange" listener above
+              history.replaceState(
+                null,
+                null,
+                '#t=' + Math.round(event.target.currentTime)
+              );
+            });
+          });
+        });
+
+        // If the user changes the hash manually, clone the fragment to the media URLs
+        window.addEventListener('hashchange', cloneMediaFragment);
       </script>
 
       <div class="examples">

--- a/examples/themes/youtube-theme.html
+++ b/examples/themes/youtube-theme.html
@@ -44,6 +44,10 @@
         </video>
       </media-theme-youtube>
 
+      <script>
+        document.querySelector('video').currentTime = 25;
+      </script>
+
       <div class="examples">
         <a href="../">View more examples</a>
       </div>

--- a/examples/vertical.html
+++ b/examples/vertical.html
@@ -45,7 +45,6 @@
         <video
           slot="media"
           src="https://stream.mux.com/1EFcsL5JET00t00mBv01t00xt00T4QeNQtsXx2cKY6DLd7RM/high.mp4"
-          preload="none"
           muted
           crossorigin
           playsinline

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "format": "prettier --write .",
     "clean": "rimraf dist",
+    "lint": "eslint src/js",
     "build:esm": "esbuild src/js/*.js src/js/*/*.js --target=es2019 --format=esm --outdir=dist --minify --sourcemap",
     "build:cjs": "esbuild src/js/*.js src/js/*/*.js --target=es2019 --format=cjs --outdir=dist/cjs --minify --sourcemap",
     "build:iife": "esbuild src/js/index.js --bundle --target=es2019 --format=iife --outdir=dist/iife --minify --sourcemap --global-name=MediaChrome",

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -73,6 +73,7 @@ export const MediaUIAttributes = {
   MEDIA_CURRENT_TIME: 'media-current-time',
   MEDIA_DURATION: 'media-duration',
   MEDIA_SEEKABLE: 'media-seekable',
+  MEDIA_PREVIEW_TIME: 'media-preview-time',
   MEDIA_PREVIEW_IMAGE: 'media-preview-image',
   MEDIA_PREVIEW_COORDS: 'media-preview-coords',
   MEDIA_CHROME_ATTRIBUTES: 'media-chrome-attributes',

--- a/src/js/extras/media-clip-selector/index.js
+++ b/src/js/extras/media-clip-selector/index.js
@@ -79,7 +79,7 @@ template.innerHTML = `
       top: 0;
     }
 
-    media-thumbnail-preview {
+    media-preview-thumbnail {
       position: absolute;
       bottom: 10px;
       border: 2px solid #fff;
@@ -93,7 +93,7 @@ template.innerHTML = `
     }
 
     /* Can't get this working. Trying a downward triangle. */
-    /* media-thumbnail-preview::after {
+    /* media-preview-thumbnail::after {
       content: "";
       display: block;
       width: 300px;
@@ -123,7 +123,7 @@ template.innerHTML = `
     }
   </style>
   <div id="thumbnailContainer">
-    <media-thumbnail-preview></media-thumbnail-preview>
+    <media-preview-thumbnail></media-preview-thumbnail>
   </div>
   <div id="selectorContainer">
     <div id="timeline"></div>
@@ -401,7 +401,7 @@ class MediaClipSelector extends window.HTMLElement {
    */
   enableThumbnails() {
     this.thumbnailPreview = this.shadowRoot.querySelector(
-      'media-thumbnail-preview'
+      'media-preview-thumbnail'
     );
     const thumbnailContainer = this.shadowRoot.querySelector(
       '#thumbnailContainer'

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -22,6 +22,7 @@ import MediaPlaybackRateButton from './media-playback-rate-button.js';
 import MediaPosterImage from './media-poster-image.js';
 import MediaProgressRange from './media-progress-range.js';
 import MediaSeekBackwardButton from './media-seek-backward-button.js';
+import MediaPreviewTimeDisplay from './media-preview-time-display.js';
 import MediaPreviewThumbnail from './media-preview-thumbnail.js';
 import MediaTimeRange from './media-time-range.js';
 import MediaLoadingIndicator from './media-loading-indicator.js';
@@ -74,6 +75,7 @@ export {
   MediaPosterImage,
   MediaProgressRange,
   MediaSeekBackwardButton,
+  MediaPreviewTimeDisplay,
   MediaPreviewThumbnail,
   MediaTimeRange,
   MediaTitleElement,

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -22,7 +22,7 @@ import MediaPlaybackRateButton from './media-playback-rate-button.js';
 import MediaPosterImage from './media-poster-image.js';
 import MediaProgressRange from './media-progress-range.js';
 import MediaSeekBackwardButton from './media-seek-backward-button.js';
-import MediaThumbnailPreview from './media-thumbnail-preview.js';
+import MediaPreviewThumbnail from './media-preview-thumbnail.js';
 import MediaTimeRange from './media-time-range.js';
 import MediaLoadingIndicator from './media-loading-indicator.js';
 import MediaTitleElement from './media-title-element.js';
@@ -73,8 +73,7 @@ export {
   MediaPosterImage,
   MediaProgressRange,
   MediaSeekBackwardButton,
-  MediaThumbnailPreview,
-  MediaThumbnailPreview as MediaThumbnailPreviewElement,
+  MediaPreviewThumbnail,
   MediaTimeRange,
   MediaTitleElement,
   MediaLoadingIndicator,

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -54,6 +54,7 @@ if (!window.customElements.get('media-container')) {
 
 export {
   MediaAirplayButton,
+  MediaCastButton,
   MediaChromeButton,
   MediaGestureReceiver,
   MediaContainer,

--- a/src/js/media-chrome-button.js
+++ b/src/js/media-chrome-button.js
@@ -152,10 +152,10 @@ class MediaChromeButton extends window.HTMLElement {
   }
 
   disconnectedCallback() {
-    const mediaControllerSelector = this.getAttribute(
+    const mediaControllerId = this.getAttribute(
       MediaUIAttributes.MEDIA_CONTROLLER
     );
-    if (mediaControllerSelector) {
+    if (mediaControllerId) {
       const mediaControllerEl = document.getElementById(mediaControllerId);
       mediaControllerEl?.unassociateElement?.(this);
     }

--- a/src/js/media-chrome-range.js
+++ b/src/js/media-chrome-range.js
@@ -110,7 +110,7 @@ template.innerHTML = `
       top: 50%;
       transform: translate(var(--media-range-track-translate-x, 0px), calc(var(--media-range-track-translate-y, 0px) - 50%));
       left: var(--media-range-padding-left, 10px);
-      right: var(--media-range-padding-left, 10px);
+      right: var(--media-range-padding-right, 10px);
       background: var(--media-range-track-background, #333);
     }
 

--- a/src/js/media-chrome-range.js
+++ b/src/js/media-chrome-range.js
@@ -52,8 +52,9 @@ template.innerHTML = `
       width: 100px;
       padding-left: var(--media-range-padding-left, 10px);
       padding-right: var(--media-range-padding-right, 10px);
-
       pointer-events: auto;
+      /* needed for vertical align issue 1px off */
+      font-size: 0;
     }
 
     :host(:hover) {

--- a/src/js/media-chrome-range.js
+++ b/src/js/media-chrome-range.js
@@ -108,7 +108,7 @@ template.innerHTML = `
       width: auto;
       position: absolute;
       top: 50%;
-      transform: translateY(-50%);
+      transform: translate(var(--media-range-track-translate-x, 0px), calc(var(--media-range-track-translate-y, 0px) - 50%));
       left: var(--media-range-padding-left, 10px);
       right: var(--media-range-padding-left, 10px);
       background: var(--media-range-track-background, #333);

--- a/src/js/media-chrome-range.js
+++ b/src/js/media-chrome-range.js
@@ -28,7 +28,8 @@ const trackStyles = `
   height: var(--track-height);
   border: var(--media-range-track-border, none);
   border-radius: var(--media-range-track-border-radius, 0);
-  background: var(--media-range-track-background-internal, var(--media-range-track-background, #eee));
+  background: var(--media-range-track-background-internal,
+    var(--media-range-track-background, #eee));
 
   box-shadow: var(--media-range-track-box-shadow, none);
   transition: var(--media-range-track-transition, none);

--- a/src/js/media-chrome-range.js
+++ b/src/js/media-chrome-range.js
@@ -4,6 +4,7 @@ import {
   Window as window,
   Document as document,
 } from './utils/server-safe-globals.js';
+import { getOrInsertCSSRule } from './utils/element-utils.js';
 
 const template = document.createElement('template');
 
@@ -294,22 +295,6 @@ class MediaChromeRange extends window.HTMLElement {
 
     return colorArray;
   }
-}
-
-/**
- * Get or insert a CSS rule with a selector in an element containing <style> tags.
- * @param  {Element} styleParent
- * @param  {string} selectorText
- * @return {CSSStyleRule|undefined}
- */
-function getOrInsertCSSRule(styleParent, selectorText) {
-  let style;
-  for (style of styleParent.querySelectorAll('style')) {
-    for (let rule of style.sheet.cssRules)
-      if (rule.selectorText === selectorText) return rule;
-  }
-  style.sheet.insertRule(`${selectorText}{}`, style.sheet.cssRules.length);
-  return style.sheet.cssRules[style.sheet.cssRules.length - 1];
 }
 
 defineCustomElement('media-chrome-range', MediaChromeRange);

--- a/src/js/media-chrome-range.js
+++ b/src/js/media-chrome-range.js
@@ -29,7 +29,8 @@ const trackStyles = `
   border: var(--media-range-track-border, none);
   border-radius: var(--media-range-track-border-radius, 0);
   background: var(--media-range-track-background-internal,
-    var(--media-range-track-background, #eee));
+    var(--media-range-track-background, #eee)),
+    var(--media-range-track-background, #333);
 
   box-shadow: var(--media-range-track-box-shadow, none);
   transition: var(--media-range-track-transition, none);
@@ -51,7 +52,8 @@ template.innerHTML = `
       transition: background 0.15s linear;
       height: 44px;
       width: 100px;
-      padding: 0 10px;
+      padding-left: var(--media-range-padding-left, 10px);
+      padding-right: var(--media-range-padding-right, 10px);
 
       pointer-events: auto;
     }
@@ -230,7 +232,7 @@ class MediaChromeRange extends window.HTMLElement {
 
     let colorArray = [
       ['var(--media-range-bar-color, #fff)', rangePercent + thumbPercent],
-      ['var(--media-range-track-background, #333)', 100],
+      ['transparent', 100],
     ];
 
     return colorArray;

--- a/src/js/media-chrome-range.js
+++ b/src/js/media-chrome-range.js
@@ -204,7 +204,7 @@ class MediaChromeRange extends window.HTMLElement {
     });
     gradientStr = gradientStr.slice(0, gradientStr.length - 1) + ')';
 
-    const { style } = findCSSRule(this.shadowRoot, ':host');
+    const { style } = getOrInsertCSSRule(this.shadowRoot, ':host');
     style.setProperty('--media-range-track-background-internal', gradientStr);
   }
 
@@ -239,11 +239,20 @@ class MediaChromeRange extends window.HTMLElement {
   }
 }
 
-function findCSSRule(el, selectorText) {
-  for (let style of el.querySelectorAll('style')) {
+/**
+ * Get or insert a CSS rule with a selector in an element containing <style> tags.
+ * @param  {Element} styleParent
+ * @param  {string} selectorText
+ * @return {CSSStyleRule|undefined}
+ */
+function getOrInsertCSSRule(styleParent, selectorText) {
+  let style;
+  for (style of styleParent.querySelectorAll('style')) {
     for (let rule of style.sheet.cssRules)
       if (rule.selectorText === selectorText) return rule;
   }
+  style.sheet.insertRule(`${selectorText}{}`, style.sheet.cssRules.length);
+  return style.sheet.cssRules[style.sheet.cssRules.length - 1];
 }
 
 defineCustomElement('media-chrome-range', MediaChromeRange);

--- a/src/js/media-chrome-range.js
+++ b/src/js/media-chrome-range.js
@@ -133,7 +133,7 @@ template.innerHTML = `
       background-color: #777;
     }
   </style>
-  <input id="range" type="range" min="0" max="1000" step="1" value="0">
+  <input id="range" type="range" min="0" max="1000" step="any" value="0">
 `;
 
 class MediaChromeRange extends window.HTMLElement {

--- a/src/js/media-chrome-range.js
+++ b/src/js/media-chrome-range.js
@@ -176,10 +176,10 @@ class MediaChromeRange extends window.HTMLElement {
   }
 
   disconnectedCallback() {
-    const mediaControllerSelector = this.getAttribute(
+    const mediaControllerId = this.getAttribute(
       MediaUIAttributes.MEDIA_CONTROLLER
     );
-    if (mediaControllerSelector) {
+    if (mediaControllerId) {
       const mediaControllerEl = document.getElementById(mediaControllerId);
       mediaControllerEl?.unassociateElement?.(this);
     }

--- a/src/js/media-chrome-range.js
+++ b/src/js/media-chrome-range.js
@@ -202,10 +202,8 @@ class MediaChromeRange extends window.HTMLElement {
     });
     gradientStr = gradientStr.slice(0, gradientStr.length - 1) + ')';
 
-    this.style.setProperty(
-      '--media-range-track-background-internal',
-      gradientStr
-    );
+    const { style } = findCSSRule(this.shadowRoot, ':host');
+    style.setProperty('--media-range-track-background-internal', gradientStr);
   }
 
   /*
@@ -218,12 +216,31 @@ class MediaChromeRange extends window.HTMLElement {
     const relativeMax = range.max - range.min;
     const rangePercent = (relativeValue / relativeMax) * 100;
 
+    let thumbPercent = 0;
+    // If the range thumb is at min or max don't correct the time range.
+    // Ideally the thumb center would go all the way to min and max values
+    // but input[type=range] doesn't play like that.
+    if (range.value > range.min && range.value < range.max) {
+      const thumbWidth =
+        getComputedStyle(this).getPropertyValue('--media-range-thumb-width') ||
+        '10px';
+      const thumbOffset = parseInt(thumbWidth) * (0.5 - rangePercent / 100);
+      thumbPercent = (thumbOffset / range.offsetWidth) * 100;
+    }
+
     let colorArray = [
-      ['var(--media-range-bar-color, #fff)', rangePercent],
+      ['var(--media-range-bar-color, #fff)', rangePercent + thumbPercent],
       ['var(--media-range-track-background, #333)', 100],
     ];
 
     return colorArray;
+  }
+}
+
+function findCSSRule(el, selectorText) {
+  for (let style of el.querySelectorAll('style')) {
+    for (let rule of style.sheet.cssRules)
+      if (rule.selectorText === selectorText) return rule;
   }
 }
 

--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -149,11 +149,11 @@ class MediaContainer extends window.HTMLElement {
     super();
 
     // Set up the Shadow DOM
-    const shadow = this.attachShadow({ mode: 'open' });
+    this.attachShadow({ mode: 'open' });
     this.shadowRoot.appendChild(template.content.cloneNode(true));
 
     // Watch for child adds/removes and update the media element if necessary
-    const mutationCallback = (mutationsList, observer) => {
+    const mutationCallback = (mutationsList) => {
       const media = this.media;
 
       for (let mutation of mutationsList) {
@@ -251,7 +251,7 @@ class MediaContainer extends window.HTMLElement {
 
   mediaSetCallback(media) {
     // Toggle play/pause with clicks on the media element itself
-    this._mediaClickPlayToggle = (_e) => {
+    this._mediaClickPlayToggle = () => {
       const eventName = media.paused
         ? MediaUIEvents.MEDIA_PLAY_REQUEST
         : MediaUIEvents.MEDIA_PAUSE_REQUEST;
@@ -293,7 +293,7 @@ class MediaContainer extends window.HTMLElement {
     return resolveMediaPromise(media);
   }
 
-  mediaUnsetCallback(media) {
+  mediaUnsetCallback() {
     // media.removeEventListener('click', this._mediaClickPlayToggle);
   }
 
@@ -346,7 +346,7 @@ class MediaContainer extends window.HTMLElement {
     };
 
     // Unhide for keyboard controlling
-    this.addEventListener('keyup', (e) => {
+    this.addEventListener('keyup', () => {
       scheduleInactive();
     });
 
@@ -379,15 +379,15 @@ class MediaContainer extends window.HTMLElement {
     });
 
     // Immediately hide if mouse leaves the container
-    this.addEventListener('mouseleave', (e) => {
+    this.addEventListener('mouseleave', () => {
       setInactive();
     });
 
     // Allow for focus styles only when using the keyboard to navigate
-    this.addEventListener('keyup', (e) => {
+    this.addEventListener('keyup', () => {
       this.setAttribute('media-keyboard-control', '');
     });
-    this.addEventListener('mouseup', (e) => {
+    this.addEventListener('mouseup', () => {
       this.removeAttribute('media-keyboard-control');
     });
   }

--- a/src/js/media-control-bar.js
+++ b/src/js/media-control-bar.js
@@ -69,10 +69,10 @@ class MediaControlBar extends window.HTMLElement {
   }
 
   disconnectedCallback() {
-    const mediaControllerSelector = this.getAttribute(
+    const mediaControllerId = this.getAttribute(
       MediaUIAttributes.MEDIA_CONTROLLER
     );
-    if (mediaControllerSelector) {
+    if (mediaControllerId) {
       const mediaControllerEl = document.getElementById(mediaControllerId);
       mediaControllerEl?.unassociateElement?.(this);
     }

--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -30,20 +30,6 @@ import {
   getTextTracksList,
   updateTracksModeTo,
 } from './utils/captions.js';
-const {
-  MEDIA_PLAY_REQUEST,
-  MEDIA_PAUSE_REQUEST,
-  MEDIA_MUTE_REQUEST,
-  MEDIA_UNMUTE_REQUEST,
-  MEDIA_VOLUME_REQUEST,
-  MEDIA_ENTER_FULLSCREEN_REQUEST,
-  MEDIA_EXIT_FULLSCREEN_REQUEST,
-  MEDIA_SEEK_REQUEST,
-  MEDIA_PREVIEW_REQUEST,
-  MEDIA_ENTER_PIP_REQUEST,
-  MEDIA_EXIT_PIP_REQUEST,
-  MEDIA_PLAYBACK_RATE_REQUEST,
-} = MediaUIEvents;
 
 class MediaController extends MediaContainer {
   constructor() {
@@ -274,7 +260,7 @@ class MediaController extends MediaContainer {
         const { detail: tracksToUpdate = [] } = e;
         updateTracksModeTo(TextTrackModes.DISABLED, tracks, tracksToUpdate);
       },
-      MEDIA_AIRPLAY_REQUEST: (_e) => {
+      MEDIA_AIRPLAY_REQUEST: () => {
         const { media } = this;
         if (!media) return;
         if (
@@ -956,7 +942,7 @@ const monitorForMediaStateReceivers = (
 
   // Observe any changes to the DOM for any descendants that are identifiable as Media State Receivers
   // and register or unregister them, depending on the change that occurred.
-  const mutationCallback = (mutationsList, _observer) => {
+  const mutationCallback = (mutationsList) => {
     mutationsList.forEach((mutationRecord) => {
       const {
         addedNodes = [],
@@ -1035,7 +1021,7 @@ export const hasVolumeSupportAsync = async (mediaEl = getTestMediaEl()) => {
  * @param  {number} ms
  * @return {Promise}
  */
-export const delay = (ms) => new Promise((resolve, reject) => setTimeout(resolve, ms));
+export const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 export const hasPipSupport = (mediaEl = getTestMediaEl()) =>
   typeof mediaEl?.requestPictureInPicture === 'function';

--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -197,14 +197,20 @@ class MediaController extends MediaContainer {
         // No media (yet), so bail early
         if (!media) return;
 
+        const time = e.detail;
+
+        // if time is null, then we're done previewing and want to remove the attributes
+        if (time === null) {
+          this.propagateMediaState(MediaUIAttributes.MEDIA_PREVIEW_TIME, undefined);
+        }
+        this.propagateMediaState(MediaUIAttributes.MEDIA_PREVIEW_TIME, time);
+
         const [track] = getTextTracksList(media, {
           kind: TextTrackKinds.METADATA,
           label: 'thumbnails',
         });
         // No thumbnails track (yet) or no cues available in thumbnails track, so bail early.
         if (!(track && track.cues)) return;
-
-        const time = e.detail;
 
         // if time is null, then we're done previewing and want to remove the attributes
         if (time === null) {

--- a/src/js/media-gesture-receiver.js
+++ b/src/js/media-gesture-receiver.js
@@ -102,10 +102,10 @@ class MediaGestureReceiver extends window.HTMLElement {
   }
 
   disconnectedCallback() {
-    const mediaControllerSelector = this.getAttribute(
+    const mediaControllerId = this.getAttribute(
       MediaUIAttributes.MEDIA_CONTROLLER
     );
-    if (mediaControllerSelector) {
+    if (mediaControllerId) {
       const mediaControllerEl = document.getElementById(mediaControllerId);
       mediaControllerEl?.unassociateElement?.(this);
     }
@@ -113,9 +113,9 @@ class MediaGestureReceiver extends window.HTMLElement {
 
   // NOTE: Currently "baking in" actions + attrs until we come up with
   // a more robust architecture (CJP)
-  handleTap(_evt) {}
+  handleTap() {}
 
-  handleMouseClick(_evt) {
+  handleMouseClick() {
     const eventName =
       this.getAttribute(MediaUIAttributes.MEDIA_PAUSED) != null
         ? MediaUIEvents.MEDIA_PLAY_REQUEST

--- a/src/js/media-preview-thumbnail.js
+++ b/src/js/media-preview-thumbnail.js
@@ -56,10 +56,10 @@ class MediaPreviewThumbnail extends window.HTMLElement {
   }
 
   disconnectedCallback() {
-    const mediaControllerSelector = this.getAttribute(
+    const mediaControllerId = this.getAttribute(
       MediaUIAttributes.MEDIA_CONTROLLER
     );
-    if (mediaControllerSelector) {
+    if (mediaControllerId) {
       const mediaControllerEl = document.getElementById(mediaControllerId);
       mediaControllerEl?.unassociateElement?.(this);
     }

--- a/src/js/media-preview-thumbnail.js
+++ b/src/js/media-preview-thumbnail.js
@@ -10,6 +10,7 @@ import {
 } from './utils/server-safe-globals.js';
 import { defineCustomElement } from './utils/defineCustomElement.js';
 import { MediaUIAttributes } from './constants.js';
+import { getOrInsertCSSRule } from './utils/element-utils.js';
 
 const template = document.createElement('template');
 template.innerHTML = `
@@ -140,22 +141,6 @@ class MediaPreviewThumbnail extends window.HTMLElement {
     resize();
     imgStyle.transform = `translate(-${x * scale}px, -${y * scale}px)`;
   }
-}
-
-/**
- * Get or insert a CSS rule with a selector in an element containing <style> tags.
- * @param  {Element} styleParent
- * @param  {string} selectorText
- * @return {CSSStyleRule|undefined}
- */
-function getOrInsertCSSRule(styleParent, selectorText) {
-  let style;
-  for (style of styleParent.querySelectorAll('style')) {
-    for (let rule of style.sheet.cssRules)
-      if (rule.selectorText === selectorText) return rule;
-  }
-  style.sheet.insertRule(`${selectorText}{}`, style.sheet.cssRules.length);
-  return style.sheet.cssRules[style.sheet.cssRules.length - 1];
 }
 
 defineCustomElement('media-preview-thumbnail', MediaPreviewThumbnail);

--- a/src/js/media-preview-thumbnail.js
+++ b/src/js/media-preview-thumbnail.js
@@ -1,5 +1,5 @@
 /*
-  <media-thumbnail-preview media="#myVideo" time="10.00">
+  <media-preview-thumbnail media="#myVideo" time="10.00">
 
   Uses the "thumbnails" track of a video element to show an image relative to
   the video time given in the `time` attribute.
@@ -28,7 +28,7 @@ template.innerHTML = `
   <img crossorigin loading="eager" decoding="async" />
 `;
 
-class MediaThumbnailPreview extends window.HTMLElement {
+class MediaPreviewThumbnail extends window.HTMLElement {
   static get observedAttributes() {
     return [
       MediaUIAttributes.MEDIA_CONTROLLER,
@@ -158,6 +158,6 @@ function getOrInsertCSSRule(styleParent, selectorText) {
   return style.sheet.cssRules[style.sheet.cssRules.length - 1];
 }
 
-defineCustomElement('media-thumbnail-preview', MediaThumbnailPreview);
+defineCustomElement('media-preview-thumbnail', MediaPreviewThumbnail);
 
-export default MediaThumbnailPreview;
+export default MediaPreviewThumbnail;

--- a/src/js/media-preview-time-display.js
+++ b/src/js/media-preview-time-display.js
@@ -1,0 +1,22 @@
+import MediaTextDisplay from './media-text-display.js';
+import { defineCustomElement } from './utils/defineCustomElement.js';
+import { formatTime } from './utils/time.js';
+import { MediaUIAttributes } from './constants.js';
+// Todo: Use data locals: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString
+
+class MediaPreviewTimeDisplay extends MediaTextDisplay {
+  static get observedAttributes() {
+    return [...super.observedAttributes, MediaUIAttributes.MEDIA_PREVIEW_TIME];
+  }
+
+  attributeChangedCallback(attrName, oldValue, newValue) {
+    if (attrName === MediaUIAttributes.MEDIA_PREVIEW_TIME && newValue != null) {
+      this.container.textContent = formatTime(newValue);
+    }
+    super.attributeChangedCallback(attrName, oldValue, newValue);
+  }
+}
+
+defineCustomElement('media-preview-time-display', MediaPreviewTimeDisplay);
+
+export default MediaPreviewTimeDisplay;

--- a/src/js/media-settings-popup.js
+++ b/src/js/media-settings-popup.js
@@ -46,7 +46,7 @@ class MediaSettingsPopup extends window.HTMLElement {
   constructor() {
     super();
 
-    const shadow = this.attachShadow({ mode: 'open' });
+    this.attachShadow({ mode: 'open' });
     this.shadowRoot.appendChild(template.content.cloneNode(true));
   }
 }

--- a/src/js/media-text-display.js
+++ b/src/js/media-text-display.js
@@ -90,10 +90,10 @@ class MediaTextDisplay extends window.HTMLElement {
   }
 
   disconnectedCallback() {
-    const mediaControllerSelector = this.getAttribute(
+    const mediaControllerId = this.getAttribute(
       MediaUIAttributes.MEDIA_CONTROLLER
     );
-    if (mediaControllerSelector) {
+    if (mediaControllerId) {
       const mediaControllerEl = document.getElementById(mediaControllerId);
       mediaControllerEl?.unassociateElement?.(this);
     }

--- a/src/js/media-thumbnail-preview.js
+++ b/src/js/media-thumbnail-preview.js
@@ -12,11 +12,9 @@ import { defineCustomElement } from './utils/defineCustomElement.js';
 import { MediaUIAttributes } from './constants.js';
 
 const template = document.createElement('template');
-
 template.innerHTML = `
   <style>
     :host {
-      background-color: #000;
       box-sizing: border-box;
       display: inline-block;
       overflow: hidden;
@@ -30,7 +28,7 @@ template.innerHTML = `
   <img crossorigin loading="eager" decoding="async" />
 `;
 
-class MediaThumbnailPreviewElement extends window.HTMLElement {
+class MediaThumbnailPreview extends window.HTMLElement {
   static get observedAttributes() {
     return [
       MediaUIAttributes.MEDIA_CONTROLLER,
@@ -105,30 +103,28 @@ class MediaThumbnailPreviewElement extends window.HTMLElement {
 
     const computedStyle = getComputedStyle(this);
     const { maxWidth, maxHeight, minWidth, minHeight } = computedStyle;
+    const maxRatio = Math.min(parseInt(maxWidth) / w, parseInt(maxHeight) / h);
+    const minRatio = Math.max(parseInt(minWidth) / w, parseInt(minHeight) / h);
 
-    const maxThumbRatio = Math.min(
-      parseInt(maxWidth) / w,
-      parseInt(maxHeight) / h
-    );
-    const minThumbRatio = Math.max(
-      parseInt(minWidth) / w,
-      parseInt(minHeight) / h
-    );
+    // maxRatio scales down and takes priority, minRatio scales up.
+    const isScalingDown = maxRatio < 1;
+    const scale = isScalingDown ? maxRatio : minRatio > 1 ? minRatio : 1;
 
-    // maxThumbRatio scales down and takes priority, minThumbRatio scales up.
-    const thumbScale =
-      maxThumbRatio < 1 ? maxThumbRatio : minThumbRatio > 1 ? minThumbRatio : 1;
-
-    this.style.width = `${w * thumbScale}px`;
-    this.style.height = `${h * thumbScale}px`;
-    this.style.aspectRatio = `${w} / ${h}`;
-
+    const { style } = findCSSRule(this.shadowRoot, ':host');
+    const imgStyle = findCSSRule(this.shadowRoot, 'img').style;
     const img = this.shadowRoot.querySelector('img');
 
+    // Revert one set of extremum to its initial value on a known scale direction.
+    const extremum = isScalingDown ? 'min' : 'max';
+    style.setProperty(`${extremum}-width`, 'initial', 'important');
+    style.setProperty(`${extremum}-height`, 'initial', 'important');
+    style.width = `${w * scale}px`;
+    style.height = `${h * scale}px`;
+
     const resize = () => {
-      img.style.width = `${this.imgWidth * thumbScale}px`;
-      img.style.height = `${this.imgHeight * thumbScale}px`;
-      img.style.display = 'block';
+      imgStyle.width = `${this.imgWidth * scale}px`;
+      imgStyle.height = `${this.imgHeight * scale}px`;
+      imgStyle.display = 'block';
     };
 
     if (img.src !== src) {
@@ -136,17 +132,23 @@ class MediaThumbnailPreviewElement extends window.HTMLElement {
         this.imgWidth = img.naturalWidth;
         this.imgHeight = img.naturalHeight;
         resize();
-      }
+      };
       img.src = src;
       resize();
     }
 
     resize();
-    img.style.left = `-${x * thumbScale}px`;
-    img.style.top = `-${y * thumbScale}px`;
+    imgStyle.transform = `translate(-${x * scale}px, -${y * scale}px)`;
   }
 }
 
-defineCustomElement('media-thumbnail-preview', MediaThumbnailPreviewElement);
+function findCSSRule(el, selectorText) {
+  for (let style of el.querySelectorAll('style')) {
+    for (let rule of style.sheet.cssRules)
+      if (rule.selectorText === selectorText) return rule;
+  }
+}
 
-export default MediaThumbnailPreviewElement;
+defineCustomElement('media-thumbnail-preview', MediaThumbnailPreview);
+
+export default MediaThumbnailPreview;

--- a/src/js/media-thumbnail-preview.js
+++ b/src/js/media-thumbnail-preview.js
@@ -110,8 +110,8 @@ class MediaThumbnailPreview extends window.HTMLElement {
     const isScalingDown = maxRatio < 1;
     const scale = isScalingDown ? maxRatio : minRatio > 1 ? minRatio : 1;
 
-    const { style } = findCSSRule(this.shadowRoot, ':host');
-    const imgStyle = findCSSRule(this.shadowRoot, 'img').style;
+    const { style } = getOrInsertCSSRule(this.shadowRoot, ':host');
+    const imgStyle = getOrInsertCSSRule(this.shadowRoot, 'img').style;
     const img = this.shadowRoot.querySelector('img');
 
     // Revert one set of extremum to its initial value on a known scale direction.
@@ -142,11 +142,20 @@ class MediaThumbnailPreview extends window.HTMLElement {
   }
 }
 
-function findCSSRule(el, selectorText) {
-  for (let style of el.querySelectorAll('style')) {
+/**
+ * Get or insert a CSS rule with a selector in an element containing <style> tags.
+ * @param  {Element} styleParent
+ * @param  {string} selectorText
+ * @return {CSSStyleRule|undefined}
+ */
+function getOrInsertCSSRule(styleParent, selectorText) {
+  let style;
+  for (style of styleParent.querySelectorAll('style')) {
     for (let rule of style.sheet.cssRules)
       if (rule.selectorText === selectorText) return rule;
   }
+  style.sheet.insertRule(`${selectorText}{}`, style.sheet.cssRules.length);
+  return style.sheet.cssRules[style.sheet.cssRules.length - 1];
 }
 
 defineCustomElement('media-thumbnail-preview', MediaThumbnailPreview);

--- a/src/js/media-time-range.js
+++ b/src/js/media-time-range.js
@@ -29,6 +29,8 @@ template.innerHTML = `
       --media-preview-background: var(--media-control-background,
         var(--media-preview-background-color));
       --media-preview-border-radius: 3px;
+      --media-box-padding-left: 10px;
+      --media-box-padding-right: 10px;
     }
 
     [part~="box"] {
@@ -371,8 +373,12 @@ function getBoxPosition(el, box, percent) {
   const rangeRect = el.range.getBoundingClientRect();
 
   // Get preview box center position
-  const leftPadding = rangeRect.left - rect.left;
-  const rightPadding = rect.right - rangeRect.right;
+  const leftPadding = parseInt(
+    getComputedStyle(el).getPropertyValue('--media-box-padding-left')
+  );
+  const rightPadding = parseInt(
+    getComputedStyle(el).getPropertyValue('--media-box-padding-right')
+  );
   const boxOffset = leftPadding + percent * rangeRect.width;
 
   // Use offset dimensions to include borders.

--- a/src/js/media-time-range.js
+++ b/src/js/media-time-range.js
@@ -24,10 +24,12 @@ const template = document.createElement('template');
 template.innerHTML = `
   <style>
     [part~="box"] {
-      display: inline-block;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
       position: absolute;
       left: 0;
-      bottom: calc(100% + 10px);
+      bottom: 100%;
     }
 
     [part~="preview-box"] {
@@ -38,6 +40,8 @@ template.innerHTML = `
 
     media-preview-thumbnail,
     ::slotted(media-preview-thumbnail) {
+      visibility: hidden;
+      transition: visibility 0s .25s;
       background-color: #000;
       max-width: var(--media-preview-thumbnail-max-width, 180px);
       max-height: var(--media-preview-thumbnail-max-height, 160px);
@@ -47,7 +51,23 @@ template.innerHTML = `
       border-radius: var(--media-preview-thumbnail-border-radius, 2px);
     }
 
-    :host([${MediaUIAttributes.MEDIA_PREVIEW_IMAGE}]:hover) [part~="preview-box"] {
+    :host([${MediaUIAttributes.MEDIA_PREVIEW_IMAGE}]:hover) media-preview-thumbnail,
+    :host([${MediaUIAttributes.MEDIA_PREVIEW_IMAGE}]:hover) ::slotted(media-preview-thumbnail) {
+      visibility: visible;
+      transition-delay: 0s;
+    }
+
+    media-preview-time-display,
+    ::slotted(media-preview-time-display) {
+      background: var(--media-preview-time-background,
+        var(--media-control-background, rgba(20,20,30, 0.7)));
+      border-radius: var(--media-preview-time-border-radius, 0);
+      padding: var(--media-preview-time-padding, 2px 10px);
+      margin: var(--media-preview-time-margin, 5px 0);
+    }
+
+    :host([${MediaUIAttributes.MEDIA_PREVIEW_IMAGE}]:hover) [part~="preview-box"],
+    :host([${MediaUIAttributes.MEDIA_PREVIEW_TIME}]:hover) [part~="preview-box"] {
       transition: visibility .5s, opacity .5s;
       visibility: visible;
       opacity: 1;
@@ -78,6 +98,7 @@ template.innerHTML = `
   <span part="box preview-box">
     <slot name="preview">
       <media-preview-thumbnail></media-preview-thumbnail>
+      <media-preview-time-display></media-preview-time-display>
     </slot>
   </span>
   <span part="box current-box">
@@ -99,6 +120,7 @@ class MediaTimeRange extends MediaChromeRange {
       MediaUIAttributes.MEDIA_SEEKABLE,
       MediaUIAttributes.MEDIA_CURRENT_TIME,
       MediaUIAttributes.MEDIA_PREVIEW_IMAGE,
+      MediaUIAttributes.MEDIA_PREVIEW_TIME,
       MediaUIAttributes.MEDIA_BUFFERED,
     ];
   }

--- a/src/js/media-time-range.js
+++ b/src/js/media-time-range.js
@@ -177,8 +177,7 @@ class MediaTimeRange extends MediaChromeRange {
 
     this._refreshBar = () => {
       const delta = (performance.now() - this._updateTimestamp) / 1000;
-      this.range.value = this._updateCurrentTime + delta;
-
+      this.range.value = this.mediaCurrentTime + delta;
       this.updateBar();
       this.updateCurrentBox();
 
@@ -199,7 +198,6 @@ class MediaTimeRange extends MediaChromeRange {
       attrName === MediaUIAttributes.MEDIA_PAUSED
     ) {
       this._updateTimestamp = performance.now();
-      this._updateCurrentTime = this.mediaCurrentTime;
       this.range.value = this.mediaCurrentTime;
       updateAriaValueText(this);
       this.updateBar();

--- a/src/js/media-time-range.js
+++ b/src/js/media-time-range.js
@@ -36,7 +36,8 @@ template.innerHTML = `
       opacity: 0;
     }
 
-    media-thumbnail-preview {
+    media-thumbnail-preview,
+    ::slotted(media-thumbnail-preview) {
       background-color: #000;
       max-width: var(--media-thumbnail-preview-max-width, 180px);
       max-height: var(--media-thumbnail-preview-max-height, 160px);

--- a/src/js/media-time-range.js
+++ b/src/js/media-time-range.js
@@ -95,26 +95,8 @@ template.innerHTML = `
       opacity: 1;
     }
 
-    #range-hover {
-      /* Add z-index so it overlaps the top of the control buttons if they are right under. */
-      z-index: 1;
-      display: none;
-      box-sizing: border-box;
-      position: absolute;
-      left: var(--media-range-padding-left, 10px);
-      right: var(--media-range-padding-right, 10px);
-      bottom: var(--media-time-range-hover-bottom, -5px);
-      height: var(--media-time-range-hover-height, max(calc(100% + 5px), 20px));
-    }
-
-    :host(:hover) #range-hover {
-      display: block;
-    }
-
-    #range {
-      z-index: 2;
-      position: relative;
-      height: var(--media-range-track-height, 4px);
+    :host([${MediaUIAttributes.MEDIA_PREVIEW_TIME}]:hover) {
+      --media-time-range-hover-display: block;
     }
   </style>
   <span part="box preview-box">
@@ -129,8 +111,6 @@ template.innerHTML = `
       <!-- <media-current-time-display></media-current-time-display> -->
     </slot>
   </span>
-  <div id="range-hover"></div>
-  <div id="range-temp"></div>
 `;
 
 class MediaTimeRange extends MediaChromeRange {
@@ -152,7 +132,6 @@ class MediaTimeRange extends MediaChromeRange {
     super();
 
     this.shadowRoot.appendChild(template.content.cloneNode(true));
-    this.shadowRoot.querySelector('#range-temp').replaceWith(this.range);
 
     this.range.addEventListener('input', () => {
       // Cancel color bar refreshing when seeking.
@@ -295,7 +274,7 @@ class MediaTimeRange extends MediaChromeRange {
 
     const buffPercent = (relativeBufferedEnd / relativeMax) * 100;
     colorsArray.splice(1, 0, [
-      'var(--media-time-buffered-color, #777)',
+      'var(--media-time-buffered-color, rgba(255,255,255, .4))',
       buffPercent,
     ]);
     return colorsArray;
@@ -320,6 +299,8 @@ class MediaTimeRange extends MediaChromeRange {
     const trackMouse = () => {
       pointermoveHandler = (evt) => {
         if ([...boxes].some((b) => evt.composedPath().includes(b))) return;
+
+        this.updatePointerBar(evt);
 
         const duration = +this.getAttribute(MediaUIAttributes.MEDIA_DURATION);
         // If no duration we can't calculate which time to show

--- a/src/js/media-time-range.js
+++ b/src/js/media-time-range.js
@@ -36,15 +36,15 @@ template.innerHTML = `
       opacity: 0;
     }
 
-    media-thumbnail-preview,
-    ::slotted(media-thumbnail-preview) {
+    media-preview-thumbnail,
+    ::slotted(media-preview-thumbnail) {
       background-color: #000;
-      max-width: var(--media-thumbnail-preview-max-width, 180px);
-      max-height: var(--media-thumbnail-preview-max-height, 160px);
-      min-width: var(--media-thumbnail-preview-min-width, 120px);
-      min-height: var(--media-thumbnail-preview-min-height, 80px);
-      border: var(--media-thumbnail-preview-border, 2px solid #fff);
-      border-radius: var(--media-thumbnail-preview-border-radius, 2px);
+      max-width: var(--media-preview-thumbnail-max-width, 180px);
+      max-height: var(--media-preview-thumbnail-max-height, 160px);
+      min-width: var(--media-preview-thumbnail-min-width, 120px);
+      min-height: var(--media-preview-thumbnail-min-height, 80px);
+      border: var(--media-preview-thumbnail-border, 2px solid #fff);
+      border-radius: var(--media-preview-thumbnail-border-radius, 2px);
     }
 
     :host([${MediaUIAttributes.MEDIA_PREVIEW_IMAGE}]:hover) [part~="preview-box"] {
@@ -77,7 +77,7 @@ template.innerHTML = `
   </style>
   <span part="box preview-box">
     <slot name="preview">
-      <media-thumbnail-preview></media-thumbnail-preview>
+      <media-preview-thumbnail></media-preview-thumbnail>
     </slot>
   </span>
   <span part="box current-box">

--- a/src/js/media-time-range.js
+++ b/src/js/media-time-range.js
@@ -33,6 +33,26 @@ template.innerHTML = `
       opacity: 0;
     }
 
+    #time-range-container {
+      z-index: 3;
+      position: relative;
+      height: 100%;
+      cursor: pointer;
+    }
+
+    #time-range-hover-padding {
+      display: none;
+      position: absolute;
+      left: 0;
+      right: 0;
+      bottom: var(--media-time-range-hover-bottom, -5px);
+      height: var(--media-time-range-hover-height, max(calc(100% + 5px), 20px));
+    }
+
+    #time-range-container:hover #time-range-hover-padding {
+      display: block;
+    }
+
     media-thumbnail-preview {
       --thumb-preview-min-width: var(--media-thumbnail-preview-min-width, 120px);
       --thumb-preview-max-width: var(--media-thumbnail-preview-max-width, 180px);
@@ -56,6 +76,9 @@ template.innerHTML = `
   <div id="thumbnail-container">
     <media-thumbnail-preview></media-thumbnail-preview>
   </div>
+  <div id="time-range-container">
+    <div id="time-range-hover-padding"></div>
+  </div>
 `;
 
 class MediaTimeRange extends MediaChromeRange {
@@ -75,6 +98,9 @@ class MediaTimeRange extends MediaChromeRange {
     super();
 
     this.shadowRoot.appendChild(template.content.cloneNode(true));
+
+    const container = this.shadowRoot.querySelector('#time-range-container');
+    container.append(this.range);
 
     this.range.addEventListener('input', () => {
       const newTime = this.range.value;

--- a/src/js/media-time-range.js
+++ b/src/js/media-time-range.js
@@ -313,7 +313,10 @@ class MediaTimeRange extends MediaChromeRange {
         trackMouse();
 
         let offRangeHandler = (evt) => {
-          if (!evt.composedPath().includes(this)) {
+          if (
+            !evt.composedPath().includes(this) ||
+            evt.composedPath().includes(thumbnailContainer)
+          ) {
             window.removeEventListener('pointermove', offRangeHandler);
             rangeEntered = false;
             stopTrackingMouse();

--- a/src/js/media-time-range.js
+++ b/src/js/media-time-range.js
@@ -40,7 +40,7 @@ template.innerHTML = `
       min-width: var(--media-thumbnail-preview-min-width, 120px);
       min-height: var(--media-thumbnail-preview-min-height, 80px);
       position: absolute;
-      bottom: calc(100% + 5px);
+      bottom: calc(100% + var(--media-thumbnail-preview-bottom, 10px));
       border: var(--media-thumbnail-preview-border, 2px solid #fff);
       border-radius: var(--media-thumbnail-preview-border-radius, 2px);
     }

--- a/src/js/media-time-range.js
+++ b/src/js/media-time-range.js
@@ -21,7 +21,6 @@ const updateAriaValueText = (el) => {
 };
 
 const template = document.createElement('template');
-
 template.innerHTML = `
   <style>
     #thumbnail-container {
@@ -35,6 +34,7 @@ template.innerHTML = `
     }
 
     media-thumbnail-preview {
+      background-color: #000;
       max-width: var(--media-thumbnail-preview-max-width, 180px);
       max-height: var(--media-thumbnail-preview-max-height, 160px);
       min-width: var(--media-thumbnail-preview-min-width, 120px);
@@ -55,7 +55,6 @@ template.innerHTML = `
       z-index: 3;
       position: relative;
       height: 100%;
-      cursor: pointer;
     }
 
     #time-range-hover-padding {

--- a/src/js/media-time-range.js
+++ b/src/js/media-time-range.js
@@ -23,6 +23,13 @@ const updateAriaValueText = (el) => {
 const template = document.createElement('template');
 template.innerHTML = `
   <style>
+    :host {
+      --media-preview-background-color: rgba(20,20,30, .5);
+      --media-preview-background: var(--media-control-background,
+        var(--media-preview-background-color));
+      --media-preview-border-radius: 3px;
+    }
+
     [part~="box"] {
       display: flex;
       flex-direction: column;
@@ -42,28 +49,43 @@ template.innerHTML = `
     ::slotted(media-preview-thumbnail) {
       visibility: hidden;
       transition: visibility 0s .25s;
-      background-color: #000;
+      background: var(--media-preview-time-background, var(--media-preview-background));
+      box-shadow: var(--media-preview-thumbnail-box-shadow, 0 0 2px rgba(0,0,0, .4));
       max-width: var(--media-preview-thumbnail-max-width, 180px);
       max-height: var(--media-preview-thumbnail-max-height, 160px);
       min-width: var(--media-preview-thumbnail-min-width, 120px);
       min-height: var(--media-preview-thumbnail-min-height, 80px);
-      border: var(--media-preview-thumbnail-border, 2px solid #fff);
-      border-radius: var(--media-preview-thumbnail-border-radius, 2px);
+      border: var(--media-preview-thumbnail-border);
+      border-radius: var(--media-preview-thumbnail-border-radius,
+        var(--media-preview-border-radius) var(--media-preview-border-radius) 0 0);
     }
 
     :host([${MediaUIAttributes.MEDIA_PREVIEW_IMAGE}]:hover) media-preview-thumbnail,
     :host([${MediaUIAttributes.MEDIA_PREVIEW_IMAGE}]:hover) ::slotted(media-preview-thumbnail) {
-      visibility: visible;
       transition-delay: 0s;
+      visibility: visible;
     }
 
     media-preview-time-display,
     ::slotted(media-preview-time-display) {
-      background: var(--media-preview-time-background,
-        var(--media-control-background, rgba(20,20,30, 0.7)));
-      border-radius: var(--media-preview-time-border-radius, 0);
-      padding: var(--media-preview-time-padding, 2px 10px);
-      margin: var(--media-preview-time-margin, 5px 0);
+      min-width: 0;
+      /* delay changing these CSS props until the preview box transition is ended */
+      transition: min-width 0s .25s, border-radius 0s .25s;
+      background: var(--media-preview-time-background, var(--media-preview-background));
+      border-radius: var(--media-preview-time-border-radius,
+        var(--media-preview-border-radius) var(--media-preview-border-radius)
+        var(--media-preview-border-radius) var(--media-preview-border-radius));
+      padding: var(--media-preview-time-padding, 1px 10px 0);
+      margin: var(--media-preview-time-margin, 0 0 10px);
+      text-shadow: var(--media-preview-time-text-shadow, 0 0 4px rgb(0 0 0 / 75%));
+    }
+
+    :host([${MediaUIAttributes.MEDIA_PREVIEW_IMAGE}]) media-preview-time-display,
+    :host([${MediaUIAttributes.MEDIA_PREVIEW_IMAGE}]) ::slotted(media-preview-time-display) {
+      transition-delay: 0s;
+      min-width: 100%;
+      border-radius: var(--media-preview-time-border-radius,
+        0 0 var(--media-preview-border-radius) var(--media-preview-border-radius));
     }
 
     :host([${MediaUIAttributes.MEDIA_PREVIEW_IMAGE}]:hover) [part~="preview-box"],
@@ -149,7 +171,7 @@ class MediaTimeRange extends MediaChromeRange {
     //   media.play().then(this.setMediaTimeWithRange);
     // };
 
-    this.enableThumbnails();
+    this.enableBoxes();
   }
 
   connectedCallback() {
@@ -263,7 +285,7 @@ class MediaTimeRange extends MediaChromeRange {
     style.transform = `translateX(${boxPos}px)`;
   }
 
-  enableThumbnails() {
+  enableBoxes() {
     const boxes = this.shadowRoot.querySelectorAll('[part~="box"]');
     const previewBox = this.shadowRoot.querySelector('[part~="preview-box"]');
 

--- a/src/js/media-time-range.js
+++ b/src/js/media-time-range.js
@@ -47,24 +47,6 @@ template.innerHTML = `
       background-color: #000;
     }
 
-    /*
-      This is a downward triangle. Commented out for now because it would also
-      require scaling the px properties below in JS; bottom and border-width.
-    */
-    /* media-thumbnail-preview::after {
-      content: "";
-      display: block;
-      width: 0;
-      height: 0;
-      position: absolute;
-      left: 50%;
-      transform: translateX(-50%);
-      bottom: -10px;
-      border-left: 10px solid transparent;
-      border-right: 10px solid transparent;
-      border-top: 10px solid #fff;
-    } */
-
     :host([${MediaUIAttributes.MEDIA_PREVIEW_IMAGE}]:hover) #thumbnailContainer {
       transition: visibility .5s, opacity .5s;
       visibility: visible;

--- a/src/js/media-time-range.js
+++ b/src/js/media-time-range.js
@@ -52,23 +52,26 @@ template.innerHTML = `
       opacity: 1;
     }
 
-    #time-range-container {
-      z-index: 3;
-      position: relative;
-      height: 100%;
-    }
-
-    #time-range-hover-padding {
+    #range-hover {
+      /* Add z-index so it overlaps the top of the control buttons if they are right under. */
+      z-index: 1;
       display: none;
+      box-sizing: border-box;
       position: absolute;
-      left: 0;
-      right: 0;
+      left: var(--media-range-padding-left, 10px);
+      right: var(--media-range-padding-right, 10px);
       bottom: var(--media-time-range-hover-bottom, -5px);
       height: var(--media-time-range-hover-height, max(calc(100% + 5px), 20px));
     }
 
-    #time-range-container:hover #time-range-hover-padding {
+    :host(:hover) #range-hover {
       display: block;
+    }
+
+    #range {
+      z-index: 2;
+      position: relative;
+      height: var(--media-range-track-height, 4px);
     }
   </style>
   <span part="box preview-box">
@@ -82,9 +85,8 @@ template.innerHTML = `
       <!-- <media-current-time-display></media-current-time-display> -->
     </slot>
   </span>
-  <div id="time-range-container">
-    <div id="time-range-hover-padding"></div>
-  </div>
+  <div id="range-hover"></div>
+  <div id="range-temp"></div>
 `;
 
 class MediaTimeRange extends MediaChromeRange {
@@ -104,9 +106,7 @@ class MediaTimeRange extends MediaChromeRange {
     super();
 
     this.shadowRoot.appendChild(template.content.cloneNode(true));
-
-    const container = this.shadowRoot.querySelector('#time-range-container');
-    container.append(this.range);
+    this.shadowRoot.querySelector('#range-temp').replaceWith(this.range);
 
     this.range.addEventListener('input', () => {
       const newTime = this.range.value;

--- a/src/js/media-time-range.js
+++ b/src/js/media-time-range.js
@@ -24,7 +24,7 @@ const template = document.createElement('template');
 
 template.innerHTML = `
   <style>
-    #thumbnailContainer {
+    #thumbnail-container {
       position: absolute;
       left: 0;
       top: 0;
@@ -47,13 +47,13 @@ template.innerHTML = `
       background-color: #000;
     }
 
-    :host([${MediaUIAttributes.MEDIA_PREVIEW_IMAGE}]:hover) #thumbnailContainer {
+    :host([${MediaUIAttributes.MEDIA_PREVIEW_IMAGE}]:hover) #thumbnail-container {
       transition: visibility .5s, opacity .5s;
       visibility: visible;
       opacity: 1;
     }
   </style>
-  <div id="thumbnailContainer">
+  <div id="thumbnail-container">
     <media-thumbnail-preview></media-thumbnail-preview>
   </div>
 `;
@@ -191,7 +191,7 @@ class MediaTimeRange extends MediaChromeRange {
       'media-thumbnail-preview'
     );
     const thumbnailContainer = this.shadowRoot.querySelector(
-      '#thumbnailContainer'
+      '#thumbnail-container'
     );
     thumbnailContainer.classList.add('enabled');
 

--- a/src/js/media-time-range.js
+++ b/src/js/media-time-range.js
@@ -7,6 +7,7 @@ import {
 import { MediaUIEvents, MediaUIAttributes } from './constants.js';
 import { nouns } from './labels/labels.js';
 import { formatAsTimePhrase } from './utils/time.js';
+import { getOrInsertCSSRule } from './utils/element-utils.js';
 
 const DEFAULT_MISSING_TIME_PHRASE = 'video not loaded, unknown time.';
 
@@ -363,22 +364,6 @@ class MediaTimeRange extends MediaChromeRange {
     };
     this.addEventListener('pointermove', rangepointermoveHander, false);
   }
-}
-
-/**
- * Get or insert a CSS rule with a selector in an element containing <style> tags.
- * @param  {Element} styleParent
- * @param  {string} selectorText
- * @return {CSSStyleRule|undefined}
- */
-function getOrInsertCSSRule(styleParent, selectorText) {
-  let style;
-  for (style of styleParent.querySelectorAll('style')) {
-    for (let rule of style.sheet.cssRules)
-      if (rule.selectorText === selectorText) return rule;
-  }
-  style.sheet.insertRule(`${selectorText}{}`, style.sheet.cssRules.length);
-  return style.sheet.cssRules[style.sheet.cssRules.length - 1];
 }
 
 function getBoxPosition(el, box, percent) {

--- a/src/js/media-time-range.js
+++ b/src/js/media-time-range.js
@@ -176,6 +176,11 @@ class MediaTimeRange extends MediaChromeRange {
     super.connectedCallback();
   }
 
+  disconnectedCallback() {
+    cancelAnimationFrame(this._refreshId);
+    super.disconnectedCallback();
+  }
+
   attributeChangedCallback(attrName, oldValue, newValue) {
     if (
       attrName === MediaUIAttributes.MEDIA_CURRENT_TIME ||

--- a/src/js/media-time-range.js
+++ b/src/js/media-time-range.js
@@ -31,6 +31,7 @@ template.innerHTML = `
       --media-preview-border-radius: 3px;
       --media-box-padding-left: 10px;
       --media-box-padding-right: 10px;
+      color: #fff;
     }
 
     [part~="box"] {
@@ -71,6 +72,7 @@ template.innerHTML = `
 
     media-preview-time-display,
     ::slotted(media-preview-time-display) {
+      color: unset;
       min-width: 0;
       /* delay changing these CSS props until the preview box transition is ended */
       transition: min-width 0s .25s, border-radius 0s .25s;

--- a/src/js/themes/media-theme-youtube.js
+++ b/src/js/themes/media-theme-youtube.js
@@ -132,7 +132,9 @@ const template = `
   <slot name="poster" slot="poster"></slot>
 
   <div class="ytp-gradient-bottom"></div>
-  <media-time-range></media-time-range>
+  <media-time-range>
+    <media-thumbnail-preview slot="preview"></media-thumbnail-preview>
+  </media-time-range>
   <media-control-bar>
     <media-play-button></media-play-button>
     <media-mute-button></media-mute-button>

--- a/src/js/themes/media-theme-youtube.js
+++ b/src/js/themes/media-theme-youtube.js
@@ -56,7 +56,8 @@ const template = `
   }
 
   media-time-range {
-    height: auto;
+    width: 100%;
+    height: 5px;
 
     --media-range-track-transition: height 0.1s linear;
     --media-range-track-background: rgba(255,255,255,.2);
@@ -70,10 +71,6 @@ const template = `
 
     --media-range-thumb-transition: transform 0.1s linear;
     --media-range-thumb-transform: scale(0) translate(0%, 0%);
-  }
-
-  media-time-range {
-    height: 5px;
   }
 
   media-time-range:hover {
@@ -118,15 +115,15 @@ const template = `
   }
 
   .ytp-gradient-bottom {
-    height: 61px;
     padding-top: 37px;
-    bottom: 0;
-    background-position: bottom;
-    width: 100%;
     position: absolute;
-    background-repeat: repeat-x;
-    transition: opacity .25s cubic-bezier(0,0,0.2,1);
+    width: 100%;
+    height: 170px;
+    bottom: 0;
     pointer-events: none;
+    background-position: bottom;
+    background-repeat: repeat-x;
+    background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAACqCAYAAABsziWkAAAAAXNSR0IArs4c6QAAAQVJREFUOE9lyNdHBQAAhfHb3nvvuu2997jNe29TJJEkkkgSSSSJJJJEEkkiifRH5jsP56Xz8PM5gcC/xfDEmjhKxEOCSaREEiSbFEqkQppJpzJMJiWyINvkUCIX8kw+JQqg0BRRxaaEEqVQZsopUQGVpooS1VBjglStqaNEPTSYRko0QbNpoUQrtJl2qsN0UqILuk0PJXqhz/RTYgAGzRA1bEYoMQpjZpwSExAyk5SYgmkzQ82aOUqEIWKilJiHBbNIiSVYhhVYhTVYhw3YhC3Yhh3YhT3YhwM4hCM4hhM4hTM4hwu4hCu4hhu4hTu4hwd4hCd4hhd4hTd4hw/4hC/4hh/4/QM2/id28uIEJAAAAABJRU5ErkJggg==");
   }
 </style>
 
@@ -134,10 +131,8 @@ const template = `
   <slot name="media" slot="media"></slot>
   <slot name="poster" slot="poster"></slot>
 
-  <div class="ytp-gradient-bottom" style="height: 170px; background-image: url(&quot;data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAACqCAYAAABsziWkAAAAAXNSR0IArs4c6QAAAQVJREFUOE9lyNdHBQAAhfHb3nvvuu2997jNe29TJJEkkkgSSSSJJJJEEkkiifRH5jsP56Xz8PM5gcC/xfDEmjhKxEOCSaREEiSbFEqkQppJpzJMJiWyINvkUCIX8kw+JQqg0BRRxaaEEqVQZsopUQGVpooS1VBjglStqaNEPTSYRko0QbNpoUQrtJl2qsN0UqILuk0PJXqhz/RTYgAGzRA1bEYoMQpjZpwSExAyk5SYgmkzQ82aOUqEIWKilJiHBbNIiSVYhhVYhTVYhw3YhC3Yhh3YhT3YhwM4hCM4hhM4hTM4hwu4hCu4hhu4hTu4hwd4hCd4hhd4hTd4hw/4hC/4hh/4/QM2/id28uIEJAAAAABJRU5ErkJggg==&quot;);"></div>
-  <media-control-bar>
-    <media-time-range></media-time-range>
-  </media-control-bar>
+  <div class="ytp-gradient-bottom"></div>
+  <media-time-range></media-time-range>
   <media-control-bar>
     <media-play-button></media-play-button>
     <media-mute-button></media-mute-button>

--- a/src/js/themes/media-theme-youtube.js
+++ b/src/js/themes/media-theme-youtube.js
@@ -64,6 +64,7 @@ const template = `
 
     --media-range-track-transition: height 0.1s linear;
     --media-range-track-background: rgba(255,255,255,.2);
+    --media-range-track-pointer-background: rgba(255,255,255,.5);
     --media-time-buffered-color: rgba(255,255,255,.4);
 
     --media-range-bar-color: rgb(229, 9, 20);

--- a/src/js/themes/media-theme-youtube.js
+++ b/src/js/themes/media-theme-youtube.js
@@ -1,0 +1,147 @@
+/* 
+<media-theme-youtube>
+  <video
+    slot="media"
+    src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/high.mp4"
+  ></video>
+</media-theme-youtube>
+*/
+
+import { defineCustomElement } from '../utils/defineCustomElement.js';
+import MediaTheme from './media-theme.js';
+
+const template = `
+<style>
+  :host {
+    display: inline-block;
+    --primary-color: #eee;
+    --secondary-color: transparent;
+  }
+
+  media-controller {
+    width: 100%;
+    height: 100%;
+
+    font-size: 13px;
+    font-family: Roboto, Arial, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    color: var(--primary-color);
+
+    --media-control-background: var(--secondary-color);
+    --media-control-hover-background: var(--secondary-color);
+    --media-range-track-height: 3px;
+    --media-range-thumb-height: 13px;
+    --media-range-thumb-width: 13px;
+    --media-range-thumb-border-radius: 13px;
+
+    --media-icon-color: var(--primary-color);
+  }
+
+  *:hover {
+    color: #fff;
+    --media-icon-color: #fff;
+  }
+
+  media-control-bar {
+    position: relative;
+  }
+
+  media-play-button {
+    --media-button-icon-width: 30px;
+    padding: 6px 10px;
+  }
+
+  media-time-range {
+    height: auto;
+
+    --media-range-track-transition: height 0.1s linear;
+    --media-range-track-background: #444;
+
+    --media-range-bar-color: rgb(229, 9, 20);
+    --media-progress-buffered-color: #999;
+
+    --media-range-thumb-border-radius: 13px;
+    --media-range-thumb-background: #f00;
+
+    --media-range-thumb-transition: transform 0.1s linear;
+    --media-range-thumb-transform: scale(0) translate(0%, 0%);
+  }
+
+  media-time-range:hover {
+    --media-range-track-height: 5px;
+    --media-range-thumb-transform: scale(1) translate(0%, 0%);
+  }
+
+  media-volume-range {
+    padding-left: 0px;
+
+    --media-range-track-background: #fff;
+    --media-range-bar-color: #fff;
+    --media-range-thumb-background: #fff;
+  }
+
+  .control-spacer {
+    flex-grow: 1;
+  }
+
+  media-mute-button + media-volume-range {
+    width: 0px;
+    overflow: hidden;
+    padding-right: 0px;
+
+    /* Set the internal width so it reveals, not grows */
+    --media-range-track-width: 60px;
+    transition: width 0.2s ease-in;
+  }
+
+  /* Expand volume control in all relevant states */
+  media-mute-button:hover + media-volume-range,
+  media-mute-button:focus + media-volume-range,
+  media-mute-button:focus-within + media-volume-range,
+  media-volume-range:hover,
+  media-volume-range:focus,
+  media-volume-range:focus-within {
+    width: 70px;
+  }
+
+  .ytp-gradient-bottom {
+    height: 61px;
+    padding-top: 37px;
+    bottom: 0;
+    background-position: bottom;
+    width: 100%;
+    position: absolute;
+    background-repeat: repeat-x;
+    transition: opacity .25s cubic-bezier(0,0,0.2,1);
+    pointer-events: none;
+  }
+</style>
+
+<media-controller>
+  <slot name="media" slot="media"></slot>
+  <slot name="poster" slot="poster"></slot>
+
+  <div class="ytp-gradient-bottom" style="height: 170px; background-image: url(&quot;data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAACqCAYAAABsziWkAAAAAXNSR0IArs4c6QAAAQVJREFUOE9lyNdHBQAAhfHb3nvvuu2997jNe29TJJEkkkgSSSSJJJJEEkkiifRH5jsP56Xz8PM5gcC/xfDEmjhKxEOCSaREEiSbFEqkQppJpzJMJiWyINvkUCIX8kw+JQqg0BRRxaaEEqVQZsopUQGVpooS1VBjglStqaNEPTSYRko0QbNpoUQrtJl2qsN0UqILuk0PJXqhz/RTYgAGzRA1bEYoMQpjZpwSExAyk5SYgmkzQ82aOUqEIWKilJiHBbNIiSVYhhVYhTVYhw3YhC3Yhh3YhT3YhwM4hCM4hhM4hTM4hwu4hCu4hhu4hTu4hwd4hCd4hhd4hTd4hw/4hC/4hh/4/QM2/id28uIEJAAAAABJRU5ErkJggg==&quot;);"></div>
+  <media-control-bar>
+    <media-time-range></media-time-range>
+  </media-control-bar>
+  <media-control-bar>
+    <media-play-button></media-play-button>
+    <media-mute-button></media-mute-button>
+    <media-volume-range></media-volume-range>
+    <media-time-display show-duration></media-time-display>
+    <span class="control-spacer"></span>
+    <media-playback-rate-button></media-playback-rate-button>
+    <media-pip-button></media-pip-button>
+    <media-fullscreen-button></media-fullscreen-button>
+  </media-control-bar>
+</media-controller>
+`;
+
+class MediaThemeYoutube extends MediaTheme {
+  static template = template;
+}
+
+defineCustomElement('media-theme-youtube', MediaThemeYoutube);
+
+export default MediaThemeYoutube;

--- a/src/js/themes/media-theme-youtube.js
+++ b/src/js/themes/media-theme-youtube.js
@@ -33,6 +33,9 @@ const template = `
     --media-range-thumb-height: 13px;
     --media-range-thumb-width: 13px;
     --media-range-thumb-border-radius: 13px;
+    --media-preview-thumbnail-border: 2px solid #fff;
+    --media-preview-thumbnail-border-radius: 2px;
+    --media-preview-time-margin: 10px 0;
 
     --media-icon-color: var(--primary-color);
   }

--- a/src/js/themes/media-theme-youtube.js
+++ b/src/js/themes/media-theme-youtube.js
@@ -134,6 +134,7 @@ const template = `
   <div class="ytp-gradient-bottom"></div>
   <media-time-range>
     <media-preview-thumbnail slot="preview"></media-preview-thumbnail>
+    <media-preview-time-display slot="preview"></media-preview-time-display>
   </media-time-range>
   <media-control-bar>
     <media-play-button></media-play-button>

--- a/src/js/themes/media-theme-youtube.js
+++ b/src/js/themes/media-theme-youtube.js
@@ -133,7 +133,7 @@ const template = `
 
   <div class="ytp-gradient-bottom"></div>
   <media-time-range>
-    <media-thumbnail-preview slot="preview"></media-thumbnail-preview>
+    <media-preview-thumbnail slot="preview"></media-preview-thumbnail>
   </media-time-range>
   <media-control-bar>
     <media-play-button></media-play-button>

--- a/src/js/themes/media-theme-youtube.js
+++ b/src/js/themes/media-theme-youtube.js
@@ -46,6 +46,10 @@ const template = `
     position: relative;
   }
 
+  media-control-bar:last-child {
+    padding: 0 10px 0 5px;
+  }
+
   media-play-button {
     --media-button-icon-width: 30px;
     padding: 6px 10px;
@@ -55,7 +59,8 @@ const template = `
     height: auto;
 
     --media-range-track-transition: height 0.1s linear;
-    --media-range-track-background: #444;
+    --media-range-track-background: rgba(255,255,255,.2);
+    --media-time-buffered-color: rgba(255,255,255,.4);
 
     --media-range-bar-color: rgb(229, 9, 20);
     --media-progress-buffered-color: #999;
@@ -67,6 +72,10 @@ const template = `
     --media-range-thumb-transform: scale(0) translate(0%, 0%);
   }
 
+  media-time-range {
+    height: 5px;
+  }
+
   media-time-range:hover {
     --media-range-track-height: 5px;
     --media-range-thumb-transform: scale(1) translate(0%, 0%);
@@ -75,7 +84,7 @@ const template = `
   media-volume-range {
     padding-left: 0px;
 
-    --media-range-track-background: #fff;
+    --media-range-track-background: rgba(255,255,255,.2);
     --media-range-bar-color: #fff;
     --media-range-thumb-background: #fff;
   }
@@ -102,6 +111,10 @@ const template = `
   media-volume-range:focus,
   media-volume-range:focus-within {
     width: 70px;
+  }
+
+  media-fullscreen-button {
+    --media-button-icon-transform: scale(1.3);
   }
 
   .ytp-gradient-bottom {

--- a/src/js/utils/element-utils.js
+++ b/src/js/utils/element-utils.js
@@ -20,3 +20,19 @@ export const containsComposedNode = (rootNode, childNode) => {
   if (rootNode.contains(childNode)) return true;
   return containsComposedNode(rootNode, childNode.getRootNode().host);
 };
+
+/**
+ * Get or insert a CSS rule with a selector in an element containing <style> tags.
+ * @param  {Element} styleParent
+ * @param  {string} selectorText
+ * @return {CSSStyleRule|undefined}
+ */
+export function getOrInsertCSSRule(styleParent, selectorText) {
+  let style;
+  for (style of styleParent.querySelectorAll('style')) {
+    for (let rule of style.sheet.cssRules)
+      if (rule.selectorText === selectorText) return rule;
+  }
+  style.sheet.insertRule(`${selectorText}{}`, style.sheet.cssRules.length);
+  return style.sheet.cssRules[style.sheet.cssRules.length - 1];
+}

--- a/src/js/utils/element-utils.js
+++ b/src/js/utils/element-utils.js
@@ -25,14 +25,17 @@ export const containsComposedNode = (rootNode, childNode) => {
  * Get or insert a CSS rule with a selector in an element containing <style> tags.
  * @param  {Element} styleParent
  * @param  {string} selectorText
- * @return {CSSStyleRule|undefined}
+ * @return {CSSStyleRule|{ style: { setProperty: () => {} } }}
  */
 export function getOrInsertCSSRule(styleParent, selectorText) {
   let style;
   for (style of styleParent.querySelectorAll('style')) {
-    for (let rule of style.sheet.cssRules)
+    for (let rule of style.sheet?.cssRules ?? [])
       if (rule.selectorText === selectorText) return rule;
   }
+  // If there is no style sheet return an empty style rule.
+  if (!style?.sheet) return { style: { setProperty: () => {} } };
+
   style.sheet.insertRule(`${selectorText}{}`, style.sheet.cssRules.length);
   return style.sheet.cssRules[style.sheet.cssRules.length - 1];
 }


### PR DESCRIPTION
- [x] fixes hiding bug when hovering on preview thumbnail 
- [x] fixes time range progress not center of drag thumb bug
- [x] makes the preview thumbnail not go out of the player bounds
- [x] refactor `<media-thumbnail-preview>` to be able to use `max-width`, `max-height`, `min-width`, `min-height` on it
- [x] add `<media-time-range>` **preview** and **current** boxes/slots that move on pointer hover and on playhead / current time 
	this allows users to add anything in the slots that they like to have moved with the boxes along side the time range.
- [x] adds a [`<media-theme-youtube>`](https://media-chrome-git-fork-luwes-improve-time-range-mux.vercel.app/examples/themes/youtube-theme.html)
- [x] add [`<media-preview-thumbnail>` example](https://media-chrome-git-fork-luwes-improve-time-range-mux.vercel.app/examples/control-elements/media-preview-thumbnail.html) 
- [x] add `<div>` range hover element that expands the hover area vertically to help on thin time ranges
- [x] add preview time code
- [x] add preview highlight on the time range
- [x] time range steps are too coarse (minimum is step value of 1?)

---

New media-time-range nesting options with `preview` and `current` slot:

```html
  <media-time-range>
    <media-preview-thumbnail slot="preview"></media-preview-thumbnail>
    <media-preview-time-display slot="preview"></media-preview-time-display>
    <media-current-time-display slot="current"></media-current-time-display>
  </media-time-range>
```

--- 

TODO: update docs with all the new CSS vars 