### PR TITLE
Etch-a-sketch theme

### DIFF
--- a/examples/themes/etch.html
+++ b/examples/themes/etch.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width" />
+    <title>Media Chrome Etch-a-Sketch Theme</title>
+    <script type="module" src="../../dist/index.js"></script>
+  </head>
+  <body>
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+
+      .examples {
+        margin-top: 20px;
+      }
+
+      #playerContainer {
+        width: 1120px;
+        padding: 95px 80px 0 80px;
+        background-color: #FE5F5F;
+        border-radius: 24px;
+        box-shadow: 10px 5px 0px #900;
+      }
+
+      media-controller {
+        width: 960px;
+        height: 540px;
+        margin: 0px auto;
+      }
+
+      media-control-bar {
+        height: 35px;
+        padding: 0;
+
+
+      }
+
+      media-time-range, media-volume-range {
+        --media-range-padding: 0;
+
+        --media-range-bar-color: #ccc;
+        --thumb-height: 0;
+        --thumb-width: 0;
+        --track-height: 100%;
+        --track-width: 100%;
+      }
+
+      #knobs {
+        display: flex;
+        justify-content: space-between;
+        padding: 20px 0;
+        margin: 0 -50px 0 -50px;
+      }
+
+      .knob {
+        background-color: #DED9D9;
+        height: 95px;
+        width: 95px;
+        color: #000;
+        border-radius: 50px;
+        --media-icon-color: #000;
+        --media-button-icon-height: 35px;
+        box-shadow: 5px 5px 0px rgba(0,0,0,0.25);
+      }
+
+
+    </style>
+
+    <main>
+      <h1>Media Chrome Etch-a-Sketch Theme</h1>
+
+      <div id="playerContainer">
+        <media-controller id="etchController">
+          <video
+            slot="media"
+            src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/high.mp4"
+            crossorigin
+            muted
+            playsinline
+          ></video>
+          <media-control-bar>
+            <media-play-button></media-play-button>
+            <media-time-range></media-time-range>
+            <media-mute-button></media-mute-button>
+            <media-volume-range></media-volume-range>
+          </media-control-bar>
+        </media-controller>
+
+        <div id="knobs">
+          <media-play-button media-controller="etchController" id="leftKnob" class="knob"></media-play-button>
+          <div id="title"></div>
+          <media-mute-button media-controller="etchController" id="rightKnob" class="knob"></media-mute-button>
+        </div>
+
+
+      </div>
+
+
+      <media-controller id="etchController2">
+        <video
+          slot="media"
+          src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/high.mp4"
+          crossorigin
+          muted
+          playsinline
+        ></video>
+      </media-controller>
+
+      <media-play-button media-controller="etchController2" id="leftKnob" class="knob"></media-play-button>
+
+      <div class="examples">
+        <a href="../">View more examples</a>
+      </div>
+    </main>
+  </body>
+</html>

--- a/examples/themes/etch.html
+++ b/examples/themes/etch.html
@@ -4,202 +4,22 @@
   <meta name="viewport" content="width=device-width" />
   <title>Media Chrome Etch-a-Sketch Theme</title>
   <script type="module" src="../../dist/index.js"></script>
-  <script
-    type="module"
-    src="https://cdn.jsdelivr.net/npm/media-chrome@0.17/dist/media-theme-element.js"
-  ></script>
+  <script type="module" src="../../src/js/themes/media-theme-etch-a-sketch.js"></script>
 </head>
 <body>
 
 <main>
 <h1>Media Chrome Etch-a-Sketch Theme</h1>
 
-<template id="etch">
-  <style>
-    * {
-      box-sizing: border-box;
-    }
-
-    .examples {
-      margin-top: 20px;
-    }
-
-    #playerContainer {
-      width: 1120px;
-      padding: 95px 80px 0 80px;
-      background-color: #FE5F5F;
-      border-radius: 24px;
-      box-shadow: 10px 5px 0px #900;
-    }
-
-    media-controller {
-      width: 960px;
-      height: 540px;
-      margin: 0px auto;
-    }
-
-    media-control-bar {
-      height: 35px;
-      padding: 0;
-
-
-    }
-
-    media-time-range, media-volume-range {
-      --media-range-padding: 0;
-
-      --media-range-bar-color: #ccc;
-      --thumb-height: 0;
-      --thumb-width: 0;
-      --track-height: 100%;
-      --track-width: 100%;
-    }
-
-    #knobs {
-      display: flex;
-      justify-content: space-between;
-      padding: 20px 0;
-      margin: 0 -50px 0 -50px;
-    }
-
-    .knob {
-      background-color: #DED9D9;
-      height: 95px;
-      width: 95px;
-      color: #000;
-      border-radius: 50px;
-      --media-icon-color: #000;
-      --media-button-icon-height: 35px;
-      box-shadow: 5px 5px 0px rgba(0,0,0,0.25);
-    }
-  </style>
-
-  <div id="playerContainer">
-    <media-controller id="etchController1">
-      <slot name="media" slot="media"></slot>
-      <media-control-bar>
-        <media-play-button></media-play-button>
-        <media-time-range></media-time-range>
-        <media-mute-button></media-mute-button>
-        <media-volume-range></media-volume-range>
-      </media-control-bar>
-    </media-controller>
-
-    <div id="knobs">
-      <media-play-button media-controller="etchController1" id="leftKnob" class="knob"></media-play-button>
-      <div id="title"></div>
-      <media-mute-button media-controller="etchController1" id="rightKnob" class="knob"></media-mute-button>
-    </div>
-  </div>
-</template>
-
-<media-theme template="etch">
+<media-theme-etch-a-sketch>
   <video
     slot="media"
-    src="https://stream.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/high.mp4"
+    src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/high.mp4"
+    crossorigin
     muted
     playsinline
-    crossorigin
   ></video>
-</media-theme>
-
-
-<br><br>
-
-<style>
-  * {
-    box-sizing: border-box;
-  }
-
-  .examples {
-    margin-top: 20px;
-  }
-
-  #playerContainer {
-    width: 1120px;
-    padding: 95px 80px 0 80px;
-    background-color: #FE5F5F;
-    border-radius: 24px;
-    box-shadow: 10px 5px 0px #900;
-  }
-
-  media-controller {
-    width: 960px;
-    height: 540px;
-    margin: 0px auto;
-  }
-
-  media-control-bar {
-    height: 35px;
-    padding: 0;
-
-
-  }
-
-  media-time-range, media-volume-range {
-    --media-range-padding: 0;
-
-    --media-range-bar-color: #ccc;
-    --thumb-height: 0;
-    --thumb-width: 0;
-    --track-height: 100%;
-    --track-width: 100%;
-  }
-
-  #knobs {
-    display: flex;
-    justify-content: space-between;
-    padding: 20px 0;
-    margin: 0 -50px 0 -50px;
-  }
-
-  .knob {
-    background-color: #DED9D9;
-    height: 95px;
-    width: 95px;
-    color: #000;
-    border-radius: 50px;
-    --media-icon-color: #000;
-    --media-button-icon-height: 35px;
-    box-shadow: 5px 5px 0px rgba(0,0,0,0.25);
-  }
-</style>
-
-<div id="playerContainer">
-  <media-controller id="etchController2">
-    <video
-    slot="media"
-    src="https://stream.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/high.mp4"
-    muted
-    playsinline
-    crossorigin
-  ></video>
-    <media-control-bar>
-      <media-play-button></media-play-button>
-      <media-time-range></media-time-range>
-      <media-mute-button></media-mute-button>
-      <media-volume-range></media-volume-range>
-    </media-control-bar>
-  </media-controller>
-
-  <div id="knobs">
-    <media-play-button media-controller="etchController2" id="leftKnob" class="knob"></media-play-button>
-    <div id="title"></div>
-    <media-mute-button media-controller="etchController2" id="rightKnob" class="knob"></media-mute-button>
-  </div>
-</div>
-
-      <!-- <media-controller id="etchController2">
-        <video
-          slot="media"
-          src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/high.mp4"
-          crossorigin
-          muted
-          playsinline
-        ></video>
-      </media-controller>
-
-      <media-play-button media-controller="etchController2" id="leftKnob" class="knob"></media-play-button> -->
+</media-theme-etch-a-sketch>
 
 
 </main>

--- a/examples/themes/etch.html
+++ b/examples/themes/etch.html
@@ -1,103 +1,195 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta name="viewport" content="width=device-width" />
-    <title>Media Chrome Etch-a-Sketch Theme</title>
-    <script type="module" src="../../dist/index.js"></script>
-  </head>
-  <body>
-    <style>
-      * {
-        box-sizing: border-box;
-      }
+<head>
+  <meta name="viewport" content="width=device-width" />
+  <title>Media Chrome Etch-a-Sketch Theme</title>
+  <script type="module" src="../../dist/index.js"></script>
+  <script
+    type="module"
+    src="https://cdn.jsdelivr.net/npm/media-chrome@0.17/dist/media-theme-element.js"
+  ></script>
+</head>
+<body>
 
-      .examples {
-        margin-top: 20px;
-      }
+<main>
+<h1>Media Chrome Etch-a-Sketch Theme</h1>
 
-      #playerContainer {
-        width: 1120px;
-        padding: 95px 80px 0 80px;
-        background-color: #FE5F5F;
-        border-radius: 24px;
-        box-shadow: 10px 5px 0px #900;
-      }
+<template id="etch">
+  <style>
+    * {
+      box-sizing: border-box;
+    }
 
-      media-controller {
-        width: 960px;
-        height: 540px;
-        margin: 0px auto;
-      }
+    .examples {
+      margin-top: 20px;
+    }
 
-      media-control-bar {
-        height: 35px;
-        padding: 0;
+    #playerContainer {
+      width: 1120px;
+      padding: 95px 80px 0 80px;
+      background-color: #FE5F5F;
+      border-radius: 24px;
+      box-shadow: 10px 5px 0px #900;
+    }
 
+    media-controller {
+      width: 960px;
+      height: 540px;
+      margin: 0px auto;
+    }
 
-      }
-
-      media-time-range, media-volume-range {
-        --media-range-padding: 0;
-
-        --media-range-bar-color: #ccc;
-        --thumb-height: 0;
-        --thumb-width: 0;
-        --track-height: 100%;
-        --track-width: 100%;
-      }
-
-      #knobs {
-        display: flex;
-        justify-content: space-between;
-        padding: 20px 0;
-        margin: 0 -50px 0 -50px;
-      }
-
-      .knob {
-        background-color: #DED9D9;
-        height: 95px;
-        width: 95px;
-        color: #000;
-        border-radius: 50px;
-        --media-icon-color: #000;
-        --media-button-icon-height: 35px;
-        box-shadow: 5px 5px 0px rgba(0,0,0,0.25);
-      }
+    media-control-bar {
+      height: 35px;
+      padding: 0;
 
 
-    </style>
+    }
 
-    <main>
-      <h1>Media Chrome Etch-a-Sketch Theme</h1>
+    media-time-range, media-volume-range {
+      --media-range-padding: 0;
 
-      <div id="playerContainer">
-        <media-controller id="etchController">
-          <video
-            slot="media"
-            src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/high.mp4"
-            crossorigin
-            muted
-            playsinline
-          ></video>
-          <media-control-bar>
-            <media-play-button></media-play-button>
-            <media-time-range></media-time-range>
-            <media-mute-button></media-mute-button>
-            <media-volume-range></media-volume-range>
-          </media-control-bar>
-        </media-controller>
+      --media-range-bar-color: #ccc;
+      --thumb-height: 0;
+      --thumb-width: 0;
+      --track-height: 100%;
+      --track-width: 100%;
+    }
 
-        <div id="knobs">
-          <media-play-button media-controller="etchController" id="leftKnob" class="knob"></media-play-button>
-          <div id="title"></div>
-          <media-mute-button media-controller="etchController" id="rightKnob" class="knob"></media-mute-button>
-        </div>
+    #knobs {
+      display: flex;
+      justify-content: space-between;
+      padding: 20px 0;
+      margin: 0 -50px 0 -50px;
+    }
+
+    .knob {
+      background-color: #DED9D9;
+      height: 95px;
+      width: 95px;
+      color: #000;
+      border-radius: 50px;
+      --media-icon-color: #000;
+      --media-button-icon-height: 35px;
+      box-shadow: 5px 5px 0px rgba(0,0,0,0.25);
+    }
+  </style>
+
+  <div id="playerContainer">
+    <media-controller id="etchController1">
+      <slot name="media" slot="media"></slot>
+      <media-control-bar>
+        <media-play-button></media-play-button>
+        <media-time-range></media-time-range>
+        <media-mute-button></media-mute-button>
+        <media-volume-range></media-volume-range>
+      </media-control-bar>
+    </media-controller>
+
+    <div id="knobs">
+      <media-play-button media-controller="etchController1" id="leftKnob" class="knob"></media-play-button>
+      <div id="title"></div>
+      <media-mute-button media-controller="etchController1" id="rightKnob" class="knob"></media-mute-button>
+    </div>
+  </div>
+</template>
+
+<media-theme template="etch">
+  <video
+    slot="media"
+    src="https://stream.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/high.mp4"
+    muted
+    playsinline
+    crossorigin
+  ></video>
+</media-theme>
 
 
-      </div>
+<br><br>
+
+<style>
+  * {
+    box-sizing: border-box;
+  }
+
+  .examples {
+    margin-top: 20px;
+  }
+
+  #playerContainer {
+    width: 1120px;
+    padding: 95px 80px 0 80px;
+    background-color: #FE5F5F;
+    border-radius: 24px;
+    box-shadow: 10px 5px 0px #900;
+  }
+
+  media-controller {
+    width: 960px;
+    height: 540px;
+    margin: 0px auto;
+  }
+
+  media-control-bar {
+    height: 35px;
+    padding: 0;
 
 
-      <media-controller id="etchController2">
+  }
+
+  media-time-range, media-volume-range {
+    --media-range-padding: 0;
+
+    --media-range-bar-color: #ccc;
+    --thumb-height: 0;
+    --thumb-width: 0;
+    --track-height: 100%;
+    --track-width: 100%;
+  }
+
+  #knobs {
+    display: flex;
+    justify-content: space-between;
+    padding: 20px 0;
+    margin: 0 -50px 0 -50px;
+  }
+
+  .knob {
+    background-color: #DED9D9;
+    height: 95px;
+    width: 95px;
+    color: #000;
+    border-radius: 50px;
+    --media-icon-color: #000;
+    --media-button-icon-height: 35px;
+    box-shadow: 5px 5px 0px rgba(0,0,0,0.25);
+  }
+</style>
+
+<div id="playerContainer">
+  <media-controller id="etchController2">
+    <video
+    slot="media"
+    src="https://stream.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/high.mp4"
+    muted
+    playsinline
+    crossorigin
+  ></video>
+    <media-control-bar>
+      <media-play-button></media-play-button>
+      <media-time-range></media-time-range>
+      <media-mute-button></media-mute-button>
+      <media-volume-range></media-volume-range>
+    </media-control-bar>
+  </media-controller>
+
+  <div id="knobs">
+    <media-play-button media-controller="etchController2" id="leftKnob" class="knob"></media-play-button>
+    <div id="title"></div>
+    <media-mute-button media-controller="etchController2" id="rightKnob" class="knob"></media-mute-button>
+  </div>
+</div>
+
+      <!-- <media-controller id="etchController2">
         <video
           slot="media"
           src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/high.mp4"
@@ -107,11 +199,9 @@
         ></video>
       </media-controller>
 
-      <media-play-button media-controller="etchController2" id="leftKnob" class="knob"></media-play-button>
+      <media-play-button media-controller="etchController2" id="leftKnob" class="knob"></media-play-button> -->
 
-      <div class="examples">
-        <a href="../">View more examples</a>
-      </div>
-    </main>
-  </body>
+
+</main>
+</body>
 </html>

--- a/src/js/media-chrome-button.js
+++ b/src/js/media-chrome-button.js
@@ -158,7 +158,7 @@ class MediaChromeButton extends window.HTMLElement {
       MediaStateReceiverAttributes.MEDIA_CONTROLLER
     );
     if (mediaControllerId) {
-      const mediaControllerEl = document.getElementById(mediaControllerId);
+      const mediaControllerEl = this.getRootNode().getElementById(mediaControllerId);
       mediaControllerEl?.associateElement?.(this);
     }
   }

--- a/src/js/media-chrome-button.js
+++ b/src/js/media-chrome-button.js
@@ -157,9 +157,16 @@ class MediaChromeButton extends window.HTMLElement {
     const mediaControllerId = this.getAttribute(
       MediaStateReceiverAttributes.MEDIA_CONTROLLER
     );
+
     if (mediaControllerId) {
-      const mediaControllerEl = this.getRootNode().getElementById(mediaControllerId);
-      mediaControllerEl?.associateElement?.(this);
+      const rootNode = this.getRootNode();
+
+      // @ts-ignore
+      if (rootNode?.getElementById) {
+        // @ts-ignore
+        const mediaControllerEl = rootNode.getElementById(mediaControllerId);
+        mediaControllerEl?.associateElement?.(this);
+      }
     }
   }
 

--- a/src/js/themes/media-theme-etch-a-sketch.js
+++ b/src/js/themes/media-theme-etch-a-sketch.js
@@ -1,0 +1,99 @@
+/* 
+<media-theme-etch-a-sketch>
+  <video
+    slot="media"
+    src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/high.mp4"
+  ></video>
+</media-theme-etch-a-sketch>
+*/
+
+import { window } from '../utils/server-safe-globals.js';
+import { MediaThemeElement } from '../media-theme-element.js';
+
+const template = document.createElement('template');
+template.innerHTML = `
+<style>
+* {
+  box-sizing: border-box;
+}
+
+.examples {
+  margin-top: 20px;
+}
+
+#playerContainer {
+  width: 1120px;
+  padding: 95px 80px 0 80px;
+  background-color: #FE5F5F;
+  border-radius: 24px;
+  box-shadow: 10px 5px 0px #900;
+}
+
+media-controller {
+  width: 960px;
+  height: 540px;
+  margin: 0px auto;
+}
+
+media-control-bar {
+  height: 35px;
+  padding: 0;
+}
+
+media-time-range, media-volume-range {
+  --media-range-padding: 0;
+
+  --media-range-bar-color: #ccc;
+  --thumb-height: 0;
+  --thumb-width: 0;
+  --track-height: 100%;
+  --track-width: 100%;
+}
+
+#knobs {
+  display: flex;
+  justify-content: space-between;
+  padding: 20px 0;
+  margin: 0 -50px 0 -50px;
+}
+
+.knob {
+  background-color: #DED9D9;
+  height: 95px;
+  width: 95px;
+  color: #000;
+  border-radius: 50px;
+  --media-icon-color: #000;
+  --media-button-icon-height: 35px;
+  box-shadow: 5px 5px 0px rgba(0,0,0,0.25);
+}
+</style>
+
+<div id="playerContainer">
+  <media-controller id="etchController1">
+    <slot name="media" slot="media"></slot>
+    <media-control-bar>
+      <media-play-button></media-play-button>
+      <media-time-range></media-time-range>
+      <media-mute-button></media-mute-button>
+      <media-volume-range></media-volume-range>
+    </media-control-bar>
+  </media-controller>
+
+  <div id="knobs">
+    <media-play-button media-controller="etchController1" id="leftKnob" class="knob"></media-play-button>
+    <div id="title"></div>
+    <media-mute-button media-controller="etchController1" id="rightKnob" class="knob"></media-mute-button>
+  </div>
+</div>
+`;
+
+class MediaThemeEtchASketch extends MediaThemeElement {
+  static template = template;
+}
+
+if (!window.customElements.get('media-theme-etch-a-sketch')) {
+  window.customElements.define('media-theme-etch-a-sketch', MediaThemeEtchASketch);
+}
+
+export default MediaThemeEtchASketch;


### PR DESCRIPTION
Pretty simple implementation.

+Had to fix the media-controller attribute in chrome-button so it can work inside a shadow dom. Should be applied (in a followup) to other components.

Goals for a more advanced one (later PRs):
* Make the knobs actually work
  * Left knob seeks
  * Right knob increases volume
* Add shine to the corners to make it look more real-ish
* On mobile, shake the device to start over (@dylanjha 's idea 😆)

<img width="1156" alt="image" src="https://user-images.githubusercontent.com/166/214977807-e4ce1580-aa62-4c0e-ba08-3870fa2ffe95.png">
