### PR TITLE
feat: add a hotkey for toggling captions: c

### DIFF
--- a/docs/src/pages/en/keyboard-shortcuts.md
+++ b/docs/src/pages/en/keyboard-shortcuts.md
@@ -8,14 +8,15 @@ layout: ../../layouts/MainLayout.astro
 
 By default, Media Controller has keyboard shortcuts that will trigger behavior when specific keys are pressed when the focus is inside the Media Controller.
 The following controls are supported:
-| Key | Behavior |
-|---------|-------------------|
-| Space | Toggle Playback |
-| `k` | Toggle Playback |
-| `m` | Toggle mute |
-| `f` | Toggle fullscreen |
-| ⬅️ | Seek back 10s |
-| ➡️ | Seek forward 10s |
+| Key     | Name to turn off | Behavior |
+|---------|------------------|----------|
+| `Space` | `nospace`        | Toggle Playback |
+| `k`     | `nok`            | Toggle Playback |
+| `m`     | `nom`            | Toggle mute |
+| `f`     | `nof`            | Toggle fullscreen |
+| `c`     | `noc`            | Toggle captions or subtitles, if available |
+| ⬅️       | `noarrowleft`    | Seek back 10s |
+| ➡️       | `noarrowright`   | Seek forward 10s |
 
 If you are implementing an interactive element that uses any of these keys, you can stopPropagation in your `keyup` handler. Alternatively, you can add a `keysUsed` property on the element or a `keysused` attribute. The values are those that match the `key` property on the KeyboardEvent. You can find a list of those values [on mdn](https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values). Additionally, since the DOM list can't have the Space key represented as `" "`, we will accept `Space` as an alternative name for it.
 Example (`keysused` attribute):

--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -17,7 +17,7 @@ import { AttributeTokenList } from './utils/attribute-token-list.js';
 import { fullscreenApi } from './utils/fullscreenApi.js';
 import { constToCamel } from './utils/stringUtils.js';
 import { containsComposedNode } from './utils/element-utils.js';
