### PR TITLE
feat: container-size attr w/ range naming

### DIFF
--- a/examples/responsive-attribute.html
+++ b/examples/responsive-attribute.html
@@ -11,7 +11,7 @@
 
       <p>This is an example of making Media Chrome responsive using the <code>media-container-size</code> attribute.</p>
 
-      <media-controller containerbreakpoints="s:0 sm:384 m:576 ml:960 l:1280 xl:1600">
+      <media-controller containerbreakpoints="xs:0 sm:384 md:576 lg:768 xl:960">
         <video
           slot="media"
           src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/high.mp4"
@@ -87,12 +87,11 @@ video {
  * It only shows the center controls and hides the bottom control bar.
  *
  */
-
-media-controller[media-container-size=s] .centered-controls-overlay {
+[media-container-size="xs"] .centered-controls-overlay {
   display: flex;
 }
 
-media-controller[media-container-size=s] media-control-bar {
+[media-container-size="xs"] media-control-bar {
   display: none;
 }
 
@@ -104,15 +103,15 @@ media-controller[media-container-size=s] media-control-bar {
  * room for the other buttons in the control bar.
  *
  */
-media-controller[media-container-size$=m] .centered-controls-overlay {
+[media-container-size="xs sm"] .centered-controls-overlay {
   display: flex;
 }
 
-media-controller[media-container-size$=m] media-control-bar {
+[media-container-size="xs sm"] media-control-bar {
   display: flex;
 }
 
-media-controller[media-container-size$=m] media-control-bar :is(
+[media-container-size="xs sm"] media-control-bar :is(
   media-play-button,
   media-seek-backward-button,
   media-seek-forward-button
@@ -122,18 +121,18 @@ media-controller[media-container-size$=m] media-control-bar :is(
 }
 
 /*
- * The default and large container size,
+ * The default and larger container size,
  * which will be selected when the container is greater than 576px wide.
  *
  * Since we have a default to hide the .centered-controls-overlay,
  * this query isn't strictly necessary but is included for the sake of completeness.
  *
  */
-media-controller[media-container-size*=l] .centered-controls-overlay {
+[media-container-size="xs sm md"] .centered-controls-overlay {
   display: none;
 }
 
-media-controller[media-container-size*=l] media-control-bar {
+[media-container-size="xs sm md"] media-control-bar {
   display: flex;
 }
 
@@ -194,6 +193,7 @@ style {
   white-space: pre;
   font-family: monospace;
   margin-left: 1em;
+  overflow-x: auto;
 }
       </style>
       <div class="examples">

--- a/examples/responsive-attribute.html
+++ b/examples/responsive-attribute.html
@@ -82,7 +82,7 @@ video {
 
 /*
  * Starting with the smallest container, this query will be selected
- * if the inline-size of the container is smaller than 396px.
+ * if the inline-size of the container is smaller than 384px.
  *
  * It only shows the center controls and hides the bottom control bar.
  *
@@ -97,7 +97,7 @@ media-controller[media-container-size=s] media-control-bar {
 }
 
 /*
- * The middle container size will be selected if the width is between 396px and 576px.
+ * The middle container size will be selected if the width is between 384px and 576px.
  *
  * Here, move the player toggle and the seek buttons from the bottom
  * control bar to the center controls section to give more breathing

--- a/examples/responsive-attribute.html
+++ b/examples/responsive-attribute.html
@@ -11,7 +11,7 @@
 
       <p>This is an example of making Media Chrome responsive using the <code>media-container-size</code> attribute.</p>
 
-      <media-controller containerbreakpoints="xs:0 sm:384 md:576 lg:768 xl:960">
+      <media-controller breakpoints="sm:384 md:576 lg:768 xl:960">
         <video
           slot="media"
           src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/high.mp4"
@@ -87,11 +87,11 @@ video {
  * It only shows the center controls and hides the bottom control bar.
  *
  */
-[media-container-size="xs"] .centered-controls-overlay {
+.centered-controls-overlay {
   display: flex;
 }
 
-[media-container-size="xs"] media-control-bar {
+media-control-bar {
   display: none;
 }
 
@@ -103,21 +103,20 @@ video {
  * room for the other buttons in the control bar.
  *
  */
-[media-container-size="xs sm"] .centered-controls-overlay {
+[breakpoint-sm] .centered-controls-overlay {
   display: flex;
 }
 
-[media-container-size="xs sm"] media-control-bar {
+[breakpoint-sm] media-control-bar {
   display: flex;
 }
 
-[media-container-size="xs sm"] media-control-bar :is(
+[breakpoint-sm] media-control-bar :is(
   media-play-button,
   media-seek-backward-button,
   media-seek-forward-button
 ) {
-    display: none;
-  }
+  display: none;
 }
 
 /*
@@ -128,11 +127,11 @@ video {
  * this query isn't strictly necessary but is included for the sake of completeness.
  *
  */
-[media-container-size="xs sm md"] .centered-controls-overlay {
+[breakpoint-md] .centered-controls-overlay {
   display: none;
 }
 
-[media-container-size="xs sm md"] media-control-bar {
+[breakpoint-md] media-control-bar {
   display: flex;
 }
 

--- a/examples/responsive-attribute.html
+++ b/examples/responsive-attribute.html
@@ -111,7 +111,7 @@ media-control-bar {
   display: flex;
 }
 
-[breakpoint-sm] media-control-bar :is(
+[breakpoint-sm]:not([breakpoint-md]) media-control-bar :is(
   media-play-button,
   media-seek-backward-button,
   media-seek-forward-button

--- a/examples/responsive-attribute.html
+++ b/examples/responsive-attribute.html
@@ -1,0 +1,204 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width" />
+    <title>Responsive Media Chrome Example</title>
+    <script type="module" src="../dist/index.js"></script>
+  </head>
+  <body>
+    <main>
+      <h1>Responsive Media Chrome Example</h1>
+
+      <p>This is an example of making Media Chrome responsive using the <code>media-container-size</code> attribute.</p>
+
+      <media-controller>
+        <video
+          slot="media"
+          src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/high.mp4"
+          muted
+          crossorigin="anonymous"
+          playsinline
+        >
+          <track
+            label="thumbnails"
+            default
+            kind="metadata"
+            src="https://image.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/storyboard.vtt"
+          />
+          <track
+            label="English"
+            kind="captions"
+            srclang="en"
+            src="./vtt/en-cc.vtt"
+          />
+        </video>
+        <media-poster-image
+          slot="poster"
+          src="https://image.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/thumbnail.jpg"
+          placeholder-src="data:image/jpeg;base64,/9j/2wBDAAUDBAQEAwUEBAQFBQUGBwwIBwcHBw8LCwkMEQ8SEhEPERETFhwXExQaFRERGCEYGh0dHx8fExciJCIeJBweHx7/2wBDAQUFBQcGBw4ICA4eFBEUHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh7/wAARCAASACADASIAAhEBAxEB/8QAGgABAAIDAQAAAAAAAAAAAAAAAAMEAgUGCP/EACkQAAEDAgMIAgMAAAAAAAAAAAEAAgMEBgUREgcUITFSkZTRQaEiscH/xAAYAQACAwAAAAAAAAAAAAAAAAAABQIDBv/EAB0RAAICAQUAAAAAAAAAAAAAAAABAgMFERUxwfD/2gAMAwEAAhEDEQA/AOZh2P2k/LOhq/Lf7VuPYvZxLQ6iqgXchvrxn9rpY7ojYCBU0IJ5HU3h9rU3NcGJVcVNJh2K4fDPTztlbm5reGRDhnxIzBPwkUc9RJ6dDHaLYojj2HWYeeH1nmSe1OzYXZJ54fW+ZJ7VeWrbO4SPuedpI/IOnB/TgsxJh4yIuGYu+TvAH9UXnafItWJmuTy1oZ0t7JoZ0t7Ii0InGhnS3smhnS3siIA//9k="
+        ></media-poster-image>
+        <media-loading-indicator media-loading slot="centered-chrome" no-auto-hide></media-loading-indicator>
+        <div slot="centered-chrome" class="centered-controls-overlay">
+          <media-seek-backward-button></media-seek-backward-button>
+          <media-play-button></media-play-button>
+          <media-seek-forward-button></media-seek-forward-button>
+        </div>
+        <media-control-bar>
+          <media-play-button></media-play-button>
+          <media-seek-backward-button seek-offset="15"></media-seek-backward-button>
+          <media-seek-forward-button seek-offset="15"></media-seek-forward-button>
+          <media-mute-button></media-mute-button>
+          <media-volume-range></media-volume-range>
+          <media-time-range></media-time-range>
+          <media-time-display show-duration remaining></media-time-display>
+          <media-captions-button default-showing></media-captions-button>
+          <media-playback-rate-button></media-playback-rate-button>
+          <media-pip-button></media-pip-button>
+          <media-fullscreen-button></media-fullscreen-button>
+          <media-airplay-button></media-airplay-button>
+        </media-control-bar>
+      </media-controller>
+
+      <p>
+        Below is the style tag for this page.
+        Take a look at the code comments that explain the usage.
+      </p>
+      <style>
+media-controller:not([audio]) {
+  display: block;
+  max-width: 1280px;
+  aspect-ratio: 16 / 9;
+}
+video {
+  width: 100%;
+}
+
+/*
+ * By default, we don't want the center controls to show up.
+ */
+.centered-controls-overlay {
+  display: none;
+}
+
+/*
+ * Starting with the smallest container, this query will be selected
+ * if the inline-size of the container is smaller than 396px.
+ *
+ * It only shows the center controls and hides the bottom control bar.
+ *
+ */
+
+media-controller[media-container-size=s] .centered-controls-overlay {
+  display: flex;
+}
+
+media-controller[media-container-size=s] media-control-bar {
+  display: none;
+}
+
+/*
+ * The middle container size will be selected if the width is between 396px and 576px.
+ *
+ * Here, move the player toggle and the seek buttons from the bottom
+ * control bar to the center controls section to give more breathing
+ * room for the other buttons in the control bar.
+ *
+ */
+media-controller[media-container-size$=m] .centered-controls-overlay {
+  display: flex;
+}
+
+media-controller[media-container-size$=m] media-control-bar {
+  display: flex;
+}
+
+media-controller[media-container-size$=m] media-control-bar :is(
+  media-play-button,
+  media-seek-backward-button,
+  media-seek-forward-button
+) {
+    display: none;
+  }
+}
+
+/*
+ * The default and large container size,
+ * which will be selected when the container is greater than 576px wide.
+ *
+ * Since we have a default to hide the .centered-controls-overlay,
+ * this query isn't strictly necessary but is included for the sake of completeness.
+ *
+ */
+media-controller[media-container-size*=l] .centered-controls-overlay {
+  display: none;
+}
+
+media-controller[media-container-size*=l] media-control-bar {
+  display: flex;
+}
+
+/*
+ * Some styles to make the center controls look nicer.
+ *
+ * Use :where here so that it doesn't override
+ * the centered-controls-overlay styles from above.
+ */
+:where(.centered-controls-overlay) {
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: center;
+  justify-content: space-evenly;
+}
+media-controller .centered-controls-overlay {
+  align-self: stretch;
+}
+[slot='centered-chrome'] {
+  margin: 0 15%;
+  --media-control-hover-background: none;
+  --media-control-background: none;
+}
+[slot='centered-chrome']:is(media-play-button, media-seek-backward-button, media-seek-forward-button) {
+  padding: 0px;
+}
+[slot='centered-chrome']media-play-button {
+  width: 20%;
+}
+[slot='centered-chrome']:is(media-seek-backward-button, media-seek-forward-button) {
+  width: 15%;
+}
+
+/*
+ * Make the loading spinner take up the entire player size and not
+ * interfere with the center controls by setting position to absolute.
+ */
+media-loading-indicator {
+  position: absolute;
+  inset: 0;
+}
+
+/*
+ * Hide unavailable buttons.
+ */
+media-airplay-button[media-airplay-unavailable],
+media-fullscreen-button[media-fullscreen-unavailable],
+media-volume-range[media-volume-unavailable],
+media-pip-button[media-pip-unavailable] {
+  display: none;
+}
+
+/*
+ * Make the style element show up on the page
+ */
+style {
+  display: block;
+  white-space: pre;
+  font-family: monospace;
+  margin-left: 1em;
+}
+      </style>
+      <div class="examples">
+        <a href="./">View more examples</a>
+      </div>
+    </main>
+  </body>
+</html>

--- a/examples/responsive-attribute.html
+++ b/examples/responsive-attribute.html
@@ -11,7 +11,7 @@
 
       <p>This is an example of making Media Chrome responsive using the <code>media-container-size</code> attribute.</p>
 
-      <media-controller>
+      <media-controller containerbreakpoints="s:0 sm:384 m:576 ml:960 l:1280 xl:1600">
         <video
           slot="media"
           src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/high.mp4"

--- a/examples/responsive-attribute.html
+++ b/examples/responsive-attribute.html
@@ -9,7 +9,7 @@
     <main>
       <h1>Responsive Media Chrome Example</h1>
 
-      <p>This is an example of making Media Chrome responsive using the <code>media-container-size</code> attribute.</p>
+      <p>This is an example of making Media Chrome responsive using the <code>breakpoint-</code> attributes.</p>
 
       <media-controller breakpoints="sm:384 md:576 lg:768 xl:960">
         <video

--- a/examples/responsive.html
+++ b/examples/responsive.html
@@ -216,6 +216,7 @@ style {
   white-space: pre;
   font-family: monospace;
   margin-left: 1em;
+  overflow-x: auto;
 }
       </style>
       <div class="examples">

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -85,7 +85,6 @@ export const MediaUIAttributes = {
   MEDIA_BUFFERED: 'media-buffered',
   MEDIA_STREAM_TYPE: 'media-stream-type',
   MEDIA_TIME_IS_LIVE: 'media-time-is-live',
-  MEDIA_CONTAINER_SIZE: 'media-container-size',
 };
 
 // Maps from state change event type -> attribute name

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -85,6 +85,7 @@ export const MediaUIAttributes = {
   MEDIA_BUFFERED: 'media-buffered',
   MEDIA_STREAM_TYPE: 'media-stream-type',
   MEDIA_TIME_IS_LIVE: 'media-time-is-live',
+  MEDIA_CONTAINER_SIZE: 'media-container-size',
 };
 
 // Maps from state change event type -> attribute name

--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -152,11 +152,11 @@ const resizeCallback = (entries) => {
     const breakpoints = container.getAttribute('containerbreakpoints') ?? defaultBreakpoints;
     const ranges = createBreakpointRanges(breakpoints);
     const [size] = getBreakpoint(ranges, entry.contentRect);
-    if (size !== container.getAttribute(MediaUIAttributes.MEDIA_CONTAINER_SIZE)) {
+    if (size !== container.getAttribute('media-container-size')) {
       if (size) {
-        container.setAttribute(MediaUIAttributes.MEDIA_CONTAINER_SIZE, size);
+        container.setAttribute('media-container-size', size);
       } else {
-        container.removeAttribute(MediaUIAttributes.MEDIA_CONTAINER_SIZE);
+        container.removeAttribute('media-container-size');
       }
     }
   }

--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -149,7 +149,8 @@ const resizeCallback = (entries) => {
 
     if (!container.isConnected) continue;
 
-    const ranges = createBreakpointRanges(defaultBreakpoints);
+    const breakpoints = container.getAttribute('containerbreakpoints') ?? defaultBreakpoints;
+    const ranges = createBreakpointRanges(breakpoints);
     const [size] = getBreakpoint(ranges, entry.contentRect);
     if (size !== container.getAttribute(MediaUIAttributes.MEDIA_CONTAINER_SIZE)) {
       if (size) {

--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -141,7 +141,7 @@ template.innerHTML = `
 
 const MEDIA_UI_ATTRIBUTE_NAMES = Object.values(MediaUIAttributes);
 
-const defaultBreakpoints = 's:0 sm:384 m:576 ml:960 l:1280 xl:1600 fhd:1920 qhd:2560 uhd:3840';
+const defaultBreakpoints = 'xs:0 sm:384 md:576 lg:768 xl:960';
 
 const resizeCallback = (entries) => {
   for (const entry of entries) {
@@ -150,11 +150,11 @@ const resizeCallback = (entries) => {
     if (!container.isConnected) continue;
 
     const breakpoints = container.getAttribute('containerbreakpoints') ?? defaultBreakpoints;
-    const ranges = createBreakpointRanges(breakpoints);
-    const [size] = getBreakpoint(ranges, entry.contentRect);
-    if (size !== container.getAttribute('media-container-size')) {
-      if (size) {
-        container.setAttribute('media-container-size', size);
+    const ranges = createBreakpointMap(breakpoints);
+    const activeBreakpoints = getBreakpoints(ranges, entry.contentRect);
+    if (activeBreakpoints !== container.getAttribute('media-container-size')) {
+      if (activeBreakpoints) {
+        container.setAttribute('media-container-size', activeBreakpoints);
       } else {
         container.removeAttribute('media-container-size');
       }
@@ -162,20 +162,15 @@ const resizeCallback = (entries) => {
   }
 };
 
-function createBreakpointRanges(breakpoints) {
+function createBreakpointMap(breakpoints) {
   const pairs = breakpoints.split(/\s+/);
-  let ranges = pairs.map((pair, i) => {
-    let [name, min] = pair.split(':');
-    let [, max = Infinity] = pairs[i + 1]?.split(':') ?? [];
-    return [name, +min, +max];
-  });
-  return ranges;
+  return Object.fromEntries(pairs.map((pair) => pair.split(':')));
 }
 
-function getBreakpoint(breakpointRanges, rect) {
-  return breakpointRanges.find(([, min, max]) => {
-    return rect.width >= min && rect.width < max;
-  });
+function getBreakpoints(breakpoints, rect) {
+  return Object.keys(breakpoints).filter((key) => {
+    return rect.width >= breakpoints[key];
+  }).join(' ');
 }
 
 /**

--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -141,7 +141,7 @@ template.innerHTML = `
 
 const MEDIA_UI_ATTRIBUTE_NAMES = Object.values(MediaUIAttributes);
 
-const defaultBreakpoints = 'xs:0 sm:384 md:576 lg:768 xl:960';
+const defaultBreakpoints = 'sm:384 md:576 lg:768 xl:960';
 
 const resizeCallback = (entries) => {
   for (const entry of entries) {
@@ -149,16 +149,20 @@ const resizeCallback = (entries) => {
 
     if (!container.isConnected) continue;
 
-    const breakpoints = container.getAttribute('containerbreakpoints') ?? defaultBreakpoints;
+    const breakpoints = container.getAttribute('breakpoints') ?? defaultBreakpoints;
     const ranges = createBreakpointMap(breakpoints);
     const activeBreakpoints = getBreakpoints(ranges, entry.contentRect);
-    if (activeBreakpoints !== container.getAttribute('media-container-size')) {
-      if (activeBreakpoints) {
-        container.setAttribute('media-container-size', activeBreakpoints);
-      } else {
-        container.removeAttribute('media-container-size');
+
+    Object.keys(ranges).forEach((name) => {
+      if (activeBreakpoints.includes(name)) {
+        if (!container.hasAttribute(`breakpoint-${name}`)) {
+          container.setAttribute(`breakpoint-${name}`, '');
+        }
+        return;
       }
-    }
+
+      container.removeAttribute(`breakpoint-${name}`);
+    });
   }
 };
 
@@ -168,9 +172,9 @@ function createBreakpointMap(breakpoints) {
 }
 
 function getBreakpoints(breakpoints, rect) {
-  return Object.keys(breakpoints).filter((key) => {
-    return rect.width >= breakpoints[key];
-  }).join(' ');
+  return Object.keys(breakpoints).filter((name) => {
+    return rect.width >= breakpoints[name];
+  });
 }
 
 /**

--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -141,14 +141,16 @@ template.innerHTML = `
 
 const MEDIA_UI_ATTRIBUTE_NAMES = Object.values(MediaUIAttributes);
 
-const defaultBreakpoints = 's:0 sm:396 m:576 ml:960 l:1280 xl:1600 2xl:1920';
+const defaultBreakpoints = 's:0 sm:384 m:576 ml:960 l:1280 xl:1600 fhd:1920 qhd:2560 uhd:3840';
+
 const resizeCallback = (entries) => {
   for (const entry of entries) {
     const container = entry.target;
 
     if (!container.isConnected) continue;
 
-    const [size] = getBreakpoint(createBreakpointRanges(defaultBreakpoints), entry.contentRect);
+    const ranges = createBreakpointRanges(defaultBreakpoints);
+    const [size] = getBreakpoint(ranges, entry.contentRect);
     if (size !== container.getAttribute(MediaUIAttributes.MEDIA_CONTAINER_SIZE)) {
       if (size) {
         container.setAttribute(MediaUIAttributes.MEDIA_CONTAINER_SIZE, size);


### PR DESCRIPTION
test url: https://media-chrome-git-fork-luwes-resize-observer-mux.vercel.app/examples/responsive-attribute.html

- removed the media-container-size attribute
- added attributes for the breakpoints: `breakpoint-sm`, `breakpoint-md`, `breakpoint-lg` and `breakpoint-xl`
- added attribute `breakpoints` for customizing breakpoints. e.g. `breakpoints="sm:300 md:400 lg:500"`