### PR TITLE
fix: gesture captured on controls bug

### DIFF
--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -14,7 +14,6 @@ import {
 } from './utils/server-safe-globals.js';
 import { MediaUIEvents, MediaUIAttributes, MediaStateChangeEvents } from './constants.js';
 import { nouns } from './labels/labels.js';
-import { containsComposedNode } from './utils/element-utils.js';
 // Guarantee that `<media-gesture-receiver/>` is available for use in the template
 import './media-gesture-receiver.js';
 

--- a/src/js/utils/element-utils.js
+++ b/src/js/utils/element-utils.js
@@ -21,6 +21,13 @@ export const containsComposedNode = (rootNode, childNode) => {
   return containsComposedNode(rootNode, childNode.getRootNode().host);
 };
 
+export const closestComposedNode = (childNode, selector) => {
+  if (!childNode) return null;
+  const closest = childNode.closest(selector);
+  if (closest) return closest;
+  return closestComposedNode(childNode.getRootNode().host, selector);
+};
+
 /**
  * Get or insert a CSS rule with a selector in an element containing <style> tags.
  * @param  {Element} styleParent


### PR DESCRIPTION
this change fixes a bug where the gestures were picked up on the controls itself.

I also took the time to instead of listening on the window listen on the media controller because it feels a bit safer / local.

currently the allowList is not extensive and could potentially be extended. 
I thought of a "video element" that wouldn't use a native "video" element under the hood.

maybe better to check if the element is just in the media slot? 

