### PR TITLE
POC of handling media errors in media chrome

### DIFF
--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -159,14 +159,31 @@ class MediaController extends MediaContainer {
       MEDIA_ENTER_PIP_REQUEST: () => {
         const media = this.media;
 
-        if (!document.pictureInPictureEnabled) return;
+        if (!document.pictureInPictureEnabled) {
+          alert('Picture-in-picture is not supported.');
+        };
+
+        if (!media.requestPictureInPicture) {
+          alert('This media does not support picture-in-picture.');
+        }
+
+        if (typeof media.readyState === 'number' && media.readyState == 0 ) {
+          alert('The video is not ready yet.');
+        }
 
         // Exit fullscreen if needed
         if (document[fullscreenApi.element]) {
           document[fullscreenApi.exit]();
         }
 
-        media.requestPictureInPicture();
+        media.requestPictureInPicture().catch(err => {
+          if (err.code === 11) {
+            // InvalidStateError
+            alert('The video is not ready yet.');
+          } else {
+            throw err;
+          }
+        });
       },
       MEDIA_EXIT_PIP_REQUEST: () => {
         if (document.pictureInPictureElement) {

--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -187,7 +187,7 @@ class MediaController extends MediaContainer {
             // if we can rely on readyState and preload
             // Only works in Chrome currently. Safari doesn't allow triggering
             // in an event listener. Also requires readyState == 4.
-            // Firefox doesn't do PiP yet.
+            // Firefox doesn't have the PiP API yet.
             if (media.readyState === 0 && media.preload === 'none') {
               function cleanup() {
                 media.removeEventListener('loadedmetadata', tryPip);

--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -191,6 +191,7 @@ class MediaController extends MediaContainer {
             if (media.readyState === 0 && media.preload === 'none') {
               function cleanup() {
                 media.removeEventListener('loadedmetadata', tryPip);
+                media.preload = 'none';
               }
 
               function tryPip() {
@@ -202,7 +203,7 @@ class MediaController extends MediaContainer {
               media.preload = 'metadata';
 
               // No easy way to know if this failed and we should clean up
-              // quickly if it doesn't to prevent other issues
+              // quickly if it doesn't to prevent an awkward delay for the user
               setTimeout(()=>{
                 if (media.readyState === 0) warnNotReady();
                 cleanup();

--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -160,15 +160,15 @@ class MediaController extends MediaContainer {
         const media = this.media;
 
         if (!document.pictureInPictureEnabled) {
-          alert('Picture-in-picture is not supported.');
+          console.warn('MediaChrome: Picture-in-picture is not enabled');
+          // Placeholder for emitting a user-facing warning
+          return;
         };
 
         if (!media.requestPictureInPicture) {
-          alert('This media does not support picture-in-picture.');
-        }
-
-        if (typeof media.readyState === 'number' && media.readyState == 0 ) {
-          alert('The video is not ready yet.');
+          console.warn('MediaChrome: The current media does not support picture-in-picture');
+          // Placeholder for emitting a user-facing warning
+          return;
         }
 
         // Exit fullscreen if needed
@@ -176,11 +176,43 @@ class MediaController extends MediaContainer {
           document[fullscreenApi.exit]();
         }
 
+        const warnNotReady = (err) => {
+          console.warn('MediaChrome: The media is not ready for picture-in-picture. It must have a readyState > 0.');
+        };
+
         media.requestPictureInPicture().catch(err => {
+          // InvalidStateError, readyState == 0 (Not ready)
           if (err.code === 11) {
-            // InvalidStateError
-            alert('The video is not ready yet.');
+            // We can assume the viewer wants the video to load, so attempt to
+            // if we can rely on readyState and preload
+            // Only works in Chrome currently. Safari doesn't allow triggering
+            // in an event listener. Also requires readyState == 4.
+            // Firefox doesn't do PiP yet.
+            if (media.readyState === 0 && media.preload === 'none') {
+              function cleanup() {
+                media.removeEventListener('loadedmetadata', tryPip);
+              }
+
+              function tryPip() {
+                media.requestPictureInPicture().catch(warnNotReady);
+                cleanup();
+              }
+
+              media.addEventListener('loadedmetadata', tryPip);
+              media.preload = 'metadata';
+
+              // No easy way to know if this failed and we should clean up
+              // quickly if it doesn't to prevent other issues
+              setTimeout(()=>{
+                if (media.readyState === 0) warnNotReady();
+                cleanup();
+              }, 1000);
+            } else {
+              // Rethrow if unknown context
+              throw err;
+            }
           } else {
+            // Rethrow if unknown context
             throw err;
           }
         });


### PR DESCRIPTION
The first pass is how I'd expect to handle PiP-not-ready errors.

Assume where `alert()`s happen, it means:
1. log to the console for the media chrome developer
3. propagate a [currently undefined] error state that an error display component could use to inform the viewer what's happening

There's a few decisions baked in:
1. Don't assume the media has the needed APIs to avoid the error (readyState in this case)
2. When it does have the API, use it, and make viewer-friendly error messaging possible
4. If the error can't be avoided (e.g. readyState isn't supported), handle known errors triggered by the viewer (InvalidStateError in this case) and make viewer friendly error messaging possible. 
5. Don't silence unknown errors from the media element

Thoughts on all that?