### PR TITLE
fix: clicking in media-container should schedule inactive

### DIFF
--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -359,6 +359,8 @@ class MediaContainer extends window.HTMLElement {
         } else {
           scheduleInactive();
         }
+      } else {
+        scheduleInactive();
       }
     });
 

--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -359,7 +359,7 @@ class MediaContainer extends window.HTMLElement {
         } else {
           scheduleInactive();
         }
-      } else {
+      } else if (['media-play-button', 'media-fullscreen-button'].includes(e.target.nodeName.toLowerCase())) {
         scheduleInactive();
       }
     });


### PR DESCRIPTION
If a user presses play but doesn't move the mouse out of the control bounds, the controls never autohide. Instead, we should schedule inactive when a click happens. Then, on pointermove automatic hiding would be prevented as usual.

Mobile behavior of toggling controls is maintained as well.

Fixes #188