### PR TITLE
tools: move from unpkg.com to jsdelivr.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Visit the [official documentation for Media Chrome](https://media-chrome-docs.ve
 ## Video Example
 
 ```html
-<script type="module" src="https://unpkg.com/media-chrome@0.7"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/media-chrome@0/+esm"></script>
 
 <media-controller>
   <video
@@ -53,7 +53,7 @@ Visit the [official documentation for Media Chrome](https://media-chrome-docs.ve
 ## Audio Example
 
 ```html
-<script type="module" src="https://unpkg.com/media-chrome@0.7"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/media-chrome@0/+esm"></script>
 
 <media-controller audio>
   <audio
@@ -98,7 +98,7 @@ Load the module in the `<head>` of your HTML page. Note the `type="module"`, tha
 > Modules are always loaded asynchronously by the browser, so it's ok to load them in the head :thumbsup:, and best for registering web components quickly.
 
 ```html
-<script type="module" src="https://unpkg.com/media-chrome@0.7"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/media-chrome@0/+esm"></script>
 ```
 
 ### Option 2: Bundled via npm
@@ -197,7 +197,7 @@ import 'media-chrome/dist/extras/media-clip-selector';
 ```html
 <script
   type="module"
-  src="https://unpkg.com/media-chrome@0.7/dist/extras/media-clip-selector"
+  src="https://cdn.jsdelivr.net/npm/media-chrome@0.5/dist/extras/media-clip-selector/index.js/+esm"
 ></script>
 ```
 

--- a/docs/src/pages/en/get-started.md
+++ b/docs/src/pages/en/get-started.md
@@ -34,7 +34,7 @@ Load the module in the `<head>` of your HTML page. Note the `type="module"`, tha
 > Modules are always loaded asynchronously by the browser, so it's ok to load them in the head 👍
 
 ```html
-<script type="module" src="https://unpkg.com/media-chrome"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/media-chrome@0/+esm"></script>
 ```
 
 ### Option 2: Bundled via npm

--- a/examples/casting.html
+++ b/examples/casting.html
@@ -4,7 +4,7 @@
     <meta name="viewport" content="width=device-width" />
     <title>Media Chrome with Casting Example</title>
     <script defer src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1"></script>
-    <script type="module" src="https://unpkg.com/castable-video"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/castable-video@0"></script>
     <script type="module" src="../dist/index.js"></script>
     <style>
       /** add styles to prevent CLS (Cumulative Layout Shift) */

--- a/examples/media-elements/dash.html
+++ b/examples/media-elements/dash.html
@@ -3,7 +3,7 @@
   <head>
     <meta name="viewport" content="width=device-width" />
     <title>Media Chrome DASH Media Example</title>
-    <script type="module" src="https://unpkg.com/dash-video-element@0"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/dash-video-element@0"></script>
     <script type="module" src="../../dist/index.js"></script>
     <style>
       .examples {

--- a/examples/media-elements/hls.html
+++ b/examples/media-elements/hls.html
@@ -3,7 +3,7 @@
   <head>
     <meta name="viewport" content="width=device-width" />
     <title>Media Chrome HLS Media Example</title>
-    <script type="module" src="https://unpkg.com/hls-video-element@0"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/hls-video-element@0"></script>
     <script type="module" src="../../dist/index.js"></script>
     <style>
       /** add styles to prevent CLS (Cumulative Layout Shift) */

--- a/examples/media-elements/jwplayer.html
+++ b/examples/media-elements/jwplayer.html
@@ -32,7 +32,7 @@
         margin-top: 20px;
       }
     </style>
-    <script type="module" src="https://unpkg.com/jwplayer-video-element"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/jwplayer-video-element@0"></script>
     <script type="module" src="../../dist/index.js"></script>
   </head>
   <body>

--- a/examples/media-elements/media-playlist.html
+++ b/examples/media-elements/media-playlist.html
@@ -3,8 +3,8 @@
   <head>
     <meta name="viewport" content="width=device-width" />
     <title>Media Chrome Media Playlist Example</title>
-    <script type="module" src="https://unpkg.com/media-playlist@0.1"></script>
-    <script type="module" src="https://unpkg.com/hls-video-element@0"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/media-playlist@0.1"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/hls-video-element@0"></script>
     <script type="module" src="../../dist/index.js"></script>
     <style>
       /** add styles to prevent CLS (Cumulative Layout Shift) */

--- a/examples/media-elements/mux-video.html
+++ b/examples/media-elements/mux-video.html
@@ -5,7 +5,7 @@
     <title>Media Chrome &lt;mux-video/&gt; Example</title>
     <script
       type="module"
-      src="https://unpkg.com/@mux/mux-video"
+      src="https://cdn.jsdelivr.net/npm/@mux/mux-video/+esm"
     ></script>
     <script type="module" src="../../dist/index.js"></script>
     <style>

--- a/examples/media-elements/videojs.html
+++ b/examples/media-elements/videojs.html
@@ -32,7 +32,7 @@
         margin-top: 20px;
       }
     </style>
-    <script type="module" src="https://unpkg.com/videojs-video-element"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/videojs-video-element@0"></script>
     <script type="module" src="../../dist/index.js"></script>
   </head>
   <body>

--- a/examples/media-elements/vimeo.html
+++ b/examples/media-elements/vimeo.html
@@ -32,7 +32,7 @@
         margin-top: 20px;
       }
     </style>
-    <script type="module" src="https://unpkg.com/vimeo-video-element"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/vimeo-video-element@0"></script>
     <script type="module" src="../../dist/index.js"></script>
   </head>
   <body>

--- a/examples/media-elements/wistia.html
+++ b/examples/media-elements/wistia.html
@@ -32,7 +32,7 @@
         margin-top: 20px;
       }
     </style>
-    <script type="module" src="https://unpkg.com/wistia-video-element"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/wistia-video-element@0"></script>
     <script type="module" src="../../dist/index.js"></script>
   </head>
   <body>

--- a/examples/media-elements/youtube.html
+++ b/examples/media-elements/youtube.html
@@ -5,7 +5,7 @@
     <title>Media Chrome Youtube Media Example</title>
     <script
       type="module"
-      src="https://unpkg.com/youtube-video-element@0.0.6"
+      src="https://cdn.jsdelivr.net/npm/youtube-video-element@0"
     ></script>
     <script type="module" src="../../dist/index.js"></script>
     <style>

--- a/examples/themes/youtube-theme.html
+++ b/examples/themes/youtube-theme.html
@@ -5,7 +5,7 @@
     <title>Media Chrome Youtube Theme Example</title>
     <script type="module" src="../../dist/index.js"></script>
     <script type="module" src="../../src/js/themes/media-theme-youtube.js"></script>
-    <!-- <script type="module" src="https://unpkg.com/youtube-video-element@0"></script> -->
+    <!-- <script type="module" src="https://cdn.jsdelivr.net/npm/youtube-video-element@0"></script> -->
   </head>
   <body>
     <style>


### PR DESCRIPTION
main reason being they provide pkg download stats but it's also more feature rich overall, faster and less downtime I imagine

https://www.jsdelivr.com/package/npm/media-chrome
[![](https://data.jsdelivr.com/v1/package/npm/media-chrome/badge)](https://www.jsdelivr.com/package/npm/media-chrome)

https://www.jsdelivr.com/network

![SCR-20221021-mhh](https://user-images.githubusercontent.com/360826/197289405-0da49879-2990-45b8-8d99-ffb6aef1e318.png)

![SCR-20221021-miu](https://user-images.githubusercontent.com/360826/197289678-79cff373-3516-4584-80c4-e17e8749312a.png)
