### PR TITLE
feat: add poster object fit and position css vars

### DIFF
--- a/docs/src/pages/en/styling.md
+++ b/docs/src/pages/en/styling.md
@@ -110,3 +110,16 @@ Our current styling architecture is still quite nascent and is very likely to un
 \* Unlike most Media Chrome buttons, the `<media-playback-rate-button/>` button displays text (and not an icon/svg), so many [button styles](#buttons) don't apply to it and some [text display styles](#text-displays) do apply to it (unlike most buttons).
 
 \*\* A few CSS Variables are more "global" in their application, so make sure you define and scope them via selectors appropriately.
+
+## Images
+
+### Elements
+
+- `<media-poster-image/>` ([docs](./media-poster-image))
+
+| Name                          | CSS Property          | Default Value | Description                                                                                     | Notes |
+| ----------------------------- | --------------------- | ------------- | ----------------------------------------------------------------------------------------------- | ----- |
+| `--media-object-fit`          | `object-fit`          | `contain`     | how the content of the image should be resized to fit the custom element                        |       |
+| `--media-object-position`     | `object-position`     | `center`      | specifies the alignment of the image within the custom element's box                            |       |
+| `--media-background-size`     | `background-size`     | `contain`     | how the content of the background placeholder image should be resized to fit the custom element |       |
+| `--media-background-position` | `background-position` | `center`      | specifies the alignment of the background placeholder image within the custom element's box     |       |

--- a/src/js/media-poster-image.js
+++ b/src/js/media-poster-image.js
@@ -13,9 +13,6 @@ template.innerHTML = `
       pointer-events: none;
       display: inline-block;
       box-sizing: border-box;
-
-      width: auto;
-      height: auto;
     }
 
     img {
@@ -23,10 +20,11 @@ template.innerHTML = `
       max-height: 100%;
       min-width: 100%;
       min-height: 100%;
-      background-size: contain;
-      background-position: center;
       background-repeat: no-repeat;
-      object-fit: contain;
+      background-position: var(--media-background-position, var(--media-object-position, center));
+      background-size: var(--media-background-size, var(--media-object-fit, contain));
+      object-fit: var(--media-object-fit, contain);
+      object-position: var(--media-object-position, center);
     }
 
     :host([${MediaUIAttributes.MEDIA_HAS_PLAYED}]) img {


### PR DESCRIPTION
Related to https://github.com/muxinc/elements/issues/444

adds positioning and size / fit css vars for the `media-poster-image` element