### PR TITLE
fix: box percentage positioning & time range border glitch

### DIFF
--- a/src/js/media-chrome-range.js
+++ b/src/js/media-chrome-range.js
@@ -46,6 +46,7 @@ template.innerHTML = `
       --media-range-padding: var(--media-control-padding, 10px);
       --_media-range-padding: var(--media-range-padding, 10px);
 
+      vertical-align: middle;
       box-sizing: border-box;
       display: inline-block;
       position: relative;

--- a/src/js/media-chrome-range.js
+++ b/src/js/media-chrome-range.js
@@ -28,6 +28,8 @@ const trackStyles = `
   min-width: 40px;
   height: var(--track-height);
   border: var(--media-range-track-border, none);
+  outline: var(--media-range-track-outline);
+  outline-offset: var(--media-range-track-outline-offset);
   border-radius: var(--media-range-track-border-radius, 0);
   background: var(--media-range-track-progress-internal, var(--media-range-track-background, #eee));
   box-shadow: var(--media-range-track-box-shadow, none);
@@ -115,7 +117,6 @@ template.innerHTML = `
       width: var(--media-range-track-width, 100%);
       height: var(--track-height);
       border-radius: var(--media-range-track-border-radius, 0);
-      box-sizing: border-box;
       position: absolute;
       top: 50%;
       transform: translate(var(--media-range-track-translate-x, 0px), calc(var(--media-range-track-translate-y, 0px) - 50%));
@@ -141,7 +142,6 @@ template.innerHTML = `
       ${/* Add z-index so it overlaps the top of the control buttons if they are right under. */''}
       z-index: 1;
       display: var(--media-time-range-hover-display, none);
-      box-sizing: border-box;
       position: absolute;
       width: 100%;
       bottom: var(--media-time-range-hover-bottom, -5px);
@@ -151,7 +151,6 @@ template.innerHTML = `
     #range {
       z-index: 2;
       position: relative;
-      height: var(--media-range-track-height, 4px);
     }
 
     ${/*

--- a/src/js/media-chrome-range.js
+++ b/src/js/media-chrome-range.js
@@ -151,6 +151,7 @@ template.innerHTML = `
     #range {
       z-index: 2;
       position: relative;
+      height: var(--media-range-track-height, 4px);
     }
 
     ${/*

--- a/src/js/media-chrome-range.js
+++ b/src/js/media-chrome-range.js
@@ -44,12 +44,9 @@ template.innerHTML = `
       --media-range-padding: var(--media-control-padding, 10px);
       --_media-range-padding: var(--media-range-padding, 10px);
 
-      position: relative;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      vertical-align: middle;
       box-sizing: border-box;
+      display: inline-block;
+      position: relative;
       background: var(--media-control-background, rgba(20,20,30, 0.7));
       transition: background 0.15s linear;
       width: 100px;
@@ -63,6 +60,11 @@ template.innerHTML = `
 
     :host(:hover) {
       background: var(--media-control-hover-background, rgba(50,50,60, 0.7));
+    }
+
+    #container {
+      position: relative;
+      height: 100%;
     }
 
     input[type=range] {
@@ -109,19 +111,19 @@ template.innerHTML = `
 
     #background,
     #pointer {
-      ${trackStyles}
-      width: auto;
+      min-width: 40px;
+      width: var(--media-range-track-width, 100%);
+      height: var(--track-height);
+      border-radius: var(--media-range-track-border-radius, 0);
+      box-sizing: border-box;
       position: absolute;
       top: 50%;
       transform: translate(var(--media-range-track-translate-x, 0px), calc(var(--media-range-track-translate-y, 0px) - 50%));
-      left: var(--media-range-padding-left, var(--_media-range-padding));
-      right: var(--media-range-padding-right, var(--_media-range-padding));
       background: var(--media-range-track-background, #333);
     }
 
     #pointer {
       min-width: auto;
-      right: auto;
       background: var(--media-range-track-pointer-background);
       border-right: var(--media-range-track-pointer-border-right);
       transition: visibility .25s, opacity .25s;
@@ -141,8 +143,7 @@ template.innerHTML = `
       display: var(--media-time-range-hover-display, none);
       box-sizing: border-box;
       position: absolute;
-      left: var(--media-range-padding-left, var(--_media-range-padding));
-      right: var(--media-range-padding-right, var(--_media-range-padding));
+      width: 100%;
       bottom: var(--media-time-range-hover-bottom, -5px);
       height: var(--media-time-range-hover-height, max(calc(100% + 5px), 20px));
     }
@@ -182,10 +183,12 @@ template.innerHTML = `
       background-color: #777;
     }
   </style>
-  <div id="background"></div>
-  <div id="pointer"></div>
-  <div id="hoverzone"></div>
-  <input id="range" type="range" min="0" max="1000" step="any" value="0">
+  <div id="container">
+    <div id="background"></div>
+    <div id="pointer"></div>
+    <div id="hoverzone"></div>
+    <input id="range" type="range" min="0" max="1000" step="any" value="0">
+  </div>
 `;
 
 class MediaChromeRange extends window.HTMLElement {
@@ -202,6 +205,7 @@ class MediaChromeRange extends window.HTMLElement {
     this.attachShadow({ mode: 'open' });
     this.shadowRoot.appendChild(template.content.cloneNode(true));
 
+    this.container = this.shadowRoot.querySelector('#container');
     this.range = this.shadowRoot.querySelector('#range');
     this.range.addEventListener('input', this.updateBar.bind(this));
   }

--- a/src/js/media-time-range.js
+++ b/src/js/media-time-range.js
@@ -34,13 +34,20 @@ template.innerHTML = `
       color: #fff;
     }
 
-    [part~="box"] {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
+    #preview-rail,
+    #current-rail {
+      width: 100%;
       position: absolute;
       left: 0;
       bottom: 100%;
+      pointer-events: none;
+    }
+
+    [part~="box"] {
+      display: inline-flex;
+      flex-direction: column;
+      align-items: center;
+      transform: translateX(-50%);
     }
 
     [part~="preview-box"] {
@@ -104,18 +111,18 @@ template.innerHTML = `
       --media-time-range-hover-display: block;
     }
   </style>
-  <span part="box preview-box">
-    <slot name="preview">
+  <div id="preview-rail">
+    <slot name="preview" part="box preview-box">
       <media-preview-thumbnail></media-preview-thumbnail>
       <media-preview-time-display></media-preview-time-display>
     </slot>
-  </span>
-  <span part="box current-box">
-    <slot name="current">
+  </div>
+  <div id="current-rail">
+    <slot name="current" part="box current-box">
       ${/* Example: add the current time to the playhead
         <media-current-time-display></media-current-time-display> */''}
     </slot>
-  </span>
+  </div>
 `;
 
 class MediaTimeRange extends MediaChromeRange {
@@ -142,7 +149,7 @@ class MediaTimeRange extends MediaChromeRange {
   constructor() {
     super();
 
-    this.shadowRoot.appendChild(template.content.cloneNode(true));
+    this.container.appendChild(template.content.cloneNode(true));
 
     this.range.addEventListener('input', () => {
       // Cancel color bar refreshing when seeking.
@@ -318,13 +325,13 @@ class MediaTimeRange extends MediaChromeRange {
 
   updateCurrentBox() {
     const currentBox = this.shadowRoot.querySelector('[part~="current-box"]');
-    const percent = this.range.value / (this.range.max - this.range.min);
-    const boxPos = getBoxPosition(this, currentBox, percent);
+    const boxRatio = this.range.value / (this.range.max - this.range.min);
+    const boxPos = getBoxPosition(this, currentBox, boxRatio);
     const { style } = getOrInsertCSSRule(
       this.shadowRoot,
-      '[part~="current-box"]'
+      '#current-rail'
     );
-    style.transform = `translateX(${boxPos}px)`;
+    style.transform = `translateX(${boxPos})`;
   }
 
   #pointermoveHandler = (evt) => {
@@ -338,18 +345,18 @@ class MediaTimeRange extends MediaChromeRange {
 
     // Get mouse position percent
     const rangeRect = this.range.getBoundingClientRect();
-    let mousePercent = (evt.clientX - rangeRect.left) / rangeRect.width;
+    let mouseRatio = (evt.clientX - rangeRect.left) / rangeRect.width;
     // Lock between 0 and 1
-    mousePercent = Math.max(0, Math.min(1, mousePercent));
+    mouseRatio = Math.max(0, Math.min(1, mouseRatio));
 
-    const boxPos = getBoxPosition(this, this.#previewBox, mousePercent);
+    const boxPos = getBoxPosition(this, this.#previewBox, mouseRatio);
     const { style } = getOrInsertCSSRule(
       this.shadowRoot,
-      '[part~="preview-box"]'
+      '#preview-rail'
     );
-    style.transform = `translateX(${boxPos}px)`;
+    style.transform = `translateX(${boxPos})`;
 
-    const detail = mousePercent * duration;
+    const detail = mouseRatio * duration;
     const mediaPreviewEvt = new window.CustomEvent(
       MediaUIEvents.MEDIA_PREVIEW_REQUEST,
       { composed: true, bubbles: true, detail }
@@ -408,37 +415,35 @@ class MediaTimeRange extends MediaChromeRange {
   }
 }
 
-function getBoxPosition(el, box, percent) {
-  const rect = el.getBoundingClientRect();
-  const rangeRect = el.range.getBoundingClientRect();
+function getBoxPosition(el, box, ratio) {
+  let position = `${ratio * 100}%`;
 
-  // Get preview box center position
+  // Get the element that enforces the bounds for the time range boxes.
+  const bounds =
+    (el.getAttribute('media-bounds')
+      ? closestComposedNode(el, `#${el.getAttribute('media-bounds')}`)
+      : el.parentElement) ?? el;
+
   const leftPadding = parseInt(
     getComputedStyle(el).getPropertyValue('--media-box-padding-left')
   );
   const rightPadding = parseInt(
     getComputedStyle(el).getPropertyValue('--media-box-padding-right')
   );
-  const boxOffset = leftPadding + percent * rangeRect.width;
 
   // Use offset dimensions to include borders.
   const boxWidth = box.offsetWidth;
-  const boxLeft = boxOffset - boxWidth / 2;
+  if (!boxWidth) return position;
 
-  // Get the element that enforces the bounding box for the hover preview.
-  const mediaBounds =
-    (el.getAttribute('media-bounds')
-      ? closestComposedNode(el, `#${el.getAttribute('media-bounds')}`)
-      : el.parentElement) ?? el;
+  const rangeRect = el.range.getBoundingClientRect();
+  const mediaBoundsRect = bounds.getBoundingClientRect();
+  const boxMin = leftPadding - (rangeRect.left - mediaBoundsRect.left - boxWidth / 2);
+  const boxMax = mediaBoundsRect.right - rangeRect.left - boxWidth / 2 - rightPadding;
 
-  const mediaBoundsRect = mediaBounds.getBoundingClientRect();
-  const offsetLeft = rect.left - mediaBoundsRect.left;
-  const offsetRight =
-    mediaBoundsRect.right - rect.left - boxWidth - rightPadding;
-  const boxMin = leftPadding - offsetLeft;
-  const boxMax = offsetRight;
+  if (!Number.isNaN(boxMin)) position = `max(${boxMin}px, ${position})`;
+  if (!Number.isNaN(boxMax)) position = `min(${position}, ${boxMax}px)`;
 
-  return Math.max(boxMin, Math.min(boxLeft, boxMax));
+  return position;
 }
 
 defineCustomElement('media-time-range', MediaTimeRange);

--- a/src/js/media-time-range.js
+++ b/src/js/media-time-range.js
@@ -36,7 +36,8 @@ template.innerHTML = `
 
     #preview-rail,
     #current-rail {
-      width: 100%;
+      ${/* 1% of parent element and upscale by 100 in the translateX() */''}
+      width: 1%;
       position: absolute;
       left: 0;
       bottom: 100%;
@@ -44,7 +45,10 @@ template.innerHTML = `
     }
 
     [part~="box"] {
-      display: inline-flex;
+      ${/* absolute position is needed here so the box doesn't overflow the bounds */''}
+      position: absolute;
+      bottom: 100%;
+      display: flex;
       flex-direction: column;
       align-items: center;
       transform: translateX(-50%);
@@ -416,7 +420,7 @@ class MediaTimeRange extends MediaChromeRange {
 }
 
 function getBoxPosition(el, box, ratio) {
-  let position = `${ratio * 100}%`;
+  let position = `${ratio * 100 * 100}%`;
 
   // Use offset dimensions to include borders.
   const boxWidth = box.offsetWidth;
@@ -440,8 +444,8 @@ function getBoxPosition(el, box, ratio) {
   const boxMin = (leftPadding - (rangeRect.left - mediaBoundsRect.left - boxWidth / 2)) / rangeRect.width * 100;
   const boxMax = (mediaBoundsRect.right - rangeRect.left - boxWidth / 2 - rightPadding) / rangeRect.width * 100;
 
-  if (!Number.isNaN(boxMin)) position = `max(${boxMin}%, ${position})`;
-  if (!Number.isNaN(boxMax)) position = `min(${position}, ${boxMax}%)`;
+  if (!Number.isNaN(boxMin)) position = `max(${boxMin * 100}%, ${position})`;
+  if (!Number.isNaN(boxMax)) position = `min(${position}, ${boxMax * 100}%)`;
 
   return position;
 }

--- a/src/js/media-time-range.js
+++ b/src/js/media-time-range.js
@@ -418,6 +418,10 @@ class MediaTimeRange extends MediaChromeRange {
 function getBoxPosition(el, box, ratio) {
   let position = `${ratio * 100}%`;
 
+  // Use offset dimensions to include borders.
+  const boxWidth = box.offsetWidth;
+  if (!boxWidth) return position;
+
   // Get the element that enforces the bounds for the time range boxes.
   const bounds =
     (el.getAttribute('media-bounds')
@@ -431,17 +435,13 @@ function getBoxPosition(el, box, ratio) {
     getComputedStyle(el).getPropertyValue('--media-box-padding-right')
   );
 
-  // Use offset dimensions to include borders.
-  const boxWidth = box.offsetWidth;
-  if (!boxWidth) return position;
-
   const rangeRect = el.range.getBoundingClientRect();
   const mediaBoundsRect = bounds.getBoundingClientRect();
-  const boxMin = leftPadding - (rangeRect.left - mediaBoundsRect.left - boxWidth / 2);
-  const boxMax = mediaBoundsRect.right - rangeRect.left - boxWidth / 2 - rightPadding;
+  const boxMin = (leftPadding - (rangeRect.left - mediaBoundsRect.left - boxWidth / 2)) / rangeRect.width * 100;
+  const boxMax = (mediaBoundsRect.right - rangeRect.left - boxWidth / 2 - rightPadding) / rangeRect.width * 100;
 
-  if (!Number.isNaN(boxMin)) position = `max(${boxMin}px, ${position})`;
-  if (!Number.isNaN(boxMax)) position = `min(${position}, ${boxMax}px)`;
+  if (!Number.isNaN(boxMin)) position = `max(${boxMin}%, ${position})`;
+  if (!Number.isNaN(boxMax)) position = `min(${position}, ${boxMax}%)`;
 
   return position;
 }

--- a/src/js/media-time-range.js
+++ b/src/js/media-time-range.js
@@ -424,8 +424,8 @@ function getBoxPosition(el, box, ratio) {
 
   // Get the element that enforces the bounds for the time range boxes.
   const bounds =
-    (el.getAttribute('media-bounds')
-      ? closestComposedNode(el, `#${el.getAttribute('media-bounds')}`)
+    (el.getAttribute('bounds')
+      ? closestComposedNode(el, `#${el.getAttribute('bounds')}`)
       : el.parentElement) ?? el;
 
   const leftPadding = parseInt(

--- a/src/js/utils/element-utils.js
+++ b/src/js/utils/element-utils.js
@@ -37,7 +37,12 @@ export const closestComposedNode = (childNode, selector) => {
 export function getOrInsertCSSRule(styleParent, selectorText) {
   let style;
   for (style of styleParent.querySelectorAll('style')) {
-    for (let rule of style.sheet?.cssRules ?? [])
+    // Catch this error. e.g. browser extension adds style tags.
+    //   Uncaught DOMException: CSSStyleSheet.cssRules getter:
+    //   Not allowed to access cross-origin stylesheet
+    let cssRules;
+    try { cssRules = style.sheet?.cssRules; } catch { continue; }
+    for (let rule of cssRules ?? [])
       if (rule.selectorText === selectorText) return rule;
   }
   // If there is no style sheet return an empty style rule.


### PR DESCRIPTION
Related #281

- fixes a `--media-range-track-border` double border bug on the chrome range
- adds a `--media-range-track-outline` and `--media-range-track-outline-offset`
- fixes the time range current time box using percentages which repositions on player resize 
  that was a tricky one but it makes the code simpler overal though introduces 1 wrapper div#container

