### PR TITLE
media-chrome-menu-button

### DIFF
--- a/examples/control-elements/media-captions-listbox.html
+++ b/examples/control-elements/media-captions-listbox.html
@@ -40,16 +40,16 @@
         muted
         crossorigin
       >
-        <track label="English" kind="captions" srclang="en" src="./vtt/elephantsdream/captions.en.vtt" default></track>
-        <track label="Japanese" kind="captions" srclang="ja" src="./vtt/elephantsdream/captions.ja.vtt"></track>
-        <track label="Swedish" kind="captions" srclang="sv" src="./vtt/elephantsdream/captions.sv.vtt"></track>
-        <track label="Russian" kind="captions" srclang="ru" src="./vtt/elephantsdream/captions.ru.vtt"></track>
-        <track label="Arabic" kind="captions" srclang="ar" src="./vtt/elephantsdream/captions.ar.vtt"></track>
-        <track label="Subs English" kind="subtitles" srclang="en" src="./vtt/elephantsdream/captions.en.vtt" default></track>
-        <track label="Subs Japanese" kind="subtitles" srclang="ja" src="./vtt/elephantsdream/captions.ja.vtt"></track>
-        <track label="Subs Swedish" kind="subtitles" srclang="sv" src="./vtt/elephantsdream/captions.sv.vtt"></track>
-        <track label="Subs Russian" kind="subtitles" srclang="ru" src="./vtt/elephantsdream/captions.ru.vtt"></track>
-        <track label="Subs Arabic" kind="subtitles" srclang="ar" src="./vtt/elephantsdream/captions.ar.vtt"></track>
+        <track label="English" kind="captions" srclang="en" src="../vtt/elephantsdream/captions.en.vtt" default></track>
+        <track label="Japanese" kind="captions" srclang="ja" src="../vtt/elephantsdream/captions.ja.vtt"></track>
+        <track label="Swedish" kind="captions" srclang="sv" src="../vtt/elephantsdream/captions.sv.vtt"></track>
+        <track label="Russian" kind="captions" srclang="ru" src="../vtt/elephantsdream/captions.ru.vtt"></track>
+        <track label="Arabic" kind="captions" srclang="ar" src="../vtt/elephantsdream/captions.ar.vtt"></track>
+        <track label="Subs English" kind="subtitles" srclang="en" src="../vtt/elephantsdream/captions.en.vtt" default></track>
+        <track label="Subs Japanese" kind="subtitles" srclang="ja" src="../vtt/elephantsdream/captions.ja.vtt"></track>
+        <track label="Subs Swedish" kind="subtitles" srclang="sv" src="../vtt/elephantsdream/captions.sv.vtt"></track>
+        <track label="Subs Russian" kind="subtitles" srclang="ru" src="../vtt/elephantsdream/captions.ru.vtt"></track>
+        <track label="Subs Arabic" kind="subtitles" srclang="ar" src="../vtt/elephantsdream/captions.ar.vtt"></track>
       </video>
       <media-control-bar>
         <media-play-button></media-play-button>

--- a/examples/control-elements/media-chrome-listbox.html
+++ b/examples/control-elements/media-chrome-listbox.html
@@ -59,7 +59,7 @@
         <option>moo</option>
       </select>
       <div class="examples">
-        <a href="./">View more examples</a>
+        <a href="../">View more examples</a>
       </div>
     </main>
   </body>

--- a/examples/control-elements/media-chrome-menu-button.html
+++ b/examples/control-elements/media-chrome-menu-button.html
@@ -7,6 +7,7 @@
   <script type="module" src="../../../dist/media-chrome-listbox.js"></script>
   <script type="module" src="../../../dist/media-chrome-listitem.js"></script>
   <script type="module" src="../../../dist/media-captions-listbox.js"></script>
