### PR TITLE
fix: set tabindex on media element, if not set

### DIFF
--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -21,6 +21,16 @@ const template = document.createElement('template');
 
 template.innerHTML = `
   <style>
+
+    /*
+     * outline on media is turned off because it is allowed to get focus to faciliate hotkeys.
+     * However, on keyboard interactions, the focus outline is shown,
+     * which is particularly noticeable when going fullscreen via hotkeys.
+     */
+    :host([media-is-fullscreen])  ::slotted([slot=media]) {
+      outline: none;
+    }
+
     :host {
       box-sizing: border-box;
       position: relative;

--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -556,6 +556,11 @@ class MediaController extends MediaContainer {
 
   mediaSetCallback(media) {
     super.mediaSetCallback(media);
+
+    if (!media.hasAttribute('tabindex')) {
+      media.setAttribute('tabindex', -1);
+    }
+
     // Listen for media state changes and propagate them to children and associated els
     Object.keys(this._mediaStatePropagators).forEach((key) => {
       const events = key.split(',');


### PR DESCRIPTION
This is so that clicking inside the player gets focus changed to be inside the player and hotkeys work as expected. If a tabindex is already set, we shouldn't override it. Otherwise, we should set it to be -1 so that clicking would change focus but it wouldn't be added to the regular tab order.

Since the primary usecase of this is for hotkeys, there will be keyboard interactions with the player after the focus change. However, this does mean that an outline will be added to the media element. This probably isn't an issue when windowed, but in fullscreen, we definitely don't want an outline border on the media.

Fixes #309