### PR TITLE
feat: fix order of layers + add chrome CSS parts

### DIFF
--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -360,7 +360,7 @@ class MediaContainer extends window.HTMLElement {
       // so, only run pointermove for mouse
       if (e.pointerType !== 'mouse') return;
 
-      if (!containsComposedNode(this, e.target)) return;
+      if (e.target === this) return;
 
       setActive();
       // Stay visible if hovered over control bar

--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -69,6 +69,8 @@ template.innerHTML = `
     }
 
     :host(:not([audio])) *[part~=layer][part~=centered-layer] {
+      display: flex;
+      flex-grow: 1;
       align-items: center;
       justify-content: center;
     }
@@ -79,7 +81,9 @@ template.innerHTML = `
       flex-grow: 1;
     }
 
-    .spacer {
+    slot[name=middle-chrome] {
+      display: inline;
+      flex-grow: 1;
       pointer-events: none;
       background: none;
     }
@@ -132,13 +136,11 @@ template.innerHTML = `
     </slot>
   </span>
   <span part="layer vertical-layer">
-    <slot name="top-chrome"></slot>
-    <span class="spacer"><slot name="middle-chrome"></slot></span>
-    <span part="layer centered-layer">
-      <slot name="centered-chrome"></slot>
-    </span>
+    <slot name="top-chrome" part="top chrome"></slot>
+    <slot name="middle-chrome" part="middle chrome"></slot>
+    <slot name="centered-chrome" part="layer centered-layer center centered chrome"></slot>
     <!-- default, effectively "bottom-chrome" -->
-    <slot></slot>
+    <slot part="bottom chrome"></slot>
   </span>
 `;
 

--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -124,17 +124,11 @@ template.innerHTML = `
     }
   </style>
 
-  <span part="layer media-layer">
-    <slot name="media"></slot>
-  </span>
-  <span part="layer poster-layer">
-    <slot name="poster"></slot>
-  </span>
-  <span part="layer gesture-layer">
-    <slot name="gestures-chrome">
-      <media-gesture-receiver slot="gestures-chrome"></media-gesture-receiver>
-    </slot>
-  </span>
+  <slot name="media" part="layer media-layer"></slot>
+  <slot name="poster" part="layer poster-layer"></slot>
+  <slot name="gestures-chrome" part="layer gesture-layer">
+    <media-gesture-receiver slot="gestures-chrome"></media-gesture-receiver>
+  </slot>
   <span part="layer vertical-layer">
     <slot name="top-chrome" part="top chrome"></slot>
     <slot name="middle-chrome" part="middle chrome"></slot>

--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -134,11 +134,11 @@ template.innerHTML = `
   <span part="layer vertical-layer">
     <slot name="top-chrome"></slot>
     <span class="spacer"><slot name="middle-chrome"></slot></span>
+    <span part="layer centered-layer">
+      <slot name="centered-chrome"></slot>
+    </span>
     <!-- default, effectively "bottom-chrome" -->
     <slot></slot>
-  </span>
-  <span part="layer centered-layer">
-    <slot name="centered-chrome"></slot>
   </span>
 `;
 

--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -69,8 +69,6 @@ template.innerHTML = `
     }
 
     :host(:not([audio])) *[part~=layer][part~=centered-layer] {
-      display: flex;
-      flex-grow: 1;
       align-items: center;
       justify-content: center;
     }


### PR DESCRIPTION
This change adds the correct order of the chrome containers so a11y tab order improves going from the top chrome elements to the center chrome elements and then to the bottom chrome elements.

Before it went from top -> bottom -> center 

This change makes use of disabling the CSS `display: contents` property on some `<slot>` elements essentially making them visible containers.

In addition some CSS parts were added for the different chrome sections which we'll be able to use in Mux Player.