+  <script type="module" src="../../../dist/media-chrome-menu-button.js"></script>
   <style>
     media-captions-listbox {
       display: block;
@@ -31,7 +32,24 @@
 <body>
   <main>
     <h1>Media Chrome Standard Video Usage Example</h1>
-    <media-captions-listbox title="Captions & Subtitles List" media-controller="mc" ></media-captions-listbox>
+    <media-chrome-menu-button>
+      <media-chrome-listitem>lorem</media-chrome-listitem>
+      <media-chrome-listitem>ipsum</media-chrome-listitem>
+      <media-chrome-listitem>dolor</media-chrome-listitem>
+      <media-chrome-listitem>sit</media-chrome-listitem>
+    </media-chrome-menu-button>
+
+    <br>
+
+    <media-chrome-menu-button aria-label="captions menu button">
+      <svg slot="button-content" aria-hidden="true" viewBox="0 0 26 24">
+        <path d="M22.83 5.68a2.58 2.58 0 0 0-2.3-2.5c-3.62-.24-11.44-.24-15.06 0a2.58 2.58 0 0 0-2.3 2.5c-.23 4.21-.23 8.43 0 12.64a2.58 2.58 0 0 0 2.3 2.5c3.62.24 11.44.24 15.06 0a2.58 2.58 0 0 0 2.3-2.5c.23-4.21.23-8.43 0-12.64Zm-11.39 9.45a3.07 3.07 0 0 1-1.91.57 3.06 3.06 0 0 1-2.34-1 3.75 3.75 0 0 1-.92-2.67 3.92 3.92 0 0 1 .92-2.77 3.18 3.18 0 0 1 2.43-1 2.94 2.94 0 0 1 2.13.78c.364.359.62.813.74 1.31l-1.43.35a1.49 1.49 0 0 0-1.51-1.17 1.61 1.61 0 0 0-1.29.58 2.79 2.79 0 0 0-.5 1.89 3 3 0 0 0 .49 1.93 1.61 1.61 0 0 0 1.27.58 1.48 1.48 0 0 0 1-.37 2.1 2.1 0 0 0 .59-1.14l1.4.44a3.23 3.23 0 0 1-1.07 1.69Zm7.22 0a3.07 3.07 0 0 1-1.91.57 3.06 3.06 0 0 1-2.34-1 3.75 3.75 0 0 1-.92-2.67 3.88 3.88 0 0 1 .93-2.77 3.14 3.14 0 0 1 2.42-1 3 3 0 0 1 2.16.82 2.8 2.8 0 0 1 .73 1.31l-1.43.35a1.49 1.49 0 0 0-1.51-1.21 1.61 1.61 0 0 0-1.29.58A2.79 2.79 0 0 0 15 12a3 3 0 0 0 .49 1.93 1.61 1.61 0 0 0 1.27.58 1.44 1.44 0 0 0 1-.37 2.1 2.1 0 0 0 .6-1.15l1.4.44a3.17 3.17 0 0 1-1.1 1.7Z"/>
+      </svg>
+      <media-captions-listbox slot="listbox" media-controller="mc"></media-captions-listbox>
+    </media-chrome-menu-button>
+
+    <br>
+
     <media-controller id="mc">
       <video
         slot="media"

--- a/examples/index.html
+++ b/examples/index.html
@@ -15,6 +15,7 @@
       <li><a href="vertical.html">Vertical video example</a></li>
       <li><a href="casting.html">Casting video example</a></li>
       <li><a href="standalone-controls.html">Standalone controls</a></li>
+      <li><a href="disabled.html">Disabled controls</a></li>
       <li>
         <a href="slots-demo.html"
           >Understanding <code>&lt;media-controller/&gt;</code> slots</a
@@ -69,6 +70,9 @@
       </li>
       <li>
         <a href="control-elements/media-captions-listbox.html">Captions List</a>
+      </li>
+      <li>
+        <a href="control-elements/media-chrome-menu-button.html">Menu Button</a>
       </li>
       <li>
         <a href="https://www.media-chrome.org/en/media-play-button">

--- a/src/js/media-chrome-listbox.js
+++ b/src/js/media-chrome-listbox.js
@@ -68,6 +68,7 @@ class MediaChromeListbox extends window.HTMLElement {
 
       if (elToSelect) {
         elToSelect.setAttribute('tabindex', 0);
+        elToSelect.setAttribute('aria-selected', 'true');
       }
     });
   }

--- a/src/js/media-chrome-listbox.js
+++ b/src/js/media-chrome-listbox.js
@@ -66,7 +66,9 @@ class MediaChromeListbox extends window.HTMLElement {
         elToSelect = els[0];
       }
 
-      elToSelect.setAttribute('tabindex', 0);
+      if (elToSelect) {
+        elToSelect.setAttribute('tabindex', 0);
+      }
     });
   }
 

--- a/src/js/media-chrome-listbox.js
+++ b/src/js/media-chrome-listbox.js
@@ -42,6 +42,11 @@ class MediaChromeListbox extends window.HTMLElement {
 
     this.#slot.addEventListener('slotchange', () => {
       this.#assignedElements = this.#slot.assignedElements();
+
+      if (this.#assignedElements.length === 1 && this.#assignedElements[0].nodeName.toLowerCase() === 'slot') {
+        this.#assignedElements = this.#assignedElements[0].assignedElements();
+      }
+
       const els = this.#items;
       const activeEls = els.some(el => el.getAttribute('tabindex') === '0');
 

--- a/src/js/media-chrome-listbox.js
+++ b/src/js/media-chrome-listbox.js
@@ -13,7 +13,7 @@ template.innerHTML = `
     list-style: none;
   }
 </style>
-<ul tabindex="0" role="listbox">
+<ul tabindex="0">
   <slot></slot>
 </ul>
 `;
@@ -79,6 +79,10 @@ class MediaChromeListbox extends window.HTMLElement {
 
   get selectedOptions() {
     return this.#items.filter(el => el.getAttribute('aria-selected') === 'true');
+  }
+
+  focus() {
+    this.selectedOptions[0]?.focus();
   }
 
   #clickListener = (e) => {

--- a/src/js/media-chrome-menu-button.js
+++ b/src/js/media-chrome-menu-button.js
@@ -1,0 +1,156 @@
+import './media-chrome-button.js';
+import './media-chrome-listbox.js';
+import { defineCustomElement } from './utils/defineCustomElement.js';
+import { Window as window, Document as document } from './utils/server-safe-globals.js';
+import { MediaStateReceiverAttributes } from './constants.js';
+
+const template = document.createElement('template');
+template.innerHTML = `
+  <style>
+  :host {
+    display: block;
+  }
+
+  media-chrome-button:not(:focus-visible) {
+    outline: none;
+  }
+  </style>
+
+  <media-chrome-button aria-haspopup="listbox">
+    <slot name="button-content"></slot>
+  </media-chrome-button>
+  <slot name="listbox" hidden>
+    <media-chrome-listbox id="listbox">
+      <slot></slot>
+    </media-chrome-listbox>
+  </slot>
+`;
+
+class MediaChromeMenuButton extends window.HTMLElement {
+  #handleClick;
+  #handleChange;
+  #button;
+  #listbox;
+  #listboxSlot;
+  #expanded = false;
+
+  static get observedAttributes() {
+    return [
+      'disabled', MediaStateReceiverAttributes.MEDIA_CONTROLLER,
+    ];
+  }
+
+  constructor() {
+    super();
+
+    const shadow = this.attachShadow({ mode: 'open' });
+
+    const buttonHTML = template.content.cloneNode(true);
+    this.nativeEl = buttonHTML;
+
+    shadow.appendChild(buttonHTML);
+
+    this.#handleClick = this.#handleClick_.bind(this);
+    this.#handleChange = this.#handleChange_.bind(this);
+
+    this.#button = this.shadowRoot.querySelector('media-chrome-button');
+    this.#listbox = this.shadowRoot.querySelector('media-chrome-listbox');
+
+    this.#listboxSlot = this.shadowRoot.querySelector('slot[name=listbox]');
+    this.#listboxSlot.addEventListener('slotchange', () => {
+      this.#listbox.removeEventListener('change', this.#handleChange);
+      // update listbox reference if necessary
+      this.#listbox = this.#listboxSlot.assignedElements()[0] || this.#listbox;
+      this.#listbox.addEventListener('change', this.#handleChange);
+    });
+  }
+
+  #handleClick_() {
+    this.#toggle();
+  }
+
+  #handleChange_() {
+    this.#toggle();
+  }
+
+  #toggle() {
+    this.#listboxSlot.hidden = !this.#listboxSlot.hidden;
+    this.#toggleExpanded();
+
+    if (!this.#listboxSlot.hidden) {
+      this.#listbox.focus();
+    } else {
+      this.#button.focus();
+    }
+  }
+
+  #toggleExpanded() {
+    this.#button.setAttribute('aria-expanded', this.#expanded);
+    this.#expanded = !this.#expanded;
+  }
+
+  enable() {
+    this.#button.handleClick = this.#handleClick;
+    this.#toggleExpanded()
+    this.#listbox.addEventListener('change', this.#handleChange);
+  }
+
+  disable() {
+    this.#button.handleClick = () => {};
+    this.#listbox.addEventListener('change', this.#handleChange);
+  }
+
+  attributeChangedCallback(attrName, oldValue, newValue) {
+    if (attrName === MediaStateReceiverAttributes.MEDIA_CONTROLLER) {
+      if (oldValue) {
+        const mediaControllerEl = document.getElementById(oldValue);
+        mediaControllerEl?.unassociateElement?.(this);
+        this.#listbox.removeAttribute(MediaStateReceiverAttributes.MEDIA_CONTROLLER);
+      }
+      if (newValue) {
+        const mediaControllerEl = document.getElementById(newValue);
+        mediaControllerEl?.associateElement?.(this);
+        this.#listbox.setAttribute(MediaStateReceiverAttributes.MEDIA_CONTROLLER, newValue);
+      }
+    } else if (attrName === 'disabled' && newValue !== oldValue) {
+      if (newValue == null) {
+        this.enable();
+      } else {
+        this.disable();
+      }
+    }
+  }
+
+  connectedCallback() {
+    if (!this.hasAttribute('disabled')) {
+      this.enable();
+    }
+
+    const mediaControllerId = this.getAttribute(
+      MediaStateReceiverAttributes.MEDIA_CONTROLLER
+    );
+    if (mediaControllerId) {
+      const mediaControllerEl = document.getElementById(mediaControllerId);
+      mediaControllerEl?.associateElement?.(this);
+      this.#listbox.setAttribute(MediaStateReceiverAttributes.MEDIA_CONTROLLER, mediaControllerId);
+    }
+  }
+
+  disconnectedCallback() {
+    this.disable();
+
+    const mediaControllerId = this.getAttribute(
+      MediaStateReceiverAttributes.MEDIA_CONTROLLER
+    );
+    if (mediaControllerId) {
+      const mediaControllerEl = document.getElementById(mediaControllerId);
+      mediaControllerEl?.unassociateElement?.(this);
+      this.#listbox.removeAttribute(MediaStateReceiverAttributes.MEDIA_CONTROLLER);
+    }
+  }
+
+}
+
+defineCustomElement('media-chrome-menu-button', MediaChromeMenuButton);
+
+export default MediaChromeMenuButton;


### PR DESCRIPTION
Adds a media-chrome-menu-button that mostly does what we expect. Not sure if menu-button is necessarily the best name, but it works. Happy to change it, though.

Usage:
```html
<media-chrome-menu-button aria-label="captions menu button">
  <svg slot="button-content" aria-hidden="true" viewBox="0 0 26 24"></svg>
  <media-captions-listbox slot="listbox" media-controller="mc"></media-captions-listbox>
</media-chrome-menu-button>
```

The next simple follow-up is a captions-menu-button that basically wraps up this above usage in a prepackaged component.
There's still some more follow up to do as per #387. With a new Off menu item, and to make it more accessible, we may want to update listbox to be able to be a role of menu instead of listbox with a listitem a role of menuitem over options.
Those things would be the immediate follow-ups, but I think we can still get this PR in with the caveat that things could change as we continue building this out.