### PR TITLE
fix(minimal-slotted-media): Do not assume media.seekable will be defi…

### DIFF
--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -1040,7 +1040,9 @@ const Delegates = {
       return true;
     }
 
-    if (seekable.length === 0) {
+    // If the slotted media does not provide a `seekable` property or its length is falsey,
+    // assume the media is not live.
+    if (!seekable?.length) {
       return false;
     }
 


### PR DESCRIPTION
…ned on the slotted media.

Fixes an RTE in our current (incomplete API) implementation of `<vimeo-element>`