### PR TITLE
feat: remove minify/srcmap esm/cjs, add esm-module

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,15 +15,16 @@
     "lint": "eslint src/js",
     "build:esm": "esbuild src/js/*.js src/js/*/*.js --target=es2019 --format=esm --outdir=dist",
     "build:esm-module": "esbuild src/js/index.js --target=es2019 --format=esm --bundle --minify --sourcemap --outfile=dist/media-chrome.mjs",
+    "postbuild:esm-module": "yarn size",
     "build:cjs": "esbuild src/js/*.js src/js/*/*.js --target=es2019 --format=cjs --outdir=dist/cjs",
     "build:iife": "esbuild src/js/index.js --bundle --target=es2019 --format=iife --outdir=dist/iife --minify --sourcemap --global-name=MediaChrome",
     "build:react": "node ./scripts/react/build.js",
-    "build": "yarn build:esm && yarn build:cjs && yarn build:iife && yarn build:react && yarn build:esm-module && yarn size",
+    "build": "yarn build:esm && yarn build:cjs && yarn build:iife && yarn build:react && yarn build:esm-module",
     "dev": "node ./scripts/esbuild.js",
     "start": "yarn dev",
     "test": "web-test-runner --coverage --config test/web-test-runner.config.js",
     "publish-release": "./scripts/publish.sh",
-    "size": "echo \"\\n  dist/\\033[1mmedia-chrome.mjs\\033[0m     \\033[0;32m$(($(cat dist/media-chrome.mjs | gzip -c9 | wc -c)/1000))kb gzip\\033[0m\\n\""
+    "size": "echo \"\\n  dist/\\033[1mmedia-chrome.mjs\\033[0m     \\033[0;32m$(($(cat dist/media-chrome.mjs | gzip -c9 | wc -c)))B gzip\\033[0m\\n\""
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -13,15 +13,17 @@
     "format": "prettier --write .",
     "clean": "rimraf dist",
     "lint": "eslint src/js",
-    "build:esm": "esbuild src/js/*.js src/js/*/*.js --target=es2019 --format=esm --outdir=dist --minify --sourcemap",
-    "build:cjs": "esbuild src/js/*.js src/js/*/*.js --target=es2019 --format=cjs --outdir=dist/cjs --minify --sourcemap",
+    "build:esm": "esbuild src/js/*.js src/js/*/*.js --target=es2019 --format=esm --outdir=dist",
+    "build:esm-module": "esbuild src/js/index.js --target=es2019 --format=esm --bundle --minify --sourcemap --outfile=dist/media-chrome.mjs",
+    "build:cjs": "esbuild src/js/*.js src/js/*/*.js --target=es2019 --format=cjs --outdir=dist/cjs",
     "build:iife": "esbuild src/js/index.js --bundle --target=es2019 --format=iife --outdir=dist/iife --minify --sourcemap --global-name=MediaChrome",
     "build:react": "node ./scripts/react/build.js",
-    "build": "yarn build:esm && yarn build:cjs && yarn build:iife && yarn build:react",
+    "build": "yarn build:esm && yarn build:cjs && yarn build:iife && yarn build:react && yarn build:esm-module && yarn size",
     "dev": "node ./scripts/esbuild.js",
     "start": "yarn dev",
     "test": "web-test-runner --coverage --config test/web-test-runner.config.js",
