### PR TITLE
fix: box bounds element type error

### DIFF
--- a/src/js/media-time-range.js
+++ b/src/js/media-time-range.js
@@ -393,9 +393,10 @@ function getBoxPosition(el, box, percent) {
   const boxLeft = boxOffset - boxWidth / 2;
 
   // Get the element that enforces the bounding box for the hover preview.
-  const mediaBounds = el.getAttribute('media-bounds')
-    ? document.getElementById(el.getAttribute('media-bounds'))
-    : el.parentElement;
+  const mediaBounds =
+    (el.getAttribute('media-bounds')
+      ? document.getElementById(el.getAttribute('media-bounds'))
+      : el.parentElement) ?? el;
 
   const mediaBoundsRect = mediaBounds.getBoundingClientRect();
   const offsetLeft = rect.left - mediaBoundsRect.left;


### PR DESCRIPTION
this fixes an issue where the bounding element for the timerange boxes would be undefined and cause a type error.

only happened for the audio only player.
https://elements-demo-vanilla-l94eg46e7-mux.vercel.app/mux-player-audio.html

![SCR-20220714-qou](https://user-images.githubusercontent.com/360826/179121605-31a444e4-0030-4bc9-a5cb-08a57c94d08f.png)

