### PR TITLE
fix: keyup handlers for some keyboard behavior should only apply once

### DIFF
--- a/src/js/media-chrome-button.js
+++ b/src/js/media-chrome-button.js
@@ -113,7 +113,7 @@ class MediaChromeButton extends window.HTMLElement {
         this.removeEventListener('keyup', keyUpHandler);
         return;
       }
-      this.addEventListener('keyup', keyUpHandler);
+      this.addEventListener('keyup', keyUpHandler, {once: true});
     });
   }
 

--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -763,7 +763,7 @@ class MediaController extends MediaContainer {
       e.preventDefault();
     }
 
-    this.addEventListener('keyup', this.#keyUpHandler);
+    this.addEventListener('keyup', this.#keyUpHandler, {once: true});
   }
 
   enableHotkeys() {


### PR DESCRIPTION
For keyboard shortcuts and media-chrome-button, we add a keyup handler on keydown to make it more reliable to recognize and disambiguate between keys used standalone (`k`) or with modifiers (`ctrl-k`). In addition, this gives us the ability to have cancellable behavior, by allowing users to press `esc` to prevent the action from happening since the `keyup` handler is removing on a `keydown` of a disallowed key like `esc`.

However, what happens if you keep an allowed key pressed, but then press a second allowed key? Currently, the behavior of the second key will trigger and the behavior of the first key will trigger depending on how quickly it is released. So, if a user pressed `k` to toggle playback but kept holding it down and then pressed `f`, the media-chrome will toggle fullscreen. If the user immediately followed by unpressing `k`, nothing else would happen. However, if the user kept `k` held down for another second, and then let go, then playback would toggle as well, since the `keyup` handler is still bound.

Instead, we want to only have these `keyup` handlers trigger once. Either, by the next key that is unpressed or if it is removed by the `keydown` handler when a disallowed key is pressed.