-    "publish-release": "./scripts/publish.sh"
+    "publish-release": "./scripts/publish.sh",
+    "size": "echo \"\\n  dist/\\033[1mmedia-chrome.mjs\\033[0m     \\033[0;32m$(($(cat dist/media-chrome.mjs | gzip -c9 | wc -c)/1000))kb gzip\\033[0m\\n\""
   },
   "repository": {
     "type": "git",

--- a/src/js/media-airplay-button.js
+++ b/src/js/media-airplay-button.js
@@ -14,9 +14,6 @@ const airplayIcon = `<svg aria-hidden="true" viewBox="0 0 26 24">
 
 const slotTemplate = document.createElement('template');
 slotTemplate.innerHTML = `
-  <style>
-  </style>
-
   <slot name="airplay">${airplayIcon}</slot>
 `;
 

--- a/src/js/media-captions-button.js
+++ b/src/js/media-captions-button.js
@@ -1,12 +1,9 @@
 import MediaChromeButton from './media-chrome-button.js';
 import { defineCustomElement } from './utils/defineCustomElement.js';
-import {
-  Window as window,
-  Document as document,
-} from './utils/server-safe-globals.js';
-import { MediaUIEvents, MediaUIAttributes } from './constants.js';
+import { Document as document } from './utils/server-safe-globals.js';
+import { MediaUIAttributes } from './constants.js';
 import { nouns } from './labels/labels.js';
-import { splitTextTracksStr, isCCOn, toggleSubsCaps } from './utils/captions.js';
+import { isCCOn, toggleSubsCaps } from './utils/captions.js';
 
 const ccIconOn = `<svg aria-hidden="true" viewBox="0 0 26 24">
   <path d="M22.83 5.68a2.58 2.58 0 0 0-2.3-2.5c-3.62-.24-11.44-.24-15.06 0a2.58 2.58 0 0 0-2.3 2.5c-.23 4.21-.23 8.43 0 12.64a2.58 2.58 0 0 0 2.3 2.5c3.62.24 11.44.24 15.06 0a2.58 2.58 0 0 0 2.3-2.5c.23-4.21.23-8.43 0-12.64Zm-11.39 9.45a3.07 3.07 0 0 1-1.91.57 3.06 3.06 0 0 1-2.34-1 3.75 3.75 0 0 1-.92-2.67 3.92 3.92 0 0 1 .92-2.77 3.18 3.18 0 0 1 2.43-1 2.94 2.94 0 0 1 2.13.78c.364.359.62.813.74 1.31l-1.43.35a1.49 1.49 0 0 0-1.51-1.17 1.61 1.61 0 0 0-1.29.58 2.79 2.79 0 0 0-.5 1.89 3 3 0 0 0 .49 1.93 1.61 1.61 0 0 0 1.27.58 1.48 1.48 0 0 0 1-.37 2.1 2.1 0 0 0 .59-1.14l1.4.44a3.23 3.23 0 0 1-1.07 1.69Zm7.22 0a3.07 3.07 0 0 1-1.91.57 3.06 3.06 0 0 1-2.34-1 3.75 3.75 0 0 1-.92-2.67 3.88 3.88 0 0 1 .93-2.77 3.14 3.14 0 0 1 2.42-1 3 3 0 0 1 2.16.82 2.8 2.8 0 0 1 .73 1.31l-1.43.35a1.49 1.49 0 0 0-1.51-1.21 1.61 1.61 0 0 0-1.29.58A2.79 2.79 0 0 0 15 12a3 3 0 0 0 .49 1.93 1.61 1.61 0 0 0 1.27.58 1.44 1.44 0 0 0 1-.37 2.1 2.1 0 0 0 .6-1.15l1.4.44a3.17 3.17 0 0 1-1.1 1.7Z"/>
@@ -19,12 +16,12 @@ const ccIconOff = `<svg aria-hidden="true" viewBox="0 0 26 24">
 const slotTemplate = document.createElement('template');
 slotTemplate.innerHTML = `
   <style>
-  :host([aria-checked="true"]) slot:not([name=on]) > *, 
+  :host([aria-checked="true"]) slot:not([name=on]) > *,
   :host([aria-checked="true"]) ::slotted(:not([slot=on])) {
     display: none !important;
   }
 
-  /* Double negative, but safer if display doesn't equal 'block' */
+  ${/* Double negative, but safer if display doesn't equal 'block' */ ''}
   :host(:not([aria-checked="true"])) slot:not([name=off]) > *, 
   :host(:not([aria-checked="true"])) ::slotted(:not([slot=off])) {
     display: none !important;

--- a/src/js/media-cast-button.js
+++ b/src/js/media-cast-button.js
@@ -19,7 +19,7 @@ slotTemplate.innerHTML = `
     display: none !important;
   }
 
-  /* Double negative, but safer if display doesn't equal 'block' */
+  ${/* Double negative, but safer if display doesn't equal 'block' */ ''}
   :host(:not([${MediaUIAttributes.MEDIA_IS_CASTING}])) slot:not([name=enter]) > *,
   :host(:not([${MediaUIAttributes.MEDIA_IS_CASTING}])) ::slotted(:not([slot=enter])) {
     display: none !important;

--- a/src/js/media-chrome-button.js
+++ b/src/js/media-chrome-button.js
@@ -19,7 +19,7 @@ template.innerHTML = `
 
     padding: var(--media-control-padding, 10px);
 
-    /* Vertically center any text */
+    ${/* Vertically center any text */''}
     font-size: 14px;
     line-height: var(--media-text-content-height, var(--media-control-height, 24px));
     font-weight: bold;
@@ -32,17 +32,17 @@ template.innerHTML = `
     font-family: Arial, sans-serif;
   }
 
-  /*
+  ${/*
     Only show outline when keyboard focusing.
     https://drafts.csswg.org/selectors-4/#the-focus-visible-pseudo
-  */
+  */''}
   :host(:focus-visible) {
     box-shadow: inset 0 0 0 2px rgba(27, 127, 204, 0.9);
     outline: 0;
   }
-  /*
+  ${/*
    * hide default focus ring, particularly when using mouse
-   */
+   */''}
   :host(:where(:focus)) {
     box-shadow: none;
     outline: 0;

--- a/src/js/media-chrome-range.js
+++ b/src/js/media-chrome-range.js
@@ -57,7 +57,7 @@ template.innerHTML = `
       padding-left: var(--media-range-padding-left, var(--_media-range-padding));
       padding-right: var(--media-range-padding-right, var(--_media-range-padding));
       pointer-events: auto;
-      /* needed for vertical align issue 1px off */
+      ${/* needed for vertical align issue 1px off */''}
       font-size: 0;
     }
 
@@ -66,28 +66,28 @@ template.innerHTML = `
     }
 
     input[type=range] {
-      /* Reset */
-      -webkit-appearance: none; /* Hides the slider so that custom slider can be made */
-      background: transparent; /* Otherwise white in Chrome */
+      ${/* Reset */''}
+      -webkit-appearance: none; ${/* Hides the slider so that custom slider can be made */''}
+      background: transparent; ${/* Otherwise white in Chrome */''}
 
-      /* Fill host with the range */
+      ${/* Fill host with the range */''}
       min-height: 100%;
-      width: var(--media-range-track-width, 100%); /* Specific width is required for Firefox. */
+      width: var(--media-range-track-width, 100%); ${/* Specific width is required for Firefox. */''}
 
       box-sizing: border-box;
       padding: 0;
       margin: 0;
     }
 
-    /* Special styling for WebKit/Blink */
+    ${/* Special styling for WebKit/Blink */''}
     input[type=range]::-webkit-slider-thumb {
       -webkit-appearance: none;
       ${thumbStyles}
-      /* You need to specify a margin in Chrome, but in Firefox and IE it is automatic */
+      ${/* You need to specify a margin in Chrome, but in Firefox and IE it is automatic */''}
       margin-top: calc(calc(0px - var(--thumb-height) + var(--track-height)) / 2);
     }
 
-    /* The thumb is not positioned relative to the track in Firefox */
+    ${/* The thumb is not positioned relative to the track in Firefox */''}
     input[type=range]::-moz-range-thumb {
       ${thumbStyles}
       translate: var(--media-range-track-translate-x, 0) var(--media-range-track-translate-y, 0);
@@ -96,10 +96,10 @@ template.innerHTML = `
     input[type=range]::-webkit-slider-runnable-track { ${trackStyles} }
     input[type=range]::-moz-range-track { ${trackStyles} }
     input[type=range]::-ms-track {
-      /* Reset */
+      ${/* Reset */''}
       width: 100%;
       cursor: pointer;
-      /* Hides the slider so custom styles can be added */
+      ${/* Hides the slider so custom styles can be added */''}
       background: transparent;
       border-color: transparent;
       color: transparent;
@@ -136,7 +136,7 @@ template.innerHTML = `
     }
 
     #hoverzone {
-      /* Add z-index so it overlaps the top of the control buttons if they are right under. */
+      ${/* Add z-index so it overlaps the top of the control buttons if they are right under. */''}
       z-index: 1;
       display: var(--media-time-range-hover-display, none);
       box-sizing: border-box;
@@ -153,10 +153,10 @@ template.innerHTML = `
       height: var(--media-range-track-height, 4px);
     }
 
-    /*
+    ${/*
      * set input to focus-visible, unless host-context is available (in chrome)
      * in which case we can have the focus ring be on the host itself
-     */
+     */''}
     :host-context([media-keyboard-control]):host(:focus),
     :host-context([media-keyboard-control]):host(:focus-within) {
       box-shadow: inset 0 0 0 2px rgba(27, 127, 204, 0.9);

--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -21,12 +21,11 @@ const template = document.createElement('template');
 
 template.innerHTML = `
   <style>
-
-    /*
+    ${/*
      * outline on media is turned off because it is allowed to get focus to faciliate hotkeys.
      * However, on keyboard interactions, the focus outline is shown,
      * which is particularly noticeable when going fullscreen via hotkeys.
-     */
+     */''}
     :host([media-is-fullscreen])  ::slotted([slot=media]) {
       outline: none;
     }
@@ -52,27 +51,26 @@ template.innerHTML = `
       background: none;
     }
 
-    /*
+    ${/*
      * when in audio mode, hide the gesture-layer which causes media-controller to be taller than the control bar
-     *
-     */
+     */''}
     :host([audio]) [part~=layer][part~=gesture-layer] {
       height: 0;
       display: block;
     }
 
-    /*
+    ${/*
      * if gestures are disabled, don't accept pointer-events
-     */
+     */''}
     :host(:not([audio])[gestures-disabled]) ::slotted([slot=gestures-chrome]),
     :host(:not([audio])[gestures-disabled]) media-gesture-receiver[slot=gestures-chrome] {
       display: none;
     }
 
-    /*
+    ${/*
      * any slotted element that isn't a poster or media slot should be pointer-events auto
      * we'll want to add here any slotted elements that shouldn't get pointer-events by default when slotted
-     */
+     */''}
     ::slotted(:not([slot=media]):not([slot=poster]):not(media-loading-indicator)) {
       pointer-events: auto;
     }
@@ -95,32 +93,32 @@ template.innerHTML = `
       background: none;
     }
 
-    /* Position the media and poster elements to fill the container */
+    ${/* Position the media and poster elements to fill the container */''}
     ::slotted([slot=media]),
     ::slotted([slot=poster]) {
       width: 100%;
       height: 100%;
     }
 
-    /* Video specific styles */
+    ${/* Video specific styles */''}
     :host(:not([audio])) .spacer {
       flex-grow: 1;
     }
 
-    /* Safari needs this to actually make the element fill the window */
+    ${/* Safari needs this to actually make the element fill the window */''}
     :host(:-webkit-full-screen) {
-      /* Needs to use !important otherwise easy to break */
+      ${/* Needs to use !important otherwise easy to break */''}
       width: 100% !important;
       height: 100% !important;
     }
 
-    /* Only add these if auto hide is not disabled */
+    ${/* Only add these if auto hide is not disabled */''}
     ::slotted(:not([slot=media]):not([no-auto-hide])) {
       opacity: 1;
       transition: opacity 0.25s;
     }
 
-    /* Hide controls when inactive, not paused, not audio and auto hide not disabled */
+    ${/* Hide controls when inactive, not paused, not audio and auto hide not disabled */''}
     :host([user-inactive]:not([${MediaUIAttributes.MEDIA_PAUSED}]):not([${MediaUIAttributes.MEDIA_IS_CASTING}]):not([audio])) ::slotted(:not([slot=media]):not([no-auto-hide])) {
       opacity: 0;
       transition: opacity 1s;
@@ -140,7 +138,7 @@ template.innerHTML = `
     <slot name="top-chrome" part="top chrome"></slot>
     <slot name="middle-chrome" part="middle chrome"></slot>
     <slot name="centered-chrome" part="layer centered-layer center centered chrome"></slot>
-    <!-- default, effectively "bottom-chrome" -->
+    ${/* default, effectively "bottom-chrome" */''}
     <slot part="bottom chrome"></slot>
   </span>
 `;

--- a/src/js/media-control-bar.js
+++ b/src/js/media-control-bar.js
@@ -15,7 +15,7 @@ const template = document.createElement('template');
 template.innerHTML = `
   <style>
     :host {
-      /* Need position to display above video for some reason */
+      ${/* Need position to display above video for some reason */''}
       box-sizing: border-box;
       display: inline-flex;
       color: var(--media-icon-color, #eee);

--- a/src/js/media-fullscreen-button.js
+++ b/src/js/media-fullscreen-button.js
@@ -31,7 +31,7 @@ slotTemplate.innerHTML = `
     display: none !important;
   }
 
-  /* Double negative, but safer if display doesn't equal 'block' */
+  ${/* Double negative, but safer if display doesn't equal 'block' */ ''}
   :host(:not([${MediaUIAttributes.MEDIA_IS_FULLSCREEN}])) slot:not([name=enter]) > *,
   :host(:not([${MediaUIAttributes.MEDIA_IS_FULLSCREEN}])) ::slotted(:not([slot=enter])) {
     display: none !important;

--- a/src/js/media-mute-button.js
+++ b/src/js/media-mute-button.js
@@ -22,7 +22,7 @@ const highIcon = `<svg aria-hidden="true" viewBox="0 0 24 24">
 const slotTemplate = document.createElement('template');
 slotTemplate.innerHTML = `
   <style>
-  /* Default to High slot/icon. */
+  ${/* Default to High slot/icon. */''}
   :host(:not([${MediaUIAttributes.MEDIA_VOLUME_LEVEL}])) slot:not([name=high]) > *, 
   :host(:not([${MediaUIAttributes.MEDIA_VOLUME_LEVEL}])) ::slotted(:not([slot=high])),
   :host([${MediaUIAttributes.MEDIA_VOLUME_LEVEL}=high]) slot:not([name=high]) > *, 

--- a/src/js/media-pip-button.js
+++ b/src/js/media-pip-button.js
@@ -19,7 +19,7 @@ slotTemplate.innerHTML = `
     display: none !important;
   }
 
-  /* Double negative, but safer if display doesn't equal 'block' */
+  ${/* Double negative, but safer if display doesn't equal 'block' */ ''}
   :host(:not([${MediaUIAttributes.MEDIA_IS_PIP}])) slot:not([name=enter]) > *, 
   :host(:not([${MediaUIAttributes.MEDIA_IS_PIP}])) ::slotted(:not([slot=enter])) {
     display: none !important;

--- a/src/js/media-text-display.js
+++ b/src/js/media-text-display.js
@@ -28,17 +28,18 @@ template.innerHTML = `
       pointer-events: auto;
     }
 
-    /*
+    ${/*
       Only show outline when keyboard focusing.
       https://drafts.csswg.org/selectors-4/#the-focus-visible-pseudo
-    */
+    */''}
     :host(:focus-visible) {
       box-shadow: inset 0 0 0 2px rgba(27, 127, 204, 0.9);
       outline: 0;
     }
-    /*
+
+    ${/*
      * hide default focus ring, particularly when using mouse
-     */
+     */''}
     :host(:where(:focus)) {
       box-shadow: none;
       outline: 0;

--- a/src/js/media-time-range.js
+++ b/src/js/media-time-range.js
@@ -74,7 +74,7 @@ template.innerHTML = `
     ::slotted(media-preview-time-display) {
       color: unset;
       min-width: 0;
-      /* delay changing these CSS props until the preview box transition is ended */
+      ${/* delay changing these CSS props until the preview box transition is ended */''}
       transition: min-width 0s .25s, border-radius 0s .25s;
       background: var(--media-preview-time-background, var(--media-preview-background));
       border-radius: var(--media-preview-time-border-radius,
@@ -112,8 +112,8 @@ template.innerHTML = `
   </span>
   <span part="box current-box">
     <slot name="current">
-      <!-- Example: add the current time to the playhead -->
-      <!-- <media-current-time-display></media-current-time-display> -->
+      ${/* Example: add the current time to the playhead
+        <media-current-time-display></media-current-time-display> */''}
     </slot>
   </span>
 `;

--- a/src/js/media-title-element.js
+++ b/src/js/media-title-element.js
@@ -9,10 +9,8 @@ const template = document.createElement('template');
 template.innerHTML = `
   <style>
     :host {
-
     }
   </style>
-
   <slot></slot>
 `;
 


### PR DESCRIPTION
- remove minify and sourcemap options from the esm and cjs bundles. these are all separate files (not bundled) so it makes less sense to minify and add sourcemaps for each file. these files are expected to be bundled by the consumer.
- adds a esm-module bundle, was mainly for getting a accurate gzip bundle size but just thought the iife could also be used for that?
- put the comments in expressions so these can be easily removed by bundlers. golfed down -1.3kB with this 🥳 

![SCR-20220922-u5h](https://user-images.githubusercontent.com/360826/191983022-ca66c968-ce9f-4717-8871-091d5865eddd.png)

![SCR-20220923-d1s](https://user-images.githubusercontent.com/360826/191983041-e6f3e4f5-908e-4968-b548-02540f9cca39.png)
