### PR TITLE
Fix mc attr

### DIFF
--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -50,6 +50,11 @@ export const MediaStateChangeEvents = {
   USER_INACTIVE: 'userinactivechange',
 };
 
+export const UIControllerAttributes = {
+  MEDIA_CHROME_ATTRIBUTES: 'media-chrome-attributes',
+  MEDIA_CONTROLLER: 'media-controller',
+};
+
 export const MediaUIAttributes = {
   MEDIA_AIRPLAY_UNAVAILABLE: 'media-airplay-unavailable',
   MEDIA_FULLSCREEN_UNAVAILABLE: 'media-fullscreen-unavailable',
@@ -75,8 +80,6 @@ export const MediaUIAttributes = {
   MEDIA_PREVIEW_TIME: 'media-preview-time',
   MEDIA_PREVIEW_IMAGE: 'media-preview-image',
   MEDIA_PREVIEW_COORDS: 'media-preview-coords',
-  MEDIA_CHROME_ATTRIBUTES: 'media-chrome-attributes',
-  MEDIA_CONTROLLER: 'media-controller',
   MEDIA_LOADING: 'media-loading',
   MEDIA_BUFFERED: 'media-buffered',
 };

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -46,8 +46,6 @@ export const MediaStateChangeEvents = {
   MEDIA_SEEKABLE: 'mediaseekablechange',
   MEDIA_PREVIEW_IMAGE: 'mediapreviewimagechange',
   MEDIA_PREVIEW_COORDS: 'mediapreviewcoordschange',
-  // MEDIA_CHROME_ATTRIBUTES: 'media-chrome-attributes',
-  // MEDIA_CONTROLLER: 'media-controller',
   MEDIA_LOADING: 'medialoadingchange',
   USER_INACTIVE: 'userinactivechange',
 };

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -50,7 +50,7 @@ export const MediaStateChangeEvents = {
   USER_INACTIVE: 'userinactivechange',
 };
 
-export const UIControllerAttributes = {
+export const MediaStateReceiverAttributes = {
   MEDIA_CHROME_ATTRIBUTES: 'media-chrome-attributes',
   MEDIA_CONTROLLER: 'media-controller',
 };

--- a/src/js/media-chrome-button.js
+++ b/src/js/media-chrome-button.js
@@ -1,4 +1,4 @@
-import { UIControllerAttributes } from './constants.js';
+import { MediaStateReceiverAttributes } from './constants.js';
 import { defineCustomElement } from './utils/defineCustomElement.js';
 import {
   Window as window,
@@ -68,7 +68,7 @@ template.innerHTML = `
 
 class MediaChromeButton extends window.HTMLElement {
   static get observedAttributes() {
-    return ['disabled', UIControllerAttributes.MEDIA_CONTROLLER];
+    return ['disabled', MediaStateReceiverAttributes.MEDIA_CONTROLLER];
   }
 
   constructor(options = {}) {
@@ -130,7 +130,7 @@ class MediaChromeButton extends window.HTMLElement {
   }
 
   attributeChangedCallback(attrName, oldValue, newValue) {
-    if (attrName === UIControllerAttributes.MEDIA_CONTROLLER) {
+    if (attrName === MediaStateReceiverAttributes.MEDIA_CONTROLLER) {
       if (oldValue) {
         const mediaControllerEl = document.getElementById(oldValue);
         mediaControllerEl?.unassociateElement?.(this);
@@ -156,7 +156,7 @@ class MediaChromeButton extends window.HTMLElement {
     this.setAttribute('role', 'button');
 
     const mediaControllerId = this.getAttribute(
-      UIControllerAttributes.MEDIA_CONTROLLER
+      MediaStateReceiverAttributes.MEDIA_CONTROLLER
     );
     if (mediaControllerId) {
       const mediaControllerEl = document.getElementById(mediaControllerId);
@@ -168,7 +168,7 @@ class MediaChromeButton extends window.HTMLElement {
     this.disable();
 
     const mediaControllerId = this.getAttribute(
-      UIControllerAttributes.MEDIA_CONTROLLER
+      MediaStateReceiverAttributes.MEDIA_CONTROLLER
     );
     if (mediaControllerId) {
       const mediaControllerEl = document.getElementById(mediaControllerId);

--- a/src/js/media-chrome-button.js
+++ b/src/js/media-chrome-button.js
@@ -1,4 +1,4 @@
-import { MediaUIAttributes } from './constants.js';
+import { UIControllerAttributes } from './constants.js';
 import { defineCustomElement } from './utils/defineCustomElement.js';
 import {
   Window as window,
@@ -68,7 +68,7 @@ template.innerHTML = `
 
 class MediaChromeButton extends window.HTMLElement {
   static get observedAttributes() {
-    return ['disabled', MediaUIAttributes.MEDIA_CONTROLLER];
+    return ['disabled', UIControllerAttributes.MEDIA_CONTROLLER];
   }
 
   constructor(options = {}) {
@@ -130,7 +130,7 @@ class MediaChromeButton extends window.HTMLElement {
   }
 
   attributeChangedCallback(attrName, oldValue, newValue) {
-    if (attrName === MediaUIAttributes.MEDIA_CONTROLLER) {
+    if (attrName === UIControllerAttributes.MEDIA_CONTROLLER) {
       if (oldValue) {
         const mediaControllerEl = document.getElementById(oldValue);
         mediaControllerEl?.unassociateElement?.(this);
@@ -156,7 +156,7 @@ class MediaChromeButton extends window.HTMLElement {
     this.setAttribute('role', 'button');
 
     const mediaControllerId = this.getAttribute(
-      MediaUIAttributes.MEDIA_CONTROLLER
+      UIControllerAttributes.MEDIA_CONTROLLER
     );
     if (mediaControllerId) {
       const mediaControllerEl = document.getElementById(mediaControllerId);
@@ -168,7 +168,7 @@ class MediaChromeButton extends window.HTMLElement {
     this.disable();
 
     const mediaControllerId = this.getAttribute(
-      MediaUIAttributes.MEDIA_CONTROLLER
+      UIControllerAttributes.MEDIA_CONTROLLER
     );
     if (mediaControllerId) {
       const mediaControllerEl = document.getElementById(mediaControllerId);

--- a/src/js/media-chrome-range.js
+++ b/src/js/media-chrome-range.js
@@ -1,4 +1,4 @@
-import { UIControllerAttributes } from './constants.js';
+import { MediaStateReceiverAttributes } from './constants.js';
 import { defineCustomElement } from './utils/defineCustomElement.js';
 import {
   Window as window,
@@ -197,7 +197,7 @@ class MediaChromeRange extends window.HTMLElement {
     return [
       'disabled',
       'aria-disabled',
-      UIControllerAttributes.MEDIA_CONTROLLER];
+      MediaStateReceiverAttributes.MEDIA_CONTROLLER];
   }
 
   constructor() {
@@ -212,7 +212,7 @@ class MediaChromeRange extends window.HTMLElement {
   }
 
   attributeChangedCallback(attrName, oldValue, newValue) {
-    if (attrName === UIControllerAttributes.MEDIA_CONTROLLER) {
+    if (attrName === MediaStateReceiverAttributes.MEDIA_CONTROLLER) {
       if (oldValue) {
         const mediaControllerEl = document.getElementById(oldValue);
         mediaControllerEl?.unassociateElement?.(this);
@@ -236,7 +236,7 @@ class MediaChromeRange extends window.HTMLElement {
 
   connectedCallback() {
     const mediaControllerId = this.getAttribute(
-      UIControllerAttributes.MEDIA_CONTROLLER
+      MediaStateReceiverAttributes.MEDIA_CONTROLLER
     );
     if (mediaControllerId) {
       const mediaControllerEl = document.getElementById(mediaControllerId);
@@ -247,7 +247,7 @@ class MediaChromeRange extends window.HTMLElement {
 
   disconnectedCallback() {
     const mediaControllerId = this.getAttribute(
-      UIControllerAttributes.MEDIA_CONTROLLER
+      MediaStateReceiverAttributes.MEDIA_CONTROLLER
     );
     if (mediaControllerId) {
       const mediaControllerEl = document.getElementById(mediaControllerId);

--- a/src/js/media-chrome-range.js
+++ b/src/js/media-chrome-range.js
@@ -1,4 +1,4 @@
-import { MediaUIAttributes } from './constants.js';
+import { UIControllerAttributes } from './constants.js';
 import { defineCustomElement } from './utils/defineCustomElement.js';
 import {
   Window as window,
@@ -197,7 +197,7 @@ class MediaChromeRange extends window.HTMLElement {
     return [
       'disabled',
       'aria-disabled',
-      MediaUIAttributes.MEDIA_CONTROLLER];
+      UIControllerAttributes.MEDIA_CONTROLLER];
   }
 
   constructor() {
@@ -212,7 +212,7 @@ class MediaChromeRange extends window.HTMLElement {
   }
 
   attributeChangedCallback(attrName, oldValue, newValue) {
-    if (attrName === MediaUIAttributes.MEDIA_CONTROLLER) {
+    if (attrName === UIControllerAttributes.MEDIA_CONTROLLER) {
       if (oldValue) {
         const mediaControllerEl = document.getElementById(oldValue);
         mediaControllerEl?.unassociateElement?.(this);
@@ -236,7 +236,7 @@ class MediaChromeRange extends window.HTMLElement {
 
   connectedCallback() {
     const mediaControllerId = this.getAttribute(
-      MediaUIAttributes.MEDIA_CONTROLLER
+      UIControllerAttributes.MEDIA_CONTROLLER
     );
     if (mediaControllerId) {
       const mediaControllerEl = document.getElementById(mediaControllerId);
@@ -247,7 +247,7 @@ class MediaChromeRange extends window.HTMLElement {
 
   disconnectedCallback() {
     const mediaControllerId = this.getAttribute(
-      MediaUIAttributes.MEDIA_CONTROLLER
+      UIControllerAttributes.MEDIA_CONTROLLER
     );
     if (mediaControllerId) {
       const mediaControllerEl = document.getElementById(mediaControllerId);

--- a/src/js/media-control-bar.js
+++ b/src/js/media-control-bar.js
@@ -3,7 +3,7 @@
 
   Auto position contorls in a line and set some base colors
 */
-import { UIControllerAttributes } from './constants.js';
+import { MediaStateReceiverAttributes } from './constants.js';
 import { defineCustomElement } from './utils/defineCustomElement.js';
 import {
   Window as window,
@@ -35,7 +35,7 @@ template.innerHTML = `
 
 class MediaControlBar extends window.HTMLElement {
   static get observedAttributes() {
-    return [UIControllerAttributes.MEDIA_CONTROLLER];
+    return [MediaStateReceiverAttributes.MEDIA_CONTROLLER];
   }
 
   constructor() {
@@ -46,7 +46,7 @@ class MediaControlBar extends window.HTMLElement {
   }
 
   attributeChangedCallback(attrName, oldValue, newValue) {
-    if (attrName === UIControllerAttributes.MEDIA_CONTROLLER) {
+    if (attrName === MediaStateReceiverAttributes.MEDIA_CONTROLLER) {
       if (oldValue) {
         const mediaControllerEl = document.getElementById(oldValue);
         mediaControllerEl?.unassociateElement?.(this);
@@ -60,7 +60,7 @@ class MediaControlBar extends window.HTMLElement {
 
   connectedCallback() {
     const mediaControllerId = this.getAttribute(
-      UIControllerAttributes.MEDIA_CONTROLLER
+      MediaStateReceiverAttributes.MEDIA_CONTROLLER
     );
     if (mediaControllerId) {
       const mediaControllerEl = document.getElementById(mediaControllerId);
@@ -70,7 +70,7 @@ class MediaControlBar extends window.HTMLElement {
 
   disconnectedCallback() {
     const mediaControllerId = this.getAttribute(
-      UIControllerAttributes.MEDIA_CONTROLLER
+      MediaStateReceiverAttributes.MEDIA_CONTROLLER
     );
     if (mediaControllerId) {
       const mediaControllerEl = document.getElementById(mediaControllerId);

--- a/src/js/media-control-bar.js
+++ b/src/js/media-control-bar.js
@@ -3,7 +3,7 @@
 
   Auto position contorls in a line and set some base colors
 */
-import { MediaUIAttributes } from './constants.js';
+import { UIControllerAttributes } from './constants.js';
 import { defineCustomElement } from './utils/defineCustomElement.js';
 import {
   Window as window,
@@ -35,7 +35,7 @@ template.innerHTML = `
 
 class MediaControlBar extends window.HTMLElement {
   static get observedAttributes() {
-    return [MediaUIAttributes.MEDIA_CONTROLLER];
+    return [UIControllerAttributes.MEDIA_CONTROLLER];
   }
 
   constructor() {
@@ -46,7 +46,7 @@ class MediaControlBar extends window.HTMLElement {
   }
 
   attributeChangedCallback(attrName, oldValue, newValue) {
-    if (attrName === MediaUIAttributes.MEDIA_CONTROLLER) {
+    if (attrName === UIControllerAttributes.MEDIA_CONTROLLER) {
       if (oldValue) {
         const mediaControllerEl = document.getElementById(oldValue);
         mediaControllerEl?.unassociateElement?.(this);
@@ -60,7 +60,7 @@ class MediaControlBar extends window.HTMLElement {
 
   connectedCallback() {
     const mediaControllerId = this.getAttribute(
-      MediaUIAttributes.MEDIA_CONTROLLER
+      UIControllerAttributes.MEDIA_CONTROLLER
     );
     if (mediaControllerId) {
       const mediaControllerEl = document.getElementById(mediaControllerId);
@@ -70,7 +70,7 @@ class MediaControlBar extends window.HTMLElement {
 
   disconnectedCallback() {
     const mediaControllerId = this.getAttribute(
-      MediaUIAttributes.MEDIA_CONTROLLER
+      UIControllerAttributes.MEDIA_CONTROLLER
     );
     if (mediaControllerId) {
       const mediaControllerEl = document.getElementById(mediaControllerId);

--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -22,7 +22,7 @@ import { toggleSubsCaps } from './utils/captions.js';
 import {
   MediaUIEvents,
   MediaUIAttributes,
-  UIControllerAttributes,
+  MediaStateReceiverAttributes,
   TextTrackKinds,
   TextTrackModes,
   AvailabilityStates,
@@ -1047,7 +1047,7 @@ const getMediaUIAttributesFrom = (child) => {
   }
 
   const mediaChromeAttributesList = child
-    ?.getAttribute?.(UIControllerAttributes.MEDIA_CHROME_ATTRIBUTES)
+    ?.getAttribute?.(MediaStateReceiverAttributes.MEDIA_CHROME_ATTRIBUTES)
     ?.split?.(/\s+/);
   if (!Array.isArray(observedAttributes || mediaChromeAttributesList))
     return [];
@@ -1210,7 +1210,7 @@ const monitorForMediaStateReceivers = (
         );
       } else if (
         type === 'attributes' &&
-        attributeName === UIControllerAttributes.MEDIA_CHROME_ATTRIBUTES
+        attributeName === MediaStateReceiverAttributes.MEDIA_CHROME_ATTRIBUTES
       ) {
         if (isMediaStateReceiver(target)) {
           // Changed from a "non-Media State Receiver" to a Media State Receiver: register it.

--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -22,6 +22,7 @@ import { toggleSubsCaps } from './utils/captions.js';
 import {
   MediaUIEvents,
   MediaUIAttributes,
+  UIControllerAttributes,
   TextTrackKinds,
   TextTrackModes,
   AvailabilityStates,
@@ -1046,7 +1047,7 @@ const getMediaUIAttributesFrom = (child) => {
   }
 
   const mediaChromeAttributesList = child
-    ?.getAttribute?.(MediaUIAttributes.MEDIA_CHROME_ATTRIBUTES)
+    ?.getAttribute?.(UIControllerAttributes.MEDIA_CHROME_ATTRIBUTES)
     ?.split?.(/\s+/);
   if (!Array.isArray(observedAttributes || mediaChromeAttributesList))
     return [];
@@ -1209,7 +1210,7 @@ const monitorForMediaStateReceivers = (
         );
       } else if (
         type === 'attributes' &&
-        attributeName === MediaUIAttributes.MEDIA_CHROME_ATTRIBUTES
+        attributeName === UIControllerAttributes.MEDIA_CHROME_ATTRIBUTES
       ) {
         if (isMediaStateReceiver(target)) {
           // Changed from a "non-Media State Receiver" to a Media State Receiver: register it.

--- a/src/js/media-gesture-receiver.js
+++ b/src/js/media-gesture-receiver.js
@@ -1,7 +1,7 @@
 import {
   MediaUIAttributes,
   MediaUIEvents,
-  UIControllerAttributes,
+  MediaStateReceiverAttributes,
   PointerTypes
 } from './constants.js';
 import { defineCustomElement } from './utils/defineCustomElement.js';
@@ -26,7 +26,7 @@ class MediaGestureReceiver extends window.HTMLElement {
   // NOTE: Currently "baking in" actions + attrs until we come up with
   // a more robust architecture (CJP)
   static get observedAttributes() {
-    return [UIControllerAttributes.MEDIA_CONTROLLER, MediaUIAttributes.MEDIA_PAUSED];
+    return [MediaStateReceiverAttributes.MEDIA_CONTROLLER, MediaUIAttributes.MEDIA_PAUSED];
   }
 
   constructor(options = {}) {
@@ -50,7 +50,7 @@ class MediaGestureReceiver extends window.HTMLElement {
   }
 
   attributeChangedCallback(attrName, oldValue, newValue) {
-    if (attrName === UIControllerAttributes.MEDIA_CONTROLLER) {
+    if (attrName === MediaStateReceiverAttributes.MEDIA_CONTROLLER) {
       if (oldValue) {
         const mediaControllerEl = document.getElementById(oldValue);
         mediaControllerEl?.unassociateElement?.(this);
@@ -67,7 +67,7 @@ class MediaGestureReceiver extends window.HTMLElement {
     this.setAttribute('aria-hidden', true);
 
     const mediaControllerEl = getMediaControllerEl(this);
-    if (this.getAttribute(UIControllerAttributes.MEDIA_CONTROLLER)) {
+    if (this.getAttribute(MediaStateReceiverAttributes.MEDIA_CONTROLLER)) {
       mediaControllerEl?.associateElement?.(this);
     }
 
@@ -77,7 +77,7 @@ class MediaGestureReceiver extends window.HTMLElement {
 
   disconnectedCallback() {
     const mediaControllerEl = getMediaControllerEl(this);
-    if (this.getAttribute(UIControllerAttributes.MEDIA_CONTROLLER)) {
+    if (this.getAttribute(MediaStateReceiverAttributes.MEDIA_CONTROLLER)) {
       mediaControllerEl?.unassociateElement?.(this);
     }
 
@@ -147,7 +147,7 @@ class MediaGestureReceiver extends window.HTMLElement {
 
 function getMediaControllerEl(controlEl) {
   const mediaControllerId = controlEl.getAttribute(
-    UIControllerAttributes.MEDIA_CONTROLLER
+    MediaStateReceiverAttributes.MEDIA_CONTROLLER
   );
   if (mediaControllerId) {
     return document.getElementById(mediaControllerId);

--- a/src/js/media-gesture-receiver.js
+++ b/src/js/media-gesture-receiver.js
@@ -1,4 +1,9 @@
-import { MediaUIAttributes, MediaUIEvents, PointerTypes } from './constants.js';
+import {
+  MediaUIAttributes,
+  MediaUIEvents,
+  UIControllerAttributes,
+  PointerTypes
+} from './constants.js';
 import { defineCustomElement } from './utils/defineCustomElement.js';
 import { closestComposedNode } from './utils/element-utils.js';
 import {
@@ -21,7 +26,7 @@ class MediaGestureReceiver extends window.HTMLElement {
   // NOTE: Currently "baking in" actions + attrs until we come up with
   // a more robust architecture (CJP)
   static get observedAttributes() {
-    return [MediaUIAttributes.MEDIA_CONTROLLER, MediaUIAttributes.MEDIA_PAUSED];
+    return [UIControllerAttributes.MEDIA_CONTROLLER, MediaUIAttributes.MEDIA_PAUSED];
   }
 
   constructor(options = {}) {
@@ -45,7 +50,7 @@ class MediaGestureReceiver extends window.HTMLElement {
   }
 
   attributeChangedCallback(attrName, oldValue, newValue) {
-    if (attrName === MediaUIAttributes.MEDIA_CONTROLLER) {
+    if (attrName === UIControllerAttributes.MEDIA_CONTROLLER) {
       if (oldValue) {
         const mediaControllerEl = document.getElementById(oldValue);
         mediaControllerEl?.unassociateElement?.(this);
@@ -62,7 +67,7 @@ class MediaGestureReceiver extends window.HTMLElement {
     this.setAttribute('aria-hidden', true);
 
     const mediaControllerEl = getMediaControllerEl(this);
-    if (this.getAttribute(MediaUIAttributes.MEDIA_CONTROLLER)) {
+    if (this.getAttribute(UIControllerAttributes.MEDIA_CONTROLLER)) {
       mediaControllerEl?.associateElement?.(this);
     }
 
@@ -72,7 +77,7 @@ class MediaGestureReceiver extends window.HTMLElement {
 
   disconnectedCallback() {
     const mediaControllerEl = getMediaControllerEl(this);
-    if (this.getAttribute(MediaUIAttributes.MEDIA_CONTROLLER)) {
+    if (this.getAttribute(UIControllerAttributes.MEDIA_CONTROLLER)) {
       mediaControllerEl?.unassociateElement?.(this);
     }
 
@@ -142,7 +147,7 @@ class MediaGestureReceiver extends window.HTMLElement {
 
 function getMediaControllerEl(controlEl) {
   const mediaControllerId = controlEl.getAttribute(
-    MediaUIAttributes.MEDIA_CONTROLLER
+    UIControllerAttributes.MEDIA_CONTROLLER
   );
   if (mediaControllerId) {
     return document.getElementById(mediaControllerId);

--- a/src/js/media-loading-indicator.js
+++ b/src/js/media-loading-indicator.js
@@ -1,4 +1,4 @@
-import { MediaUIAttributes } from './constants.js';
+import { MediaUIAttributes, UIControllerAttributes } from './constants.js';
 import { nouns } from './labels/labels.js';
 import { defineCustomElement } from './utils/defineCustomElement.js';
 import {
@@ -70,7 +70,7 @@ const DEFAULT_LOADING_DELAY = 500;
 class MediaLoadingIndicator extends window.HTMLElement {
   static get observedAttributes() {
     return [
-      MediaUIAttributes.MEDIA_CONTROLLER,
+      UIControllerAttributes.MEDIA_CONTROLLER,
       MediaUIAttributes.MEDIA_PAUSED,
       MediaUIAttributes.MEDIA_LOADING,
       'loading-delay',
@@ -110,7 +110,7 @@ class MediaLoadingIndicator extends window.HTMLElement {
           this.loadingDelayHandle = undefined;
         }, loadingDelay);
       }
-    } else if (attrName === MediaUIAttributes.MEDIA_CONTROLLER) {
+    } else if (attrName === UIControllerAttributes.MEDIA_CONTROLLER) {
       if (oldValue) {
         const mediaControllerEl = document.getElementById(oldValue);
         mediaControllerEl?.unassociateElement?.(this);
@@ -124,7 +124,7 @@ class MediaLoadingIndicator extends window.HTMLElement {
 
   connectedCallback() {
     const mediaControllerId = this.getAttribute(
-      MediaUIAttributes.MEDIA_CONTROLLER
+      UIControllerAttributes.MEDIA_CONTROLLER
     );
     if (mediaControllerId) {
       const mediaControllerEl = document.getElementById(mediaControllerId);
@@ -138,7 +138,7 @@ class MediaLoadingIndicator extends window.HTMLElement {
       this.loadingDelayHandle = undefined;
     }
     const mediaControllerId = this.getAttribute(
-      MediaUIAttributes.MEDIA_CONTROLLER
+      UIControllerAttributes.MEDIA_CONTROLLER
     );
     if (mediaControllerId) {
       const mediaControllerEl = document.getElementById(mediaControllerId);

--- a/src/js/media-loading-indicator.js
+++ b/src/js/media-loading-indicator.js
@@ -1,4 +1,4 @@
-import { MediaUIAttributes, UIControllerAttributes } from './constants.js';
+import { MediaUIAttributes, MediaStateReceiverAttributes } from './constants.js';
 import { nouns } from './labels/labels.js';
 import { defineCustomElement } from './utils/defineCustomElement.js';
 import {
@@ -70,7 +70,7 @@ const DEFAULT_LOADING_DELAY = 500;
 class MediaLoadingIndicator extends window.HTMLElement {
   static get observedAttributes() {
     return [
-      UIControllerAttributes.MEDIA_CONTROLLER,
+      MediaStateReceiverAttributes.MEDIA_CONTROLLER,
       MediaUIAttributes.MEDIA_PAUSED,
       MediaUIAttributes.MEDIA_LOADING,
       'loading-delay',
@@ -110,7 +110,7 @@ class MediaLoadingIndicator extends window.HTMLElement {
           this.loadingDelayHandle = undefined;
         }, loadingDelay);
       }
-    } else if (attrName === UIControllerAttributes.MEDIA_CONTROLLER) {
+    } else if (attrName === MediaStateReceiverAttributes.MEDIA_CONTROLLER) {
       if (oldValue) {
         const mediaControllerEl = document.getElementById(oldValue);
         mediaControllerEl?.unassociateElement?.(this);
@@ -124,7 +124,7 @@ class MediaLoadingIndicator extends window.HTMLElement {
 
   connectedCallback() {
     const mediaControllerId = this.getAttribute(
-      UIControllerAttributes.MEDIA_CONTROLLER
+      MediaStateReceiverAttributes.MEDIA_CONTROLLER
     );
     if (mediaControllerId) {
       const mediaControllerEl = document.getElementById(mediaControllerId);
@@ -138,7 +138,7 @@ class MediaLoadingIndicator extends window.HTMLElement {
       this.loadingDelayHandle = undefined;
     }
     const mediaControllerId = this.getAttribute(
-      UIControllerAttributes.MEDIA_CONTROLLER
+      MediaStateReceiverAttributes.MEDIA_CONTROLLER
     );
     if (mediaControllerId) {
       const mediaControllerEl = document.getElementById(mediaControllerId);

--- a/src/js/media-preview-thumbnail.js
+++ b/src/js/media-preview-thumbnail.js
@@ -9,7 +9,7 @@ import {
   Document as document,
 } from './utils/server-safe-globals.js';
 import { defineCustomElement } from './utils/defineCustomElement.js';
-import { MediaUIAttributes } from './constants.js';
+import { MediaUIAttributes, UIControllerAttributes } from './constants.js';
 import { getOrInsertCSSRule } from './utils/element-utils.js';
 
 const template = document.createElement('template');
@@ -32,7 +32,7 @@ template.innerHTML = `
 class MediaPreviewThumbnail extends window.HTMLElement {
   static get observedAttributes() {
     return [
-      MediaUIAttributes.MEDIA_CONTROLLER,
+      UIControllerAttributes.MEDIA_CONTROLLER,
       'time',
       MediaUIAttributes.MEDIA_PREVIEW_IMAGE,
       MediaUIAttributes.MEDIA_PREVIEW_COORDS,
@@ -48,7 +48,7 @@ class MediaPreviewThumbnail extends window.HTMLElement {
 
   connectedCallback() {
     const mediaControllerId = this.getAttribute(
-      MediaUIAttributes.MEDIA_CONTROLLER
+      UIControllerAttributes.MEDIA_CONTROLLER
     );
     if (mediaControllerId) {
       const mediaControllerEl = document.getElementById(mediaControllerId);
@@ -58,7 +58,7 @@ class MediaPreviewThumbnail extends window.HTMLElement {
 
   disconnectedCallback() {
     const mediaControllerId = this.getAttribute(
-      MediaUIAttributes.MEDIA_CONTROLLER
+      UIControllerAttributes.MEDIA_CONTROLLER
     );
     if (mediaControllerId) {
       const mediaControllerEl = document.getElementById(mediaControllerId);
@@ -76,7 +76,7 @@ class MediaPreviewThumbnail extends window.HTMLElement {
     ) {
       this.update();
     }
-    if (attrName === MediaUIAttributes.MEDIA_CONTROLLER) {
+    if (attrName === UIControllerAttributes.MEDIA_CONTROLLER) {
       if (oldValue) {
         const mediaControllerEl = document.getElementById(oldValue);
         mediaControllerEl?.unassociateElement?.(this);

--- a/src/js/media-preview-thumbnail.js
+++ b/src/js/media-preview-thumbnail.js
@@ -9,7 +9,7 @@ import {
   Document as document,
 } from './utils/server-safe-globals.js';
 import { defineCustomElement } from './utils/defineCustomElement.js';
-import { MediaUIAttributes, UIControllerAttributes } from './constants.js';
+import { MediaUIAttributes, MediaStateReceiverAttributes } from './constants.js';
 import { getOrInsertCSSRule } from './utils/element-utils.js';
 
 const template = document.createElement('template');
@@ -32,7 +32,7 @@ template.innerHTML = `
 class MediaPreviewThumbnail extends window.HTMLElement {
   static get observedAttributes() {
     return [
-      UIControllerAttributes.MEDIA_CONTROLLER,
+      MediaStateReceiverAttributes.MEDIA_CONTROLLER,
       'time',
       MediaUIAttributes.MEDIA_PREVIEW_IMAGE,
       MediaUIAttributes.MEDIA_PREVIEW_COORDS,
@@ -48,7 +48,7 @@ class MediaPreviewThumbnail extends window.HTMLElement {
 
   connectedCallback() {
     const mediaControllerId = this.getAttribute(
-      UIControllerAttributes.MEDIA_CONTROLLER
+      MediaStateReceiverAttributes.MEDIA_CONTROLLER
     );
     if (mediaControllerId) {
       const mediaControllerEl = document.getElementById(mediaControllerId);
@@ -58,7 +58,7 @@ class MediaPreviewThumbnail extends window.HTMLElement {
 
   disconnectedCallback() {
     const mediaControllerId = this.getAttribute(
-      UIControllerAttributes.MEDIA_CONTROLLER
+      MediaStateReceiverAttributes.MEDIA_CONTROLLER
     );
     if (mediaControllerId) {
       const mediaControllerEl = document.getElementById(mediaControllerId);
@@ -76,7 +76,7 @@ class MediaPreviewThumbnail extends window.HTMLElement {
     ) {
       this.update();
     }
-    if (attrName === UIControllerAttributes.MEDIA_CONTROLLER) {
+    if (attrName === MediaStateReceiverAttributes.MEDIA_CONTROLLER) {
       if (oldValue) {
         const mediaControllerEl = document.getElementById(oldValue);
         mediaControllerEl?.unassociateElement?.(this);

--- a/src/js/media-text-display.js
+++ b/src/js/media-text-display.js
@@ -1,4 +1,4 @@
-import { MediaUIAttributes } from './constants.js';
+import { UIControllerAttributes } from './constants.js';
 import { defineCustomElement } from './utils/defineCustomElement.js';
 import {
   Window as window,
@@ -52,7 +52,7 @@ template.innerHTML = `
 
 class MediaTextDisplay extends window.HTMLElement {
   static get observedAttributes() {
-    return [MediaUIAttributes.MEDIA_CONTROLLER];
+    return [UIControllerAttributes.MEDIA_CONTROLLER];
   }
 
   constructor() {
@@ -64,7 +64,7 @@ class MediaTextDisplay extends window.HTMLElement {
   }
 
   attributeChangedCallback(attrName, oldValue, newValue) {
-    if (attrName === MediaUIAttributes.MEDIA_CONTROLLER) {
+    if (attrName === UIControllerAttributes.MEDIA_CONTROLLER) {
       if (oldValue) {
         const mediaControllerEl = document.getElementById(oldValue);
         mediaControllerEl?.unassociateElement?.(this);
@@ -78,7 +78,7 @@ class MediaTextDisplay extends window.HTMLElement {
 
   connectedCallback() {
     const mediaControllerId = this.getAttribute(
-      MediaUIAttributes.MEDIA_CONTROLLER
+      UIControllerAttributes.MEDIA_CONTROLLER
     );
     if (mediaControllerId) {
       const mediaControllerEl = document.getElementById(mediaControllerId);
@@ -88,7 +88,7 @@ class MediaTextDisplay extends window.HTMLElement {
 
   disconnectedCallback() {
     const mediaControllerId = this.getAttribute(
-      MediaUIAttributes.MEDIA_CONTROLLER
+      UIControllerAttributes.MEDIA_CONTROLLER
     );
     if (mediaControllerId) {
       const mediaControllerEl = document.getElementById(mediaControllerId);

--- a/src/js/media-text-display.js
+++ b/src/js/media-text-display.js
@@ -1,4 +1,4 @@
-import { UIControllerAttributes } from './constants.js';
+import { MediaStateReceiverAttributes } from './constants.js';
 import { defineCustomElement } from './utils/defineCustomElement.js';
 import {
   Window as window,
@@ -52,7 +52,7 @@ template.innerHTML = `
 
 class MediaTextDisplay extends window.HTMLElement {
   static get observedAttributes() {
-    return [UIControllerAttributes.MEDIA_CONTROLLER];
+    return [MediaStateReceiverAttributes.MEDIA_CONTROLLER];
   }
 
   constructor() {
@@ -64,7 +64,7 @@ class MediaTextDisplay extends window.HTMLElement {
   }
 
   attributeChangedCallback(attrName, oldValue, newValue) {
-    if (attrName === UIControllerAttributes.MEDIA_CONTROLLER) {
+    if (attrName === MediaStateReceiverAttributes.MEDIA_CONTROLLER) {
       if (oldValue) {
         const mediaControllerEl = document.getElementById(oldValue);
         mediaControllerEl?.unassociateElement?.(this);
@@ -78,7 +78,7 @@ class MediaTextDisplay extends window.HTMLElement {
 
   connectedCallback() {
     const mediaControllerId = this.getAttribute(
-      UIControllerAttributes.MEDIA_CONTROLLER
+      MediaStateReceiverAttributes.MEDIA_CONTROLLER
     );
     if (mediaControllerId) {
       const mediaControllerEl = document.getElementById(mediaControllerId);
@@ -88,7 +88,7 @@ class MediaTextDisplay extends window.HTMLElement {
 
   disconnectedCallback() {
     const mediaControllerId = this.getAttribute(
-      UIControllerAttributes.MEDIA_CONTROLLER
+      MediaStateReceiverAttributes.MEDIA_CONTROLLER
     );
     if (mediaControllerId) {
       const mediaControllerEl = document.getElementById(mediaControllerId);


### PR DESCRIPTION
Fixes #366 

The media-controller attribute on UI components stopped working at some point, and it appears to be because the attribute was being lumped in with all the state attributes. I think that was having a few weird side effects, but the result was the button's media-controller attribute was getting reset to nothing by the media controller, then causing the button to unregister itself from the media controller (which was only half working. The play request event was still working after being unregistered. So something maybe worth digging more into).