-import MediaCaptionsButton from './media-captions-button.js';
+import { toggleSubsCaps } from './utils/captions.js';
 
 import {
   MediaUIEvents,
@@ -884,7 +884,7 @@ class MediaController extends MediaContainer {
         break;
 
       case 'c':
-        MediaCaptionsButton.prototype.handleClick.call(this, e);
+        toggleSubsCaps(this);
         break;
 
       case 'ArrowLeft':

--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -17,6 +17,7 @@ import { AttributeTokenList } from './utils/attribute-token-list.js';
 import { fullscreenApi } from './utils/fullscreenApi.js';
 import { constToCamel } from './utils/stringUtils.js';
 import { containsComposedNode } from './utils/element-utils.js';
+import MediaCaptionsButton from './media-captions-button.js';
 
 import {
   MediaUIEvents,
@@ -32,7 +33,7 @@ import {
   updateTracksModeTo,
 } from './utils/captions.js';
 
-const ButtonPressedKeys = ['Enter', ' ', 'f', 'm', 'k', 'ArrowLeft', 'ArrowRight'];
+const ButtonPressedKeys = ['ArrowLeft', 'ArrowRight', 'Enter', ' ', 'f', 'm', 'k', 'c'];
 const DEFAULT_SEEK_OFFSET = 10;
 
 /**
@@ -376,7 +377,7 @@ class MediaController extends MediaContainer {
         // Since these propagators are all called when boostrapping state, let's verify this is
         // a real playing event by checking that 1) there's media and 2) it isn't currently paused.
         this.propagateMediaState(MediaUIAttributes.MEDIA_HAS_PLAYED, !this.media?.paused);
-      }, 
+      },
       volumechange: () => {
         this.propagateMediaState(MediaUIAttributes.MEDIA_MUTED, getMuted(this));
         this.propagateMediaState(MediaUIAttributes.MEDIA_VOLUME, getVolume(this));
@@ -880,6 +881,10 @@ class MediaController extends MediaContainer {
         this.dispatchEvent(
           new window.CustomEvent(eventName, { composed: true, bubbles: true })
         );
+        break;
+
+      case 'c':
+        MediaCaptionsButton.prototype.handleClick.call(this, e);
         break;
 
       case 'ArrowLeft':

--- a/src/js/utils/captions.js
+++ b/src/js/utils/captions.js
@@ -1,3 +1,5 @@
+import { MediaUIEvents, MediaUIAttributes } from '../constants.js';
+
 // NOTE: This is generic for any CSS/html list representation. Consider renaming and moving to generic module.
 /**
  * Splits a string (representing TextTracks) into an array of strings based on whitespace.
@@ -223,4 +225,91 @@ export const getTextTracksList = (media, filterPredOrObj = () => true) => {
       : textTrackObjAsPred(filterPredOrObj);
 
   return Array.from(media.textTracks).filter(filterPred);
+};
+
+
+/**
+ * Are captions enabled?
+ *
+ * @param {HTMLElement} el - An HTMLElement that has caption related attributes on it.
+ * @returns {boolean} Whether captions are enabled or not
+ */
+export const isCCOn = (el) => {
+  const showingCaptions = !!el.getAttribute(
+    MediaUIAttributes.MEDIA_CAPTIONS_SHOWING
+  );
+  const showingSubtitlesAsCaptions =
+    !el.hasAttribute('no-subtitles-fallback') &&
+    !!el.getAttribute(MediaUIAttributes.MEDIA_SUBTITLES_SHOWING);
+  return showingCaptions || showingSubtitlesAsCaptions;
+};
+
+/**
+ * Trigger the appropriate event on the provided element that will toggle either captions or subtitles as appropriate.
+ *
+ * This was originally in media-captions-button.
+ *
+ * @param {HTMLElement} el - An HTMLElement that has caption related attributes on it.
+ */
+export const toggleSubsCaps = (el) => {
+  const ccIsOn = isCCOn(el);
+  if (ccIsOn) {
+    // Closed Captions is on. Clicking should disable any currently showing captions (and subtitles, if relevant)
+    // For why we are requesting tracks to `mode="disabled"` and not `mode="hidden"`, see: https://github.com/muxinc/media-chrome/issues/60
+    const captionsShowingStr = el.getAttribute(
+      MediaUIAttributes.MEDIA_CAPTIONS_SHOWING
+    );
+    // If we have currently showing captions track(s), request for them to be disabled.
+    if (captionsShowingStr) {
+      const evt = new window.CustomEvent(
+        MediaUIEvents.MEDIA_DISABLE_CAPTIONS_REQUEST,
+        { composed: true, bubbles: true, detail: captionsShowingStr }
+      );
+      el.dispatchEvent(evt);
+    }
+    const subtitlesShowingStr = el.getAttribute(
+      MediaUIAttributes.MEDIA_SUBTITLES_SHOWING
+    );
+    // If we have currently showing subtitles track(s) and we're using subtitle fallback (true/"on" by default), request for them to be disabled.
+    if (subtitlesShowingStr && !el.hasAttribute('no-subtitles-fallback')) {
+      const evt = new window.CustomEvent(
+        MediaUIEvents.MEDIA_DISABLE_SUBTITLES_REQUEST,
+        { composed: true, bubbles: true, detail: subtitlesShowingStr }
+      );
+      el.dispatchEvent(evt);
+    }
+  } else {
+    // Closed Captions is off. Clicking should show the first relevant captions track or subtitles track if we're using subtitle fallback (true/"on" by default)
+    const [ccTrackStr] =
+      splitTextTracksStr(
+        el.getAttribute(MediaUIAttributes.MEDIA_CAPTIONS_LIST) ?? ''
+      ) ?? [];
+    if (ccTrackStr) {
+      // If we have at least one captions track, request for the first one to be showing.
+      const evt = new window.CustomEvent(
+        MediaUIEvents.MEDIA_SHOW_CAPTIONS_REQUEST,
+        { composed: true, bubbles: true, detail: ccTrackStr }
+      );
+      el.dispatchEvent(evt);
+    } else if (!el.hasAttribute('no-subtitles-fallback')) {
+      // If we don't have a captions track and we're using subtitles fallback (true/"on" by default), check if we have any subtitles available.
+      const [subTrackStr] =
+        splitTextTracksStr(
+          el.getAttribute(MediaUIAttributes.MEDIA_SUBTITLES_LIST) ?? ''
+        ) ?? [];
+      if (subTrackStr) {
+        // If we have at least one subtitles track (and didn't have any captions tracks), request for the first one to be showing as a fallback for captions.
+        const evt = new window.CustomEvent(
+          MediaUIEvents.MEDIA_SHOW_SUBTITLES_REQUEST,
+          { composed: true, bubbles: true, detail: subTrackStr }
+        );
+        el.dispatchEvent(evt);
+      }
+    } else {
+      // If we end up here, it means we have an enabled CC-button that a user has clicked on but there are no captions and no subtitles (or we've disabled subtitles fallback).
+      console.error(
+        'Attempting to enable closed captions but none are available! Please verify your media content if this is unexpected.'
+      );
+    }
+  }
 };


### PR DESCRIPTION
Adds a `c` hotkey to toggle captions.

This uses method delegation to the `MediaCaptionsButton`'s `handleClick` method because there's a lot of code there.

~Needs a quick addition to docs still, but also, due to the recent media-gestures-receiver change, the player doesn't get focus when click on the video element and thus keyboard shortcuts don't work there. Though, might want a fix for that separately from this.~