### PR TITLE
fix: `gestures-disabled` attribute

### DIFF
--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -57,7 +57,7 @@ template.innerHTML = `
      */
     :host(:not([audio])[gestures-disabled]) ::slotted([slot=gestures-chrome]),
     :host(:not([audio])[gestures-disabled]) media-gesture-receiver[slot=gestures-chrome] {
-      pointer-events: none;
+      display: none;
     }
 
     /*


### PR DESCRIPTION
related #301

setting any element to `display: none` in the gesture-layer will disable gestures on that element.