### PR TITLE
fix: prevent hotkeys from scrolling page

### DIFF
--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -751,6 +751,18 @@ class MediaController extends MediaContainer {
       this.removeEventListener('keyup', this.#keyUpHandler);
       return;
     }
+
+    // if the pressed key might move the page, we need to preventDefault on keydown
+    // because doing so on keyup is too late
+    // We also want to make sure that the hotkey hasn't been turned off before doing so
+    if (
+      [' ', 'ArrowLeft', 'ArrowRight'].includes(key) &&
+      !(this.#hotKeys.contains(`no${key.toLowerCase()}`) ||
+        key === ' ' && this.#hotKeys.contains('nospace'))
+    ) {
+      e.preventDefault();
+    }
+
     this.addEventListener('keyup', this.#keyUpHandler);
   }
 


### PR DESCRIPTION
If a key will scroll the page, such as Space, ArrowLeft, and ArrowRight, we want to prevent the default action so the page won't scroll.

Browsers scroll on keydown rather than keyup, so, we have to do the preventDefault separately from where we do the action. This has the side-effect that should someone choose to cancel an action -- for example, holding down space and then hitting escape to prevent playback toggling from happening -- then the default behavior, in the example, scrolling down a page, will still be prevented.

Fixes #295