### PR TITLE
fix: remove web component class globals

### DIFF
--- a/src/js/extras/media-clip-selector/index.js
+++ b/src/js/extras/media-clip-selector/index.js
@@ -1,8 +1,4 @@
-import { defineCustomElement } from '../../utils/defineCustomElement.js';
-import {
-  Window as window,
-  Document as document,
-} from '../../utils/server-safe-globals.js';
+import { window, document } from '../../utils/server-safe-globals.js';
 import { MediaUIEvents, MediaUIAttributes } from '../../constants.js';
 
 const template = document.createElement('template');
@@ -495,6 +491,8 @@ class MediaClipSelector extends window.HTMLElement {
   }
 }
 
-defineCustomElement('media-clip-selector', MediaClipSelector);
+if (!window.customElements.get('media-clip-selector')) {
+  window.customElements.define('media-clip-selector', MediaClipSelector);
+}
 
 export default MediaClipSelector;

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -28,7 +28,7 @@ import MediaLoadingIndicator from './media-loading-indicator.js';
 import MediaTitleElement from './media-title-element.js';
 import MediaVolumeRange from './media-volume-range.js';
 import MediaTheme from './themes/media-theme.js';
-import { Window as window } from './utils/server-safe-globals.js';
+import { window } from './utils/server-safe-globals.js';
 
 // Alias <media-controller> as <media-chrome>
 // Might move MediaChrome to include default controls

--- a/src/js/media-airplay-button.js
+++ b/src/js/media-airplay-button.js
@@ -1,9 +1,5 @@
 import MediaChromeButton from './media-chrome-button.js';
-import { defineCustomElement } from './utils/defineCustomElement.js';
-import {
-  Window as window,
-  Document as document,
-} from './utils/server-safe-globals.js';
+import { window, document } from './utils/server-safe-globals.js';
 import { MediaUIEvents, MediaUIAttributes } from './constants.js';
 import { verbs } from './labels/labels.js';
 
@@ -43,6 +39,8 @@ class MediaAirplayButton extends MediaChromeButton {
   }
 }
 
-defineCustomElement('media-airplay-button', MediaAirplayButton);
+if (!window.customElements.get('media-airplay-button')) {
+  window.customElements.define('media-airplay-button', MediaAirplayButton);
+}
 
 export default MediaAirplayButton;

--- a/src/js/media-captions-button.js
+++ b/src/js/media-captions-button.js
@@ -1,6 +1,5 @@
 import MediaChromeButton from './media-chrome-button.js';
-import { defineCustomElement } from './utils/defineCustomElement.js';
-import { Document as document } from './utils/server-safe-globals.js';
+import { window, document } from './utils/server-safe-globals.js';
 import { MediaUIAttributes } from './constants.js';
 import { nouns } from './labels/labels.js';
 import { isCCOn, toggleSubsCaps } from './utils/captions.js';
@@ -117,6 +116,8 @@ class MediaCaptionsButton extends MediaChromeButton {
   }
 }
 
-defineCustomElement('media-captions-button', MediaCaptionsButton);
+if (!window.customElements.get('media-captions-button')) {
+  window.customElements.define('media-captions-button', MediaCaptionsButton);
+}
 
 export default MediaCaptionsButton;

--- a/src/js/media-captions-listbox.js
+++ b/src/js/media-captions-listbox.js
@@ -1,6 +1,5 @@
 import MediaChromeListbox from './media-chrome-listbox.js';
-import { defineCustomElement } from './utils/defineCustomElement.js';
-import { Window as window, Document as document } from './utils/server-safe-globals.js';
+import { window, document } from './utils/server-safe-globals.js';
 import { MediaUIAttributes, MediaUIEvents } from './constants.js';
 import { parseTextTracksStr, parseTextTrackStr, formatTextTrackObj } from './utils/captions.js';
 
@@ -136,7 +135,8 @@ class MediaCaptionsListbox extends MediaChromeListbox {
   }
 }
 
-
-defineCustomElement('media-captions-listbox', MediaCaptionsListbox);
+if (!window.customElements.get('media-captions-listbox')) {
+  window.customElements.define('media-captions-listbox', MediaCaptionsListbox);
+}
 
 export default MediaCaptionsListbox;

--- a/src/js/media-cast-button.js
+++ b/src/js/media-cast-button.js
@@ -1,9 +1,5 @@
 import MediaChromeButton from './media-chrome-button.js';
-import { defineCustomElement } from './utils/defineCustomElement.js';
-import {
-  Window as window,
-  Document as document,
-} from './utils/server-safe-globals.js';
+import { window, document } from './utils/server-safe-globals.js';
 import { MediaUIEvents, MediaUIAttributes } from './constants.js';
 import { verbs } from './labels/labels.js';
 
@@ -75,6 +71,8 @@ class MediaCastButton extends MediaChromeButton {
   }
 }
 
-defineCustomElement('media-cast-button', MediaCastButton);
+if (!window.customElements.get('media-cast-button')) {
+  window.customElements.define('media-cast-button', MediaCastButton);
+}
 
 export default MediaCastButton;

--- a/src/js/media-chrome-button.js
+++ b/src/js/media-chrome-button.js
@@ -1,9 +1,5 @@
 import { MediaStateReceiverAttributes } from './constants.js';
-import { defineCustomElement } from './utils/defineCustomElement.js';
-import {
-  Window as window,
-  Document as document,
-} from './utils/server-safe-globals.js';
+import { window, document } from './utils/server-safe-globals.js';
 
 const template = document.createElement('template');
 
@@ -190,6 +186,8 @@ class MediaChromeButton extends window.HTMLElement {
   handleClick(e) {} // eslint-disable-line
 }
 
-defineCustomElement('media-chrome-button', MediaChromeButton);
+if (!window.customElements.get('media-chrome-button')) {
+  window.customElements.define('media-chrome-button', MediaChromeButton);
+}
 
 export default MediaChromeButton;

--- a/src/js/media-chrome-listbox.js
+++ b/src/js/media-chrome-listbox.js
@@ -1,9 +1,5 @@
 import { MediaStateReceiverAttributes } from './constants.js';
-import { defineCustomElement } from './utils/defineCustomElement.js';
-import {
-  Window as window,
-  Document as document,
-} from './utils/server-safe-globals.js';
+import { window, document } from './utils/server-safe-globals.js';
 
 const template = document.createElement('template');
 
@@ -309,6 +305,8 @@ class MediaChromeListbox extends window.HTMLElement {
   }
 }
 
-defineCustomElement('media-chrome-listbox', MediaChromeListbox);
+if (!window.customElements.get('media-chrome-listbox')) {
+  window.customElements.define('media-chrome-listbox', MediaChromeListbox);
+}
 
 export default MediaChromeListbox;

--- a/src/js/media-chrome-listitem.js
+++ b/src/js/media-chrome-listitem.js
@@ -1,9 +1,5 @@
 import { MediaStateReceiverAttributes } from './constants.js';
-import { defineCustomElement } from './utils/defineCustomElement.js';
-import {
-  Window as window,
-  Document as document,
-} from './utils/server-safe-globals.js';
+import { window, document } from './utils/server-safe-globals.js';
 
 const template = document.createElement('template');
 
@@ -110,6 +106,8 @@ class MediaChromeListitem extends window.HTMLElement {
   handleClick() {}
 }
 
-defineCustomElement('media-chrome-listitem', MediaChromeListitem);
+if (!window.customElements.get('media-chrome-listitem')) {
+  window.customElements.define('media-chrome-listitem', MediaChromeListitem);
+}
 
 export default MediaChromeListitem;

--- a/src/js/media-chrome-menu-button.js
+++ b/src/js/media-chrome-menu-button.js
@@ -1,7 +1,6 @@
 import './media-chrome-button.js';
 import './media-chrome-listbox.js';
-import { defineCustomElement } from './utils/defineCustomElement.js';
-import { Window as window, Document as document } from './utils/server-safe-globals.js';
+import { window, document } from './utils/server-safe-globals.js';
 import { MediaStateReceiverAttributes } from './constants.js';
 
 const template = document.createElement('template');
@@ -151,6 +150,8 @@ class MediaChromeMenuButton extends window.HTMLElement {
 
 }
 
-defineCustomElement('media-chrome-menu-button', MediaChromeMenuButton);
+if (!window.customElements.get('media-chrome-menu-button')) {
+  window.customElements.define('media-chrome-menu-button', MediaChromeMenuButton);
+}
 
 export default MediaChromeMenuButton;

--- a/src/js/media-chrome-range.js
+++ b/src/js/media-chrome-range.js
@@ -1,9 +1,5 @@
 import { MediaStateReceiverAttributes } from './constants.js';
-import { defineCustomElement } from './utils/defineCustomElement.js';
-import {
-  Window as window,
-  Document as document,
-} from './utils/server-safe-globals.js';
+import { window, document } from './utils/server-safe-globals.js';
 import { getOrInsertCSSRule } from './utils/element-utils.js';
 
 const template = document.createElement('template');
@@ -331,6 +327,8 @@ class MediaChromeRange extends window.HTMLElement {
   }
 }
 
-defineCustomElement('media-chrome-range', MediaChromeRange);
+if (!window.customElements.get('media-chrome-range')) {
+  window.customElements.define('media-chrome-range', MediaChromeRange);
+}
 
 export default MediaChromeRange;

--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -7,11 +7,7 @@
   * Position controls at the bottom
   * Auto-hide controls on inactivity while playing
 */
-import { defineCustomElement } from './utils/defineCustomElement.js';
-import {
-  Window as window,
-  Document as document,
-} from './utils/server-safe-globals.js';
+import { window, document } from './utils/server-safe-globals.js';
 import { MediaUIEvents, MediaUIAttributes, MediaStateChangeEvents } from './constants.js';
 import { nouns } from './labels/labels.js';
 // Guarantee that `<media-gesture-receiver/>` is available for use in the template
@@ -428,6 +424,8 @@ class MediaContainer extends window.HTMLElement {
 
 // Aliasing media-controller to media-container in main index until we know
 // we're not breaking people with the change.
-defineCustomElement('media-container-temp', MediaContainer);
+if (!window.customElements.get('media-container-temp')) {
+  window.customElements.define('media-container-temp', MediaContainer);
+}
 
 export default MediaContainer;

--- a/src/js/media-control-bar.js
+++ b/src/js/media-control-bar.js
@@ -4,11 +4,7 @@
   Auto position contorls in a line and set some base colors
 */
 import { MediaStateReceiverAttributes } from './constants.js';
-import { defineCustomElement } from './utils/defineCustomElement.js';
-import {
-  Window as window,
-  Document as document,
-} from './utils/server-safe-globals.js';
+import { window, document } from './utils/server-safe-globals.js';
 
 const template = document.createElement('template');
 
@@ -79,6 +75,8 @@ class MediaControlBar extends window.HTMLElement {
   }
 }
 
-defineCustomElement('media-control-bar', MediaControlBar);
+if (!window.customElements.get('media-control-bar')) {
+  window.customElements.define('media-control-bar', MediaControlBar);
+}
 
 export default MediaControlBar;

--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -8,11 +8,7 @@
   * Auto-hide controls on inactivity while playing
 */
 import MediaContainer from './media-container.js';
-import { defineCustomElement } from './utils/defineCustomElement.js';
-import {
-  Window as window,
-  Document as document,
-} from './utils/server-safe-globals.js';
+import { window, document } from './utils/server-safe-globals.js';
 import { AttributeTokenList } from './utils/attribute-token-list.js';
 import { fullscreenApi } from './utils/fullscreenApi.js';
 import { constToCamel } from './utils/utils.js';
@@ -1370,6 +1366,8 @@ function serializeTimeRanges(timeRanges = emptyTimeRanges) {
     .join(' ');
 }
 
-defineCustomElement('media-controller', MediaController);
+if (!window.customElements.get('media-controller')) {
+  window.customElements.define('media-controller', MediaController);
+}
 
 export default MediaController;

--- a/src/js/media-current-time-display.js
+++ b/src/js/media-current-time-display.js
@@ -1,5 +1,5 @@
 import MediaTextDisplay from './media-text-display.js';
-import { defineCustomElement } from './utils/defineCustomElement.js';
+import { window } from './utils/server-safe-globals.js';
 import { formatTime } from './utils/time.js';
 import { MediaUIAttributes } from './constants.js';
 // Todo: Use data locals: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString
@@ -17,6 +17,8 @@ class MediaCurrentTimeDisplay extends MediaTextDisplay {
   }
 }
 
-defineCustomElement('media-current-time-display', MediaCurrentTimeDisplay);
+if (!window.customElements.get('media-current-time-display')) {
+  window.customElements.define('media-current-time-display', MediaCurrentTimeDisplay);
+}
 
 export default MediaCurrentTimeDisplay;

--- a/src/js/media-duration-display.js
+++ b/src/js/media-duration-display.js
@@ -1,5 +1,5 @@
 import MediaTextDisplay from './media-text-display.js';
-import { defineCustomElement } from './utils/defineCustomElement.js';
+import { window } from './utils/server-safe-globals.js';
 import { formatTime } from './utils/time.js';
 import { MediaUIAttributes } from './constants.js';
 // Todo: Use data locals: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString
@@ -17,6 +17,8 @@ class MediaDurationDisplay extends MediaTextDisplay {
   }
 }
 
-defineCustomElement('media-duration-display', MediaDurationDisplay);
+if (!window.customElements.get('media-duration-display')) {
+  window.customElements.define('media-duration-display', MediaDurationDisplay);
+}
 
 export default MediaDurationDisplay;

--- a/src/js/media-fullscreen-button.js
+++ b/src/js/media-fullscreen-button.js
@@ -7,11 +7,7 @@
   If none, the button will make the media fullscreen.
 */
 import MediaChromeButton from './media-chrome-button.js';
-import { defineCustomElement } from './utils/defineCustomElement.js';
-import {
-  Window as window,
-  Document as document,
-} from './utils/server-safe-globals.js';
+import { window, document } from './utils/server-safe-globals.js';
 import { MediaUIEvents, MediaUIAttributes } from './constants.js';
 import { verbs } from './labels/labels.js';
 
@@ -87,6 +83,8 @@ class MediaFullscreenButton extends MediaChromeButton {
   }
 }
 
-defineCustomElement('media-fullscreen-button', MediaFullscreenButton);
+if (!window.customElements.get('media-fullscreen-button')) {
+  window.customElements.define('media-fullscreen-button', MediaFullscreenButton);
+}
 
 export default MediaFullscreenButton;

--- a/src/js/media-gesture-receiver.js
+++ b/src/js/media-gesture-receiver.js
@@ -4,12 +4,8 @@ import {
   MediaStateReceiverAttributes,
   PointerTypes
 } from './constants.js';
-import { defineCustomElement } from './utils/defineCustomElement.js';
 import { closestComposedNode } from './utils/element-utils.js';
-import {
-  Window as window,
-  Document as document,
-} from './utils/server-safe-globals.js';
+import { window, document } from './utils/server-safe-globals.js';
 
 const template = document.createElement('template');
 
@@ -159,6 +155,8 @@ function getMediaControllerEl(controlEl) {
   return closestComposedNode(controlEl, 'media-controller');
 }
 
-defineCustomElement('media-gesture-receiver', MediaGestureReceiver);
+if (!window.customElements.get('media-gesture-receiver')) {
+  window.customElements.define('media-gesture-receiver', MediaGestureReceiver);
+}
 
 export default MediaGestureReceiver;

--- a/src/js/media-loading-indicator.js
+++ b/src/js/media-loading-indicator.js
@@ -1,10 +1,6 @@
 import { MediaUIAttributes, MediaStateReceiverAttributes } from './constants.js';
 import { nouns } from './labels/labels.js';
-import { defineCustomElement } from './utils/defineCustomElement.js';
-import {
-  Window as window,
-  Document as document,
-} from './utils/server-safe-globals.js';
+import { window, document } from './utils/server-safe-globals.js';
 // Todo: Use data locals: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString
 
 const template = document.createElement('template');
@@ -147,6 +143,8 @@ class MediaLoadingIndicator extends window.HTMLElement {
   }
 }
 
-defineCustomElement('media-loading-indicator', MediaLoadingIndicator);
+if (!window.customElements.get('media-loading-indicator')) {
+  window.customElements.define('media-loading-indicator', MediaLoadingIndicator);
+}
 
 export default MediaLoadingIndicator;

--- a/src/js/media-mute-button.js
+++ b/src/js/media-mute-button.js
@@ -1,9 +1,5 @@
 import MediaChromeButton from './media-chrome-button.js';
-import { defineCustomElement } from './utils/defineCustomElement.js';
-import {
-  Window as window,
-  Document as document,
-} from './utils/server-safe-globals.js';
+import { window, document } from './utils/server-safe-globals.js';
 import { MediaUIEvents, MediaUIAttributes } from './constants.js';
 import { verbs } from './labels/labels.js';
 
@@ -90,6 +86,8 @@ class MediaMuteButton extends MediaChromeButton {
   }
 }
 
-defineCustomElement('media-mute-button', MediaMuteButton);
+if (!window.customElements.get('media-mute-button')) {
+  window.customElements.define('media-mute-button', MediaMuteButton);
+}
 
 export default MediaMuteButton;

--- a/src/js/media-pip-button.js
+++ b/src/js/media-pip-button.js
@@ -1,9 +1,5 @@
 import MediaChromeButton from './media-chrome-button.js';
-import { defineCustomElement } from './utils/defineCustomElement.js';
-import {
-  Window as window,
-  Document as document,
-} from './utils/server-safe-globals.js';
+import { window, document } from './utils/server-safe-globals.js';
 import { MediaUIEvents, MediaUIAttributes } from './constants.js';
 import { verbs } from './labels/labels.js';
 
@@ -68,6 +64,8 @@ class MediaPipButton extends MediaChromeButton {
   }
 }
 
-defineCustomElement('media-pip-button', MediaPipButton);
+if (!window.customElements.get('media-pip-button')) {
+  window.customElements.define('media-pip-button', MediaPipButton);
+}
 
 export default MediaPipButton;

--- a/src/js/media-play-button.js
+++ b/src/js/media-play-button.js
@@ -1,9 +1,5 @@
 import MediaChromeButton from './media-chrome-button.js';
-import {
-  Window as window,
-  Document as document,
-} from './utils/server-safe-globals.js';
-import { defineCustomElement } from './utils/defineCustomElement.js';
+import { window, document } from './utils/server-safe-globals.js';
 import { MediaUIEvents, MediaUIAttributes } from './constants.js';
 import { verbs } from './labels/labels.js';
 
@@ -71,6 +67,8 @@ class MediaPlayButton extends MediaChromeButton {
   }
 }
 
-defineCustomElement('media-play-button', MediaPlayButton);
+if (!window.customElements.get('media-play-button')) {
+  window.customElements.define('media-play-button', MediaPlayButton);
+}
 
 export default MediaPlayButton;

--- a/src/js/media-playback-rate-button.js
+++ b/src/js/media-playback-rate-button.js
@@ -1,9 +1,5 @@
 import MediaChromeButton from './media-chrome-button.js';
-import { defineCustomElement } from './utils/defineCustomElement.js';
-import {
-  Window as window,
-  Document as document,
-} from './utils/server-safe-globals.js';
+import { window, document } from './utils/server-safe-globals.js';
 import { MediaUIEvents, MediaUIAttributes } from './constants.js';
 import { nouns } from './labels/labels.js';
 
@@ -79,6 +75,8 @@ class MediaPlaybackRateButton extends MediaChromeButton {
   }
 }
 
-defineCustomElement('media-playback-rate-button', MediaPlaybackRateButton);
+if (!window.customElements.get('media-playback-rate-button')) {
+  window.customElements.define('media-playback-rate-button', MediaPlaybackRateButton);
+}
 
 export default MediaPlaybackRateButton;

--- a/src/js/media-poster-image.js
+++ b/src/js/media-poster-image.js
@@ -1,8 +1,4 @@
-import { defineCustomElement } from './utils/defineCustomElement.js';
-import {
-  Window as window,
-  Document as document,
-} from './utils/server-safe-globals.js';
+import { window, document } from './utils/server-safe-globals.js';
 import { MediaUIAttributes } from './constants.js';
 
 const template = document.createElement('template');
@@ -75,6 +71,8 @@ class MediaPosterImage extends window.HTMLElement {
   }
 }
 
-defineCustomElement('media-poster-image', MediaPosterImage);
+if (!window.customElements.get('media-poster-image')) {
+  window.customElements.define('media-poster-image', MediaPosterImage);
+}
 
 export default MediaPosterImage;

--- a/src/js/media-preview-thumbnail.js
+++ b/src/js/media-preview-thumbnail.js
@@ -4,11 +4,7 @@
   Uses the "thumbnails" track of a video element to show an image relative to
   the video time given in the `time` attribute.
 */
-import {
-  Window as window,
-  Document as document,
-} from './utils/server-safe-globals.js';
-import { defineCustomElement } from './utils/defineCustomElement.js';
+import { window, document } from './utils/server-safe-globals.js';
 import { MediaUIAttributes, MediaStateReceiverAttributes } from './constants.js';
 import { getOrInsertCSSRule } from './utils/element-utils.js';
 
@@ -146,6 +142,8 @@ class MediaPreviewThumbnail extends window.HTMLElement {
   }
 }
 
-defineCustomElement('media-preview-thumbnail', MediaPreviewThumbnail);
+if (!window.customElements.get('media-preview-thumbnail')) {
+  window.customElements.define('media-preview-thumbnail', MediaPreviewThumbnail);
+}
 
 export default MediaPreviewThumbnail;

--- a/src/js/media-preview-time-display.js
+++ b/src/js/media-preview-time-display.js
@@ -1,5 +1,5 @@
 import MediaTextDisplay from './media-text-display.js';
-import { defineCustomElement } from './utils/defineCustomElement.js';
+import { window } from './utils/server-safe-globals.js';
 import { formatTime } from './utils/time.js';
 import { MediaUIAttributes } from './constants.js';
 // Todo: Use data locals: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString
@@ -17,6 +17,8 @@ class MediaPreviewTimeDisplay extends MediaTextDisplay {
   }
 }
 
-defineCustomElement('media-preview-time-display', MediaPreviewTimeDisplay);
+if (!window.customElements.get('media-preview-time-display')) {
+  window.customElements.define('media-preview-time-display', MediaPreviewTimeDisplay);
+}
 
 export default MediaPreviewTimeDisplay;

--- a/src/js/media-progress-range.js
+++ b/src/js/media-progress-range.js
@@ -3,7 +3,7 @@
 */
 
 import MediaTimeRange from './media-time-range.js';
-import { defineCustomElement } from './utils/defineCustomElement.js';
+import { window } from './utils/server-safe-globals.js';
 
 class MediaProgressRange extends MediaTimeRange {
   constructor() {
@@ -15,6 +15,8 @@ class MediaProgressRange extends MediaTimeRange {
   }
 }
 
-defineCustomElement('media-progress-range', MediaProgressRange);
+if (!window.customElements.get('media-progress-range')) {
+  window.customElements.define('media-progress-range', MediaProgressRange);
+}
 
 export default MediaProgressRange;

--- a/src/js/media-seek-backward-button.js
+++ b/src/js/media-seek-backward-button.js
@@ -1,9 +1,5 @@
 import MediaChromeButton from './media-chrome-button.js';
-import { defineCustomElement } from './utils/defineCustomElement.js';
-import {
-  Window as window,
-  Document as document,
-} from './utils/server-safe-globals.js';
+import { window, document } from './utils/server-safe-globals.js';
 import { MediaUIEvents, MediaUIAttributes } from './constants.js';
 import { verbs } from './labels/labels.js';
 import { getSlotted, updateIconText } from './utils/element-utils.js';
@@ -83,6 +79,8 @@ class MediaSeekBackwardButton extends MediaChromeButton {
   }
 }
 
-defineCustomElement('media-seek-backward-button', MediaSeekBackwardButton);
+if (!window.customElements.get('media-seek-backward-button')) {
+  window.customElements.define('media-seek-backward-button', MediaSeekBackwardButton);
+}
 
 export default MediaSeekBackwardButton;

--- a/src/js/media-seek-forward-button.js
+++ b/src/js/media-seek-forward-button.js
@@ -1,9 +1,5 @@
 import MediaChromeButton from './media-chrome-button.js';
-import { defineCustomElement } from './utils/defineCustomElement.js';
-import {
-  Window as window,
-  Document as document,
-} from './utils/server-safe-globals.js';
+import { window, document } from './utils/server-safe-globals.js';
 import { MediaUIEvents, MediaUIAttributes } from './constants.js';
 import { verbs } from './labels/labels.js';
 import { getSlotted, updateIconText } from './utils/element-utils.js';
@@ -87,6 +83,8 @@ class MediaSeekForwardButton extends MediaChromeButton {
   }
 }
 
-defineCustomElement('media-seek-forward-button', MediaSeekForwardButton);
+if (!window.customElements.get('media-seek-forward-button')) {
+  window.customElements.define('media-seek-forward-button', MediaSeekForwardButton);
+}
 
 export default MediaSeekForwardButton;

--- a/src/js/media-settings-popup.js
+++ b/src/js/media-settings-popup.js
@@ -1,10 +1,6 @@
 // Work in progress
 
-import { defineCustomElement } from './utils/defineCustomElement.js';
-import {
-  Document as document,
-  Window as window,
-} from './utils/server-safe-globals.js';
+import { window, document } from './utils/server-safe-globals.js';
 
 const template = document.createElement('template');
 
@@ -51,6 +47,8 @@ class MediaSettingsPopup extends window.HTMLElement {
   }
 }
 
-defineCustomElement('media-settings-popup', MediaSettingsPopup);
+if (!window.customElements.get('media-settings-popup')) {
+  window.customElements.define('media-settings-popup', MediaSettingsPopup);
+}
 
 export default MediaSettingsPopup;

--- a/src/js/media-text-display.js
+++ b/src/js/media-text-display.js
@@ -1,9 +1,5 @@
 import { MediaStateReceiverAttributes } from './constants.js';
-import { defineCustomElement } from './utils/defineCustomElement.js';
-import {
-  Window as window,
-  Document as document,
-} from './utils/server-safe-globals.js';
+import { window, document } from './utils/server-safe-globals.js';
 // Todo: Use data locals: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString
 
 const template = document.createElement('template');
@@ -97,6 +93,8 @@ class MediaTextDisplay extends window.HTMLElement {
   }
 }
 
-defineCustomElement('media-text-display', MediaTextDisplay);
+if (!window.customElements.get('media-text-display')) {
+  window.customElements.define('media-text-display', MediaTextDisplay);
+}
 
 export default MediaTextDisplay;

--- a/src/js/media-theme-element.js
+++ b/src/js/media-theme-element.js
@@ -1,5 +1,4 @@
-import { Window as window } from './utils/server-safe-globals.js';
-import { defineCustomElement } from './utils/defineCustomElement.js';
+import { window } from './utils/server-safe-globals.js';
 import { TemplateInstance } from './utils/template-parts.js';
 import { processor } from './utils/template-processor.js';
 import { camelCase } from './utils/utils.js';
@@ -87,4 +86,6 @@ export class MediaThemeElement extends window.HTMLElement {
   }
 }
 
-defineCustomElement('media-theme', MediaThemeElement);
+if (!window.customElements.get('media-theme')) {
+  window.customElements.define('media-theme', MediaThemeElement);
+}

--- a/src/js/media-time-display.js
+++ b/src/js/media-time-display.js
@@ -1,5 +1,5 @@
 import MediaTextDisplay from './media-text-display.js';
-import { defineCustomElement } from './utils/defineCustomElement.js';
+import { window } from './utils/server-safe-globals.js';
 import { formatAsTimePhrase, formatTime } from './utils/time.js';
 import { MediaUIAttributes } from './constants.js';
 import { nouns } from './labels/labels.js';
@@ -137,6 +137,8 @@ class MediaTimeDisplay extends MediaTextDisplay {
   }
 }
 
-defineCustomElement('media-time-display', MediaTimeDisplay);
+if (!window.customElements.get('media-time-display')) {
+  window.customElements.define('media-time-display', MediaTimeDisplay);
+}
 
 export default MediaTimeDisplay;

--- a/src/js/media-time-range.js
+++ b/src/js/media-time-range.js
@@ -1,9 +1,5 @@
 import MediaChromeRange from './media-chrome-range.js';
-import { defineCustomElement } from './utils/defineCustomElement.js';
-import {
-  Window as window,
-  Document as document,
-} from './utils/server-safe-globals.js';
+import { window, document } from './utils/server-safe-globals.js';
 import { MediaUIEvents, MediaUIAttributes } from './constants.js';
 import { nouns } from './labels/labels.js';
 import { formatAsTimePhrase } from './utils/time.js';
@@ -454,6 +450,8 @@ class MediaTimeRange extends MediaChromeRange {
   }
 }
 
-defineCustomElement('media-time-range', MediaTimeRange);
+if (!window.customElements.get('media-time-range')) {
+  window.customElements.define('media-time-range', MediaTimeRange);
+}
 
 export default MediaTimeRange;

--- a/src/js/media-title-element.js
+++ b/src/js/media-title-element.js
@@ -1,8 +1,4 @@
-import { defineCustomElement } from './utils/defineCustomElement.js';
-import {
-  Window as window,
-  Document as document,
-} from './utils/server-safe-globals.js';
+import { window, document } from './utils/server-safe-globals.js';
 
 const template = document.createElement('template');
 
@@ -23,6 +19,8 @@ class MediaTitleBar extends window.HTMLElement {
   }
 }
 
-defineCustomElement('media-title-bar', MediaTitleBar);
+if (!window.customElements.get('media-title-bar')) {
+  window.customElements.define('media-title-bar', MediaTitleBar);
+}
 
 export default MediaTitleBar;

--- a/src/js/media-volume-range.js
+++ b/src/js/media-volume-range.js
@@ -1,6 +1,5 @@
-import { Window as window } from './utils/server-safe-globals.js';
+import { window } from './utils/server-safe-globals.js';
 import MediaChromeRange from './media-chrome-range.js';
-import { defineCustomElement } from './utils/defineCustomElement.js';
 import { MediaUIAttributes, MediaUIEvents } from './constants.js';
 import { nouns } from './labels/labels.js';
 
@@ -66,6 +65,8 @@ class MediaVolumeRange extends MediaChromeRange {
   }
 }
 
-defineCustomElement('media-volume-range', MediaVolumeRange);
+if (!window.customElements.get('media-volume-range')) {
+  window.customElements.define('media-volume-range', MediaVolumeRange);
+}
 
 export default MediaVolumeRange;

--- a/src/js/themes/media-theme-demuxed-2022.js
+++ b/src/js/themes/media-theme-demuxed-2022.js
@@ -7,7 +7,7 @@
 </media-theme-demuxed-2022>
 */
 
-import { defineCustomElement } from '../utils/defineCustomElement.js';
+import { window } from '../utils/server-safe-globals.js';
 import { MediaThemeElement } from '../media-theme-element.js';
 
 const template = document.createElement('template');
@@ -396,6 +396,8 @@ class MediaThemeDemuxed extends MediaThemeElement {
   }
 }
 
-defineCustomElement('media-theme-demuxed-2022', MediaThemeDemuxed);
+if (!window.customElements.get('media-theme-demuxed-2022')) {
+  window.customElements.define('media-theme-demuxed-2022', MediaThemeDemuxed);
+}
 
 export default MediaThemeDemuxed;

--- a/src/js/themes/media-theme-netflix.js
+++ b/src/js/themes/media-theme-netflix.js
@@ -7,7 +7,7 @@
 </media-theme-netflix>
 */
 
-import { defineCustomElement } from '../utils/defineCustomElement.js';
+import { window } from '../utils/server-safe-globals.js';
 import { MediaThemeElement } from '../media-theme-element.js';
 
 const template = document.createElement('template');
@@ -138,6 +138,8 @@ class MediaThemeNetflix extends MediaThemeElement {
   static template = template;
 }
 
-defineCustomElement('media-theme-netflix', MediaThemeNetflix);
+if (!window.customElements.get('media-theme-netflix')) {
+  window.customElements.define('media-theme-netflix', MediaThemeNetflix);
+}
 
 export default MediaThemeNetflix;

--- a/src/js/themes/media-theme-responsive.js
+++ b/src/js/themes/media-theme-responsive.js
@@ -7,7 +7,7 @@
 </media-theme-responsive>
 */
 
-import { defineCustomElement } from '../utils/defineCustomElement.js';
+import { window } from '../utils/server-safe-globals.js';
 import { MediaThemeElement } from '../media-theme-element.js';
 
 const template = document.createElement('template');
@@ -126,6 +126,8 @@ class MediaThemeResponsive extends MediaThemeElement {
   static template = template;
 }
 
-defineCustomElement('media-theme-responsive', MediaThemeResponsive);
+if (!window.customElements.get('media-theme-responsive')) {
+  window.customElements.define('media-theme-responsive', MediaThemeResponsive);
+}
 
 export default MediaThemeResponsive;

--- a/src/js/themes/media-theme-winamp.js
+++ b/src/js/themes/media-theme-winamp.js
@@ -1,4 +1,4 @@
-import { defineCustomElement } from '../utils/defineCustomElement.js';
+import { window } from '../utils/server-safe-globals.js';
 import { MediaThemeElement } from '../media-theme-element.js';
 
 const template = document.createElement('template');
@@ -413,6 +413,8 @@ class MediaThemeWinamp extends MediaThemeElement {
   static template = template;
 }
 
-defineCustomElement('media-theme-winamp', MediaThemeWinamp);
+if (!window.customElements.get('media-theme-winamp')) {
+  window.customElements.define('media-theme-winamp', MediaThemeWinamp);
+}
 
 export default MediaThemeWinamp;

--- a/src/js/themes/media-theme-youtube.js
+++ b/src/js/themes/media-theme-youtube.js
@@ -7,7 +7,7 @@
 </media-theme-youtube>
 */
 
-import { defineCustomElement } from '../utils/defineCustomElement.js';
+import { window } from '../utils/server-safe-globals.js';
 import { MediaThemeElement } from '../media-theme-element.js';
 
 const template = document.createElement('template');
@@ -154,6 +154,8 @@ class MediaThemeYoutube extends MediaThemeElement {
   static template = template;
 }
 
-defineCustomElement('media-theme-youtube', MediaThemeYoutube);
+if (!window.customElements.get('media-theme-youtube')) {
+  window.customElements.define('media-theme-youtube', MediaThemeYoutube);
+}
 
 export default MediaThemeYoutube;

--- a/src/js/themes/media-theme.js
+++ b/src/js/themes/media-theme.js
@@ -1,8 +1,4 @@
-import { defineCustomElement } from '../utils/defineCustomElement.js';
-import {
-  Window as window,
-  Document as document,
-} from '../utils/server-safe-globals.js';
+import { window, document } from '../utils/server-safe-globals.js';
 
 class MediaTheme extends window.HTMLElement {
   static template = '';
@@ -33,6 +29,8 @@ class MediaTheme extends window.HTMLElement {
   }
 }
 
-defineCustomElement('media-theme-base', MediaTheme);
+if (!window.customElements.get('media-theme-base')) {
+  window.customElements.define('media-theme-base', MediaTheme);
+}
 
 export default MediaTheme;

--- a/src/js/utils/defineCustomElement.js
+++ b/src/js/utils/defineCustomElement.js
@@ -1,8 +1,0 @@
-import { Window as window } from './server-safe-globals.js';
-
-export function defineCustomElement(name, element) {
-  if (!window.customElements.get(name)) {
-    window.customElements.define(name, element);
-    window[element.name] = element;
-  }
-}

--- a/src/js/utils/fullscreenApi.js
+++ b/src/js/utils/fullscreenApi.js
@@ -1,4 +1,4 @@
-import { Document as document } from './server-safe-globals.js';
+import { document } from './server-safe-globals.js';
 
 export const fullscreenApi = {
   enter: 'requestFullscreen',

--- a/src/js/utils/server-safe-globals.js
+++ b/src/js/utils/server-safe-globals.js
@@ -6,7 +6,12 @@ class EventTarget {
   }
 }
 
+class ResizeObserver {
+  observe() {}
+}
+
 const windowShim = {
+  ResizeObserver,
   HTMLElement: class HTMLElement extends EventTarget {},
   DocumentFragment: class DocumentFragment extends EventTarget {},
   customElements: {
@@ -44,6 +49,7 @@ export const isServer =
   * document?,
   * chrome?,
   * DocumentFragment?,
+  * ResizeObserver?
   * } }
   * */
 export const Window = isServer ? windowShim : window;
@@ -60,3 +66,5 @@ export const Window = isServer ? windowShim : window;
   * } }
   */
 export const Document = isServer ? documentShim : window.document;
+
+export { Window as window, Document as document };

--- a/src/js/utils/template-parts.js
+++ b/src/js/utils/template-parts.js
@@ -1,4 +1,4 @@
-import { Window as window } from '../utils/server-safe-globals.js';
+import { window } from '../utils/server-safe-globals.js';
 
 /* Adapted from https://github.com/dy/template-parts - ISC - Dmitry Iv. */
 


### PR DESCRIPTION
fixes #252

Removes the `defineCustomElement` utility function as well which is simpler and works better with custom element tooling like the custom element analyzer https://custom-elements-manifest.open-wc.org/analyzer/getting-started/