### PR TITLE
fix: Media Live Button style changes during live window

### DIFF
--- a/src/js/media-live-button.js
+++ b/src/js/media-live-button.js
@@ -22,10 +22,14 @@ slotTemplate.innerHTML = `
     color: var(--media-live-button-icon-color, rgb(140, 140, 140));
   }
 
-  :host(:not([${MEDIA_PAUSED}])[${MEDIA_TIME_IS_LIVE}]) slot[name=indicator] > *,
-  :host(:not([${MEDIA_PAUSED}])[${MEDIA_TIME_IS_LIVE}]) ::slotted([slot=indicator]) {
+  :host([${MEDIA_TIME_IS_LIVE}]) slot[name=indicator] > *,
+  :host([${MEDIA_TIME_IS_LIVE}]) ::slotted([slot=indicator]) {
     fill: var(--media-live-indicator-color, rgb(255, 0, 0));
     color: var(--media-live-indicator-color, rgb(255, 0, 0));
+  }
+
+  :host([${MEDIA_TIME_IS_LIVE}]) {
+    cursor: not-allowed;
   }
 
   </style>


### PR DESCRIPTION
- Makes the live indicator remain visually active while we are within the live window, as opposed to going grey immediately after pausing
- Shows disabled cursor for the button while within the live window, mimics old behaviour

@cjpillsbury can you double check these are as we discussed