### PR TITLE
fix: add a way to package media themes as web comp

### DIFF
--- a/src/js/themes/media-theme-netflix.js
+++ b/src/js/themes/media-theme-netflix.js
@@ -8,9 +8,10 @@
 */
 
 import { defineCustomElement } from '../utils/defineCustomElement.js';
-import MediaTheme from './media-theme.js';
+import { MediaThemeElement } from '../media-theme-element.js';
 
-const template = `
+const template = document.createElement('template');
+template.innerHTML = `
 <style>
   :host {
     display: inline-block;
@@ -133,7 +134,7 @@ const template = `
 </media-controller>
 `;
 
-class MediaThemeNetflix extends MediaTheme {
+class MediaThemeNetflix extends MediaThemeElement {
   static template = template;
 }
 


### PR DESCRIPTION
Similar to @heff 's comment https://github.com/muxinc/media-chrome/pull/362#discussion_r1034168845

I think maybe an extends makes sense here with a static `template` property.

