### PR TITLE
fix: template syntax & add streamType to template props

### DIFF
--- a/examples/experimental/themes/youtube-theme.html
+++ b/examples/experimental/themes/youtube-theme.html
@@ -148,6 +148,14 @@
           <slot name="media" slot="media"></slot>
           <slot name="poster" slot="poster"></slot>
 
+          <div slot="top-chrome">
+            <media-control-bar>
+              <media-text-display>
+                {{streamType}}
+              </media-text-display>
+            </media-control-bar>
+          </div>
+
           <div class="ytp-gradient-bottom"></div>
           <media-time-range>
             <media-preview-thumbnail slot="preview"></media-preview-thumbnail>

--- a/src/js/media-theme-element.js
+++ b/src/js/media-theme-element.js
@@ -6,6 +6,13 @@ import { camelCase } from './utils/utils.js';
 // Export Template parts for players.
 export * from './utils/template-parts.js';
 
+const observedMediaAttributes = {
+  'media-stream-type': 'streamType'
+};
+
+/**
+ * @extends {HTMLElement}
+ */
 export class MediaThemeElement extends window.HTMLElement {
   static template;
   static observedAttributes = ['template'];
@@ -21,8 +28,12 @@ export class MediaThemeElement extends window.HTMLElement {
     this.renderRoot = this.attachShadow({ mode: 'open' });
 
     const observer = new MutationObserver(() => this.render());
-    // @ts-ignore
     observer.observe(this, { attributes: true });
+    observer.observe(this.renderRoot, {
+      attributeFilter: Object.keys(observedMediaAttributes),
+      attributeOldValue: true,
+      subtree: true,
+    })
 
     this.createRenderer();
   }
@@ -35,6 +46,7 @@ export class MediaThemeElement extends window.HTMLElement {
   get template() {
     const templateId = this.getAttribute('template');
     if (templateId) {
+      // @ts-ignore
       const template = this.getRootNode()?.getElementById(templateId);
       if (template) return template;
     }
@@ -48,12 +60,18 @@ export class MediaThemeElement extends window.HTMLElement {
   }
 
   get props() {
+    const observedAttributes = [
+      ...Array.from(this.attributes),
+      ...Array.from(this.mediaController?.attributes ?? [])
+        .filter(({ name }) => observedMediaAttributes[name])
+    ];
     const props = {};
-    for (let attr of this.attributes) {
+    for (let attr of observedAttributes) {
+      const name = observedMediaAttributes[attr.name] ?? camelCase(attr.name);
       if (attr.value != null) {
-        props[camelCase(attr.name)] = attr.value === '' ? true : attr.value;
+        props[name] = attr.value === '' ? true : attr.value;
       } else {
-        props[camelCase(attr.name)] = false;
+        props[name] = false;
       }
     }
     return props;

--- a/src/js/media-theme-element.js
+++ b/src/js/media-theme-element.js
@@ -7,7 +7,8 @@ import { camelCase } from './utils/utils.js';
 export * from './utils/template-parts.js';
 
 const observedMediaAttributes = {
-  'media-stream-type': 'streamType'
+  'media-stream-type': 'streamType',
+  'media-container-size': 'containerSize'
 };
 
 /**
@@ -65,6 +66,7 @@ export class MediaThemeElement extends window.HTMLElement {
       ...Array.from(this.mediaController?.attributes ?? [])
         .filter(({ name }) => observedMediaAttributes[name])
     ];
+
     const props = {};
     for (let attr of observedAttributes) {
       const name = observedMediaAttributes[attr.name] ?? camelCase(attr.name);
@@ -74,6 +76,7 @@ export class MediaThemeElement extends window.HTMLElement {
         props[name] = false;
       }
     }
+
     return props;
   }
 

--- a/src/js/media-theme-element.js
+++ b/src/js/media-theme-element.js
@@ -8,7 +8,6 @@ export * from './utils/template-parts.js';
 
 const observedMediaAttributes = {
   'media-stream-type': 'streamType',
-  'media-container-size': 'containerSize'
 };
 
 /**

--- a/src/js/themes/media-theme-demuxed-2022.js
+++ b/src/js/themes/media-theme-demuxed-2022.js
@@ -389,6 +389,7 @@ class MediaThemeDemuxed extends MediaThemeElement {
 
   attributeChangedCallback(name, _oldValue, newValue) {
     if(name === "stream-type" && newValue === "live") {
+      /** @type {HTMLMediaElement} */
       const media = this.querySelector('[slot="media"]');
       media.muted = true;
       media.play();

--- a/src/js/utils/template-processor.js
+++ b/src/js/utils/template-processor.js
@@ -52,18 +52,10 @@ export const processor = {
       if (part instanceof InnerTemplatePart) {
         if (!part.directive) {
           // Transform short-hand if/partial attributes to directive & expression.
-          let directive = DirectiveNames.find((n) => part.template.hasAttribute(n));
-          let expression = directive && part.template.getAttribute(directive);
-
-          // Transform block attributes to directive & expression.
-          const block = part.template.getAttribute('block');
-          if (block) {
-            [directive, expression] = block.split(/\s+(.*)/);
-          }
-
+          const directive = DirectiveNames.find((n) => part.template.hasAttribute(n));
           if (directive) {
             part.directive = directive;
-            part.expression = expression;
+            part.expression = part.template.getAttribute(directive);
           }
         }
         Directives[part.directive]?.(part, state);

--- a/src/js/utils/template-processor.js
+++ b/src/js/utils/template-processor.js
@@ -129,6 +129,10 @@ export const processor = {
 const conditions = {
   '==': (a, b) => a == b,
   '!=': (a, b) => a != b,
+  '>': (a, b) => a > b,
+  '>=': (a, b) => a >= b,
+  '<': (a, b) => a < b,
+  '<=': (a, b) => a <= b,
 };
 
 // Support minimal conditional expressions e.g.
@@ -140,7 +144,7 @@ export function evaluateCondition(expr, state) {
     boolean: /true|false/,
     number: /-?\d+\.?\d*/,
     string: /(["'])((?:\\.|[^\\])*?)\1/,
-    operator: /[!=]=/,
+    operator: /[!=><]=|[><]/,
     ws: /\s+/,
     param: /[$a-z_][$\w]*/i,
   });

--- a/src/js/utils/template-processor.js
+++ b/src/js/utils/template-processor.js
@@ -52,10 +52,18 @@ export const processor = {
       if (part instanceof InnerTemplatePart) {
         if (!part.directive) {
           // Transform short-hand if/partial attributes to directive & expression.
-          const directive = DirectiveNames.find((n) => part.template.hasAttribute(n));
+          let directive = DirectiveNames.find((n) => part.template.hasAttribute(n));
+          let expression = directive && part.template.getAttribute(directive);
+
+          // Transform block attributes to directive & expression.
+          const block = part.template.getAttribute('block');
+          if (block) {
+            [directive, expression] = block.split(/\s+(.*)/);
+          }
+
           if (directive) {
             part.directive = directive;
-            part.expression = part.template.getAttribute(directive);
+            part.expression = expression;
           }
         }
         Directives[part.directive]?.(part, state);

--- a/test/unit/template-processor.spec.js
+++ b/test/unit/template-processor.spec.js
@@ -1,7 +1,7 @@
 import { assert } from '@open-wc/testing';
-import { evaluateCondition } from '../../src/js/utils/template-processor.js';
+import { evaluateCondition, getParamValue } from '../../src/js/utils/template-processor.js';
 
-describe('template processor', () => {
+describe('evaluateCondition', () => {
   it('can evaluate a simple boolean condition', () => {
     assert(evaluateCondition('true'));
     assert(evaluateCondition('true == myVar', { myVar: true }));
@@ -11,6 +11,12 @@ describe('template processor', () => {
   it('can evaluate a simple number condition', async () => {
     assert(!evaluateCondition('0'));
     assert(evaluateCondition('1'));
+    assert(evaluateCondition('5 > 3'));
+    assert(evaluateCondition('5 >= 3'));
+    assert(evaluateCondition('5 >= 5'));
+    assert(evaluateCondition('2 < 3'));
+    assert(evaluateCondition('2 <= 3'));
+    assert(evaluateCondition('3 <= 3'));
     assert(evaluateCondition('myVar == 22', { myVar: 22 }));
     assert(evaluateCondition('myVar != 22', { myVar: 23 }));
   });
@@ -20,5 +26,16 @@ describe('template processor', () => {
     assert(evaluateCondition('"thruthy"'));
     assert(evaluateCondition('myVar == "a string"', { myVar: 'a string' }));
     assert(evaluateCondition('myVar != "a string"', { myVar: 'lalala' }));
+  });
+});
+
+describe('getParamValue', () => {
+  it('gets the correct value from string', () => {
+    assert.equal(getParamValue('true'), true);
+    assert.equal(getParamValue('false'), false);
+    assert.equal(getParamValue('"hello world"'), 'hello world');
+    assert.equal(getParamValue("'hello world'"), 'hello world');
+    assert.equal(getParamValue('360'), 360);
+    assert.equal(getParamValue('myVar', { myVar: 'val' }), 'val');
   });
 });

--- a/test/unit/template-processor.spec.js
+++ b/test/unit/template-processor.spec.js
@@ -45,7 +45,7 @@ describe('processor', () => {
 
   it('InnerTemplatePart: simple truthy if condition', async () => {
     const template = document.createElement('template');
-    template.innerHTML = `<div>hello<template block="if x"> world</template>!</div>`;
+    template.innerHTML = `<div>hello<template if="x"> world</template>!</div>`;
     const instance = new TemplateInstance(template, { x: false }, processor);
     assert.equal(instance.children[0].innerHTML, 'hello!');
 
@@ -55,7 +55,7 @@ describe('processor', () => {
 
   it('InnerTemplatePart: simple value if condition', async () => {
     const template = document.createElement('template');
-    template.innerHTML = `<div>hello<template block="if x == 'hello'"> world</template>!</div>`;
+    template.innerHTML = `<div>hello<template if="x == 'hello'"> world</template>!</div>`;
     const instance = new TemplateInstance(template, { x: false }, processor);
     assert.equal(instance.childNodes[0].innerHTML, 'hello!');
 
@@ -70,7 +70,7 @@ describe('processor', () => {
     const template = document.createElement('template');
     template.innerHTML = `
       <div>
-        hello<template block="if x >= 1"> world<template block="if loud">!</template></template>
+        hello<template if="x >= 1"> world<template if="loud">!</template></template>
       </div>`;
     const instance = new TemplateInstance(template, { x: 0 }, processor);
     assert.equal(instance.children[0].textContent.trim(), 'hello');

--- a/test/unit/template-processor.spec.js
+++ b/test/unit/template-processor.spec.js
@@ -1,5 +1,6 @@
 import { assert } from '@open-wc/testing';
-import { evaluateCondition, getParamValue } from '../../src/js/utils/template-processor.js';
+import { evaluateCondition, getParamValue, processor } from '../../src/js/utils/template-processor.js';
+import { TemplateInstance } from '../../src/js/utils/template-parts.js';
 
 describe('evaluateCondition', () => {
   it('can evaluate a simple boolean condition', () => {
@@ -38,4 +39,31 @@ describe('getParamValue', () => {
     assert.equal(getParamValue('360'), 360);
     assert.equal(getParamValue('myVar', { myVar: 'val' }), 'val');
   });
+});
+
+describe('processor', () => {
+
+  it('InnerTemplatePart: simple truthy if condition', async () => {
+    const template = document.createElement('template');
+    template.innerHTML = `<div>hello<template block="if x"> world</template>!</div>`;
+    const instance = new TemplateInstance(template, { x: false }, processor);
+    assert.equal(instance.childNodes[0].innerHTML, 'hello!');
+
+    instance.update({ x: true });
+    assert.equal(instance.childNodes[0].innerHTML, 'hello world!');
+  });
+
+  it('InnerTemplatePart: simple value if condition', async () => {
+    const template = document.createElement('template');
+    template.innerHTML = `<div>hello<template block="if x == 'hello'"> world</template>!</div>`;
+    const instance = new TemplateInstance(template, { x: false }, processor);
+    assert.equal(instance.childNodes[0].innerHTML, 'hello!');
+
+    instance.update({ x: 'hell' });
+    assert.equal(instance.childNodes[0].innerHTML, 'hello!');
+
+    instance.update({ x: 'hello' });
+    assert.equal(instance.childNodes[0].innerHTML, 'hello world!');
+  });
+
 });

--- a/test/unit/template-processor.spec.js
+++ b/test/unit/template-processor.spec.js
@@ -47,10 +47,10 @@ describe('processor', () => {
     const template = document.createElement('template');
     template.innerHTML = `<div>hello<template block="if x"> world</template>!</div>`;
     const instance = new TemplateInstance(template, { x: false }, processor);
-    assert.equal(instance.childNodes[0].innerHTML, 'hello!');
+    assert.equal(instance.children[0].innerHTML, 'hello!');
 
     instance.update({ x: true });
-    assert.equal(instance.childNodes[0].innerHTML, 'hello world!');
+    assert.equal(instance.children[0].innerHTML, 'hello world!');
   });
 
   it('InnerTemplatePart: simple value if condition', async () => {
@@ -60,10 +60,26 @@ describe('processor', () => {
     assert.equal(instance.childNodes[0].innerHTML, 'hello!');
 
     instance.update({ x: 'hell' });
-    assert.equal(instance.childNodes[0].innerHTML, 'hello!');
+    assert.equal(instance.children[0].innerHTML, 'hello!');
 
     instance.update({ x: 'hello' });
-    assert.equal(instance.childNodes[0].innerHTML, 'hello world!');
+    assert.equal(instance.children[0].innerHTML, 'hello world!');
+  });
+
+  it('InnerTemplatePart: nested if blocks (logical AND)', async () => {
+    const template = document.createElement('template');
+    template.innerHTML = `
+      <div>
+        hello<template block="if x >= 1"> world<template block="if loud">!</template></template>
+      </div>`;
+    const instance = new TemplateInstance(template, { x: 0 }, processor);
+    assert.equal(instance.children[0].textContent.trim(), 'hello');
+
+    instance.update({ x: 1 });
+    assert.equal(instance.children[0].textContent.trim(), 'hello world');
+
+    instance.update({ x: 1, loud: true });
+    assert.equal(instance.children[0].textContent.trim(), 'hello world!');
   });
 
 });


### PR DESCRIPTION
- adds `>`, `>=`, `<`, `<=` operators
- add the `media-stream-type` attribute to the available theme props as `streamType`

For a logical AND we decided to use nested `if` templates instead of supporting more complex expressions like in #383 