### PR TITLE
Feat/configurable fullscreen element

### DIFF
--- a/docs/src/pages/en/media-controller.md
+++ b/docs/src/pages/en/media-controller.md
@@ -111,3 +111,26 @@ By default, when a user unpauses a live stream, media-controller will also autom
   ...
 </media-controller>
 ```
+
+### fullscreen-element
+
+`fullscreen-element` (`id` string)
+
+By default, the media-controller will be the target element when entering fullscreen. However, you may specify a different element by setting `fullscreen-element` to that
+element's `id` attribute.
+
+```html
+<div id="wrapper">
+  <media-controller fullscreen-element="wrapper">
+    ...
+  </media-controller>
+  <div>This will show up when in fullscreen.</div>
+  ...
+</div>
+```
+
+NOTE: For more advanced use cases, there is also the `fullscreenElement` property, which allows you to set the target fullscreen element by reference instead.
+
+```js
+mediaControllerEl.fullscreenElement = myWrapperEl;
+```

--- a/examples/index.html
+++ b/examples/index.html
@@ -14,6 +14,7 @@
       <li><a href="mobile.html">Mobile example</a></li>
       <li><a href="vertical.html">Vertical video example</a></li>
       <li><a href="casting.html">Casting video example</a></li>
+      <li><a href="wrapper.html">Using a wrapper element for your UI</a></li>
       <li><a href="standalone-controls.html">Standalone controls</a></li>
       <li><a href="disabled.html">Disabled controls</a></li>
       <li>

--- a/examples/standalone-controls.html
+++ b/examples/standalone-controls.html
@@ -26,7 +26,7 @@
       <h1>Standalone Controls Example</h1>
       <p>
         This example shows how individual controls can be used without the
-        <code>media-container</code> element.
+        <code>media-controller</code> element.
       </p>
 
       <media-controller id="controller">

--- a/examples/wrapper.html
+++ b/examples/wrapper.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width" />
+    <title>Media Chrome Standalone Controls Example</title>
+    <script type="module" src="../dist/index.js"></script>
+    <style>
+      /** add styles to prevent CLS (Cumulative Layout Shift) */
+      media-controller:not([audio]) {
+        aspect-ratio: 16 / 9; /* set container aspect ratio if preload=none */
+      }
+
+      #wrapper {
+        display: flex;
+        flex-direction: column;
+        width: 50vw;
+        align-items: stretch;
+      }
+
+      #wrapper > media-control-bar {
+        flex-grow: 0;
+        flex-shrink: 1;
+      }
+
+      #wrapper > .spacer {
+        background-color: var(--media-background-color, #000);
+        flex-grow: 1;
+      }
+
+      #wrapper > .fullscreen-overlay {
+        display: var(--fullscreen-overaly-display, none);
+        /* Can use fixed since we're fullscreen */
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        pointer-events: none;
+        color: #ffffff;
+      }
+
+      #wrapper:is(:fullscreen, :-webkit-full-screen, :-moz-full-screen, :-ms-fullscreen) {
+        --fullscreen-overaly-display: 'initial';
+      }
+
+      video {
+        width: 100%; /* prevents video to expand beyond its container */
+      }
+
+      .examples {
+        margin-top: 20px;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Using a Wrapper Element with Media Chrome Example</h1>
+      <p>
+        This example shows how you can use a wrapper element for your Player UI
+        or "chrome". It takes advantage of:
+      </p>
+      <ul>
+        <li>
+          Using "Standalone controls" via the
+          <code>media-controller</code> attribute
+        </li>
+        <li>
+          Targetting the wrapper instead of the <code>media-controller</code> via the
+          <code>fullscreen-element</code> attribute
+        </li>
+        <li>
+          Using CSS selectors and CSS variables to show an overlay only when in fullscreen.
+        </li>
+      </ul>
+
+      <span id="wrapper">
+        <media-controller fullscreen-element="wrapper" id="controller">
+          <video
+            playsinline
+            slot="media"
+            src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/high.mp4"
+          >
+            <track
+              label="English"
+              kind="captions"
+              srclang="en"
+              default
+              src="./vtt/en-cc.vtt"
+            />
+          </video>
+        </media-controller>
+        <div class="spacer"></div>
+        <media-control-bar media-controller="controller">
+          <media-play-button></media-play-button>
+          <media-mute-button></media-mute-button>
+          <media-seek-backward-button></media-seek-backward-button>
+          <media-seek-forward-button></media-seek-forward-button>
+          <media-volume-range></media-volume-range>
+          <media-time-range></media-time-range>
+          <media-time-display remaining show-duration></media-time-display>
+          <media-captions-button></media-captions-button>
+          <media-playback-rate-button></media-playback-rate-button>
+          <media-pip-button></media-pip-button>
+          <media-fullscreen-button></media-fullscreen-button>
+        </media-control-bar>
+        <span class="fullscreen-overlay">
+          <span>This is an overlay</span>
+        </span>
+      </span>
+
+      <div class="examples">
+        <a href="./">View more examples</a>
+      </div>
+    </main>
+  </body>
+</html>

--- a/examples/wrapper.html
+++ b/examples/wrapper.html
@@ -28,7 +28,7 @@
       }
 
       #wrapper > .fullscreen-overlay {
-        display: var(--fullscreen-overaly-display, none);
+        display: var(--fullscreen-overlay-display, none);
         /* Can use fixed since we're fullscreen */
         position: fixed;
         top: 0;

--- a/examples/wrapper.html
+++ b/examples/wrapper.html
@@ -40,7 +40,7 @@
       }
 
       #wrapper:is(:fullscreen, :-webkit-full-screen, :-moz-full-screen, :-ms-fullscreen) {
-        --fullscreen-overaly-display: 'initial';
+        --fullscreen-overlay-display: initial;
       }
 
       video {

--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -48,6 +48,7 @@ class MediaController extends MediaContainer {
   }
 
   #hotKeys = new AttributeTokenList(this, 'hotkeys');
+  #fullscreenElement;
 
   constructor() {
     super();
@@ -161,7 +162,7 @@ class MediaController extends MediaContainer {
 
         if (super[fullscreenApi.enter]) {
           // Media chrome container fullscreen
-          super[fullscreenApi.enter]();
+          this.fullscreenElement[fullscreenApi.enter]();
         } else if (media.webkitEnterFullscreen) {
           // Media element fullscreen using iOS API
           media.webkitEnterFullscreen();
@@ -426,7 +427,7 @@ class MediaController extends MediaContainer {
         // could be several ancestors up the tree. Use event.target instead.
         const isSomeElementFullscreen = !!document[fullscreenApi.element];
         const fullscreenEl = isSomeElementFullscreen && e?.target;
-        const isFullScreen = containsComposedNode(this, fullscreenEl);
+        const isFullScreen = containsComposedNode(this.fullscreenElement, fullscreenEl);
         this.propagateMediaState(
           MediaUIAttributes.MEDIA_IS_FULLSCREEN,
           isFullScreen
@@ -576,6 +577,17 @@ class MediaController extends MediaContainer {
     };
 
     this.enableHotkeys();
+  }
+
+  get fullscreenElement() {
+    if (this.hasAttribute('fullscreen-element')) {
+      return document.getElementById(this.getAttribute('fullscreen-element'));
+    }
+    return this.#fullscreenElement ?? this;
+  }
+
+  set fullscreenElement(element) {
+    this.#fullscreenElement = element;
   }
 
   attributeChangedCallback(attrName, oldValue, newValue) {

--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -606,6 +606,7 @@ class MediaController extends MediaContainer {
       this.propagateMediaState(MediaUIAttributes.MEDIA_STREAM_TYPE);
     } else if (attrName === 'fullscreen-element') {
       const el = newValue 
+        // @ts-ignore
         ? this.getRootNode()?.getElementById(newValue) 
         : undefined;
       // NOTE: Setting the internal private prop here to not

--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -606,7 +606,7 @@ class MediaController extends MediaContainer {
       this.propagateMediaState(MediaUIAttributes.MEDIA_STREAM_TYPE);
     } else if (attrName === 'fullscreen-element') {
       const el = newValue 
-        ? document.getElementById('fullscreen-element') 
+        ? this.getRootNode()?.getElementById(newValue) 
         : undefined;
       // NOTE: Setting the internal private prop here to not
       // clear the attribute that was just set (CJP).

--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -580,13 +580,13 @@ class MediaController extends MediaContainer {
   }
 
   get fullscreenElement() {
-    if (this.hasAttribute('fullscreen-element')) {
-      return document.getElementById(this.getAttribute('fullscreen-element'));
-    }
     return this.#fullscreenElement ?? this;
   }
 
   set fullscreenElement(element) {
+    if (this.hasAttribute('fullscreen-element')) {
+      this.removeAttribute('fullscreen-element');
+    }
     this.#fullscreenElement = element;
   }
 
@@ -604,6 +604,13 @@ class MediaController extends MediaContainer {
         this.#hotKeys.value = newValue;
     } else if (attrName === 'default-stream-type') {
       this.propagateMediaState(MediaUIAttributes.MEDIA_STREAM_TYPE);
+    } else if (attrName === 'fullscreen-element') {
+      const el = newValue 
+        ? document.getElementById('fullscreen-element') 
+        : undefined;
+      // NOTE: Setting the internal private prop here to not
+      // clear the attribute that was just set (CJP).
+      this.#fullscreenElement = el;
     }
 
     super.attributeChangedCallback(attrName, oldValue, newValue);


### PR DESCRIPTION
This PR adds the ability to target something other than the `<media-controller/>` instance for fullscreen. It also adds an example that takes advantage of this.

TODO:
- [x] Update Docs