### PR TITLE
fix: decoupled controller in media-theme

### DIFF
--- a/src/js/media-chrome-button.js
+++ b/src/js/media-chrome-button.js
@@ -131,12 +131,13 @@ class MediaChromeButton extends window.HTMLElement {
   attributeChangedCallback(attrName, oldValue, newValue) {
     if (attrName === MediaStateReceiverAttributes.MEDIA_CONTROLLER) {
       if (oldValue) {
-        const mediaControllerEl = document.getElementById(oldValue);
-        mediaControllerEl?.unassociateElement?.(this);
+        this.mediaController?.unassociateElement?.(this);
+        this.mediaController = null;
       }
       if (newValue) {
-        const mediaControllerEl = document.getElementById(newValue);
-        mediaControllerEl?.associateElement?.(this);
+        // @ts-ignore
+        this.mediaController = this.getRootNode()?.getElementById(newValue);
+        this.mediaController?.associateElement?.(this);
       }
     } else if (attrName === 'disabled' && newValue !== oldValue) {
       if (newValue == null) {
@@ -158,21 +159,16 @@ class MediaChromeButton extends window.HTMLElement {
       MediaStateReceiverAttributes.MEDIA_CONTROLLER
     );
     if (mediaControllerId) {
-      const mediaControllerEl = document.getElementById(mediaControllerId);
-      mediaControllerEl?.associateElement?.(this);
+      // @ts-ignore
+      this.mediaController = this.getRootNode()?.getElementById(mediaControllerId);
+      this.mediaController?.associateElement?.(this);
     }
   }
 
   disconnectedCallback() {
     this.disable();
-
-    const mediaControllerId = this.getAttribute(
-      MediaStateReceiverAttributes.MEDIA_CONTROLLER
-    );
-    if (mediaControllerId) {
-      const mediaControllerEl = document.getElementById(mediaControllerId);
-      mediaControllerEl?.unassociateElement?.(this);
-    }
+    // Use cached mediaController, getRootNode() doesn't work if disconnected.
+    this.mediaController?.unassociateElement?.(this);
   }
 
   get keysUsed() {

--- a/src/js/media-chrome-button.js
+++ b/src/js/media-chrome-button.js
@@ -66,6 +66,8 @@ template.innerHTML = `
  * @extends {HTMLElement}
  */
 class MediaChromeButton extends window.HTMLElement {
+  #mediaController;
+
   static get observedAttributes() {
     return ['disabled', MediaStateReceiverAttributes.MEDIA_CONTROLLER];
   }
@@ -131,13 +133,13 @@ class MediaChromeButton extends window.HTMLElement {
   attributeChangedCallback(attrName, oldValue, newValue) {
     if (attrName === MediaStateReceiverAttributes.MEDIA_CONTROLLER) {
       if (oldValue) {
-        this.mediaController?.unassociateElement?.(this);
-        this.mediaController = null;
+        this.#mediaController?.unassociateElement?.(this);
+        this.#mediaController = null;
       }
       if (newValue) {
         // @ts-ignore
-        this.mediaController = this.getRootNode()?.getElementById(newValue);
-        this.mediaController?.associateElement?.(this);
+        this.#mediaController = this.getRootNode()?.getElementById(newValue);
+        this.#mediaController?.associateElement?.(this);
       }
     } else if (attrName === 'disabled' && newValue !== oldValue) {
       if (newValue == null) {
@@ -160,15 +162,16 @@ class MediaChromeButton extends window.HTMLElement {
     );
     if (mediaControllerId) {
       // @ts-ignore
-      this.mediaController = this.getRootNode()?.getElementById(mediaControllerId);
-      this.mediaController?.associateElement?.(this);
+      this.#mediaController = this.getRootNode()?.getElementById(mediaControllerId);
+      this.#mediaController?.associateElement?.(this);
     }
   }
 
   disconnectedCallback() {
     this.disable();
     // Use cached mediaController, getRootNode() doesn't work if disconnected.
-    this.mediaController?.unassociateElement?.(this);
+    this.#mediaController?.unassociateElement?.(this);
+    this.#mediaController = null;
   }
 
   get keysUsed() {

--- a/src/js/media-control-bar.js
+++ b/src/js/media-control-bar.js
@@ -30,6 +30,8 @@ template.innerHTML = `
 `;
 
 class MediaControlBar extends window.HTMLElement {
+  #mediaController;
+
   static get observedAttributes() {
     return [MediaStateReceiverAttributes.MEDIA_CONTROLLER];
   }
@@ -44,12 +46,13 @@ class MediaControlBar extends window.HTMLElement {
   attributeChangedCallback(attrName, oldValue, newValue) {
     if (attrName === MediaStateReceiverAttributes.MEDIA_CONTROLLER) {
       if (oldValue) {
-        const mediaControllerEl = document.getElementById(oldValue);
-        mediaControllerEl?.unassociateElement?.(this);
+        this.#mediaController?.unassociateElement?.(this);
+        this.#mediaController = null;
       }
       if (newValue) {
-        const mediaControllerEl = document.getElementById(newValue);
-        mediaControllerEl?.associateElement?.(this);
+        // @ts-ignore
+        this.#mediaController = this.getRootNode()?.getElementById(newValue);
+        this.#mediaController?.associateElement?.(this);
       }
     }
   }
@@ -59,19 +62,16 @@ class MediaControlBar extends window.HTMLElement {
       MediaStateReceiverAttributes.MEDIA_CONTROLLER
     );
     if (mediaControllerId) {
-      const mediaControllerEl = document.getElementById(mediaControllerId);
-      mediaControllerEl?.associateElement?.(this);
+      // @ts-ignore
+      this.#mediaController = this.getRootNode()?.getElementById(mediaControllerId);
+      this.#mediaController?.associateElement?.(this);
     }
   }
 
   disconnectedCallback() {
-    const mediaControllerId = this.getAttribute(
-      MediaStateReceiverAttributes.MEDIA_CONTROLLER
-    );
-    if (mediaControllerId) {
-      const mediaControllerEl = document.getElementById(mediaControllerId);
-      mediaControllerEl?.unassociateElement?.(this);
-    }
+    // Use cached mediaController, getRootNode() doesn't work if disconnected.
+    this.#mediaController?.unassociateElement?.(this);
+    this.#mediaController = null;
   }
 }
 

--- a/src/js/media-gesture-receiver.js
+++ b/src/js/media-gesture-receiver.js
@@ -75,7 +75,7 @@ class MediaGestureReceiver extends window.HTMLElement {
   }
 
   disconnectedCallback() {
-    this.#mediaController = getMediaControllerEl(this);
+    // Use cached mediaController, getRootNode() doesn't work if disconnected.
     if (this.getAttribute(MediaStateReceiverAttributes.MEDIA_CONTROLLER)) {
       this.#mediaController?.unassociateElement?.(this);
     }
@@ -154,7 +154,7 @@ function getMediaControllerEl(controlEl) {
     MediaStateReceiverAttributes.MEDIA_CONTROLLER
   );
   if (mediaControllerId) {
-    return this.getRootNode()?.getElementById(mediaControllerId);
+    return controlEl.getRootNode()?.getElementById(mediaControllerId);
   }
   return closestComposedNode(controlEl, 'media-controller');
 }

--- a/src/js/media-gesture-receiver.js
+++ b/src/js/media-gesture-receiver.js
@@ -19,6 +19,8 @@ template.innerHTML = `
 `;
 
 class MediaGestureReceiver extends window.HTMLElement {
+  #mediaController;
+
   // NOTE: Currently "baking in" actions + attrs until we come up with
   // a more robust architecture (CJP)
   static get observedAttributes() {
@@ -48,12 +50,13 @@ class MediaGestureReceiver extends window.HTMLElement {
   attributeChangedCallback(attrName, oldValue, newValue) {
     if (attrName === MediaStateReceiverAttributes.MEDIA_CONTROLLER) {
       if (oldValue) {
-        const mediaControllerEl = document.getElementById(oldValue);
-        mediaControllerEl?.unassociateElement?.(this);
+        this.#mediaController?.unassociateElement?.(this);
+        this.#mediaController = null;
       }
       if (newValue) {
-        const mediaControllerEl = document.getElementById(newValue);
-        mediaControllerEl?.associateElement?.(this);
+        // @ts-ignore
+        this.#mediaController = this.getRootNode()?.getElementById(newValue);
+        this.#mediaController?.associateElement?.(this);
       }
     }
   }
@@ -62,23 +65,24 @@ class MediaGestureReceiver extends window.HTMLElement {
     this.setAttribute('tabindex', -1);
     this.setAttribute('aria-hidden', true);
 
-    const mediaControllerEl = getMediaControllerEl(this);
+    this.#mediaController = getMediaControllerEl(this);
     if (this.getAttribute(MediaStateReceiverAttributes.MEDIA_CONTROLLER)) {
-      mediaControllerEl?.associateElement?.(this);
+      this.#mediaController?.associateElement?.(this);
     }
 
-    mediaControllerEl?.addEventListener('pointerdown', this);
-    mediaControllerEl?.addEventListener('click', this);
+    this.#mediaController?.addEventListener('pointerdown', this);
+    this.#mediaController?.addEventListener('click', this);
   }
 
   disconnectedCallback() {
-    const mediaControllerEl = getMediaControllerEl(this);
+    this.#mediaController = getMediaControllerEl(this);
     if (this.getAttribute(MediaStateReceiverAttributes.MEDIA_CONTROLLER)) {
-      mediaControllerEl?.unassociateElement?.(this);
+      this.#mediaController?.unassociateElement?.(this);
     }
 
-    mediaControllerEl?.removeEventListener('pointerdown', this);
-    mediaControllerEl?.removeEventListener('click', this);
+    this.#mediaController?.removeEventListener('pointerdown', this);
+    this.#mediaController?.removeEventListener('click', this);
+    this.#mediaController = null;
   }
 
   handleEvent(event) {
@@ -150,7 +154,7 @@ function getMediaControllerEl(controlEl) {
     MediaStateReceiverAttributes.MEDIA_CONTROLLER
   );
   if (mediaControllerId) {
-    return document.getElementById(mediaControllerId);
+    return this.getRootNode()?.getElementById(mediaControllerId);
   }
   return closestComposedNode(controlEl, 'media-controller');
 }

--- a/src/js/media-loading-indicator.js
+++ b/src/js/media-loading-indicator.js
@@ -64,6 +64,8 @@ svg, img, ::slotted(svg), ::slotted(img) {
 const DEFAULT_LOADING_DELAY = 500;
 
 class MediaLoadingIndicator extends window.HTMLElement {
+  #mediaController;
+
   static get observedAttributes() {
     return [
       MediaStateReceiverAttributes.MEDIA_CONTROLLER,
@@ -108,12 +110,13 @@ class MediaLoadingIndicator extends window.HTMLElement {
       }
     } else if (attrName === MediaStateReceiverAttributes.MEDIA_CONTROLLER) {
       if (oldValue) {
-        const mediaControllerEl = document.getElementById(oldValue);
-        mediaControllerEl?.unassociateElement?.(this);
+        this.#mediaController?.unassociateElement?.(this);
+        this.#mediaController = null;
       }
       if (newValue) {
-        const mediaControllerEl = document.getElementById(newValue);
-        mediaControllerEl?.associateElement?.(this);
+        // @ts-ignore
+        this.#mediaController = this.getRootNode()?.getElementById(newValue);
+        this.#mediaController?.associateElement?.(this);
       }
     }
   }
@@ -123,8 +126,9 @@ class MediaLoadingIndicator extends window.HTMLElement {
       MediaStateReceiverAttributes.MEDIA_CONTROLLER
     );
     if (mediaControllerId) {
-      const mediaControllerEl = document.getElementById(mediaControllerId);
-      mediaControllerEl?.associateElement?.(this);
+      // @ts-ignore
+      this.#mediaController = this.getRootNode()?.getElementById(mediaControllerId);
+      this.#mediaController?.associateElement?.(this);
     }
   }
 
@@ -133,13 +137,10 @@ class MediaLoadingIndicator extends window.HTMLElement {
       clearTimeout(this.loadingDelayHandle);
       this.loadingDelayHandle = undefined;
     }
-    const mediaControllerId = this.getAttribute(
-      MediaStateReceiverAttributes.MEDIA_CONTROLLER
-    );
-    if (mediaControllerId) {
-      const mediaControllerEl = document.getElementById(mediaControllerId);
-      mediaControllerEl?.unassociateElement?.(this);
-    }
+
+    // Use cached mediaController, getRootNode() doesn't work if disconnected.
+    this.#mediaController?.unassociateElement?.(this);
+    this.#mediaController = null;
   }
 }
 

--- a/src/js/media-preview-thumbnail.js
+++ b/src/js/media-preview-thumbnail.js
@@ -29,6 +29,8 @@ template.innerHTML = `
  * @extends {HTMLElement}
  */
 class MediaPreviewThumbnail extends window.HTMLElement {
+  #mediaController;
+
   static get observedAttributes() {
     return [
       MediaStateReceiverAttributes.MEDIA_CONTROLLER,
@@ -50,19 +52,16 @@ class MediaPreviewThumbnail extends window.HTMLElement {
       MediaStateReceiverAttributes.MEDIA_CONTROLLER
     );
     if (mediaControllerId) {
-      const mediaControllerEl = document.getElementById(mediaControllerId);
-      mediaControllerEl?.associateElement?.(this);
+      // @ts-ignore
+      this.#mediaController = this.getRootNode()?.getElementById(mediaControllerId);
+      this.#mediaController?.associateElement?.(this);
     }
   }
 
   disconnectedCallback() {
-    const mediaControllerId = this.getAttribute(
-      MediaStateReceiverAttributes.MEDIA_CONTROLLER
-    );
-    if (mediaControllerId) {
-      const mediaControllerEl = document.getElementById(mediaControllerId);
-      mediaControllerEl?.unassociateElement?.(this);
-    }
+    // Use cached mediaController, getRootNode() doesn't work if disconnected.
+    this.#mediaController?.unassociateElement?.(this);
+    this.#mediaController = null;
   }
 
   attributeChangedCallback(attrName, oldValue, newValue) {
@@ -77,12 +76,13 @@ class MediaPreviewThumbnail extends window.HTMLElement {
     }
     if (attrName === MediaStateReceiverAttributes.MEDIA_CONTROLLER) {
       if (oldValue) {
-        const mediaControllerEl = document.getElementById(oldValue);
-        mediaControllerEl?.unassociateElement?.(this);
+        this.#mediaController?.unassociateElement?.(this);
+        this.#mediaController = null;
       }
       if (newValue) {
-        const mediaControllerEl = document.getElementById(newValue);
-        mediaControllerEl?.associateElement?.(this);
+        // @ts-ignore
+        this.#mediaController = this.getRootNode()?.getElementById(newValue);
+        this.#mediaController?.associateElement?.(this);
       }
     }
   }

--- a/src/js/media-text-display.js
+++ b/src/js/media-text-display.js
@@ -47,6 +47,8 @@ template.innerHTML = `
 `;
 
 class MediaTextDisplay extends window.HTMLElement {
+  #mediaController;
+
   static get observedAttributes() {
     return [MediaStateReceiverAttributes.MEDIA_CONTROLLER];
   }
@@ -62,12 +64,13 @@ class MediaTextDisplay extends window.HTMLElement {
   attributeChangedCallback(attrName, oldValue, newValue) {
     if (attrName === MediaStateReceiverAttributes.MEDIA_CONTROLLER) {
       if (oldValue) {
-        const mediaControllerEl = document.getElementById(oldValue);
-        mediaControllerEl?.unassociateElement?.(this);
+        this.#mediaController?.unassociateElement?.(this);
+        this.#mediaController = null;
       }
       if (newValue) {
-        const mediaControllerEl = document.getElementById(newValue);
-        mediaControllerEl?.associateElement?.(this);
+        // @ts-ignore
+        this.#mediaController = this.getRootNode()?.getElementById(newValue);
+        this.#mediaController?.associateElement?.(this);
       }
     }
   }
@@ -77,19 +80,16 @@ class MediaTextDisplay extends window.HTMLElement {
       MediaStateReceiverAttributes.MEDIA_CONTROLLER
     );
     if (mediaControllerId) {
-      const mediaControllerEl = document.getElementById(mediaControllerId);
-      mediaControllerEl?.associateElement?.(this);
+      // @ts-ignore
+      this.#mediaController = this.getRootNode()?.getElementById(mediaControllerId);
+      this.#mediaController?.associateElement?.(this);
     }
   }
 
   disconnectedCallback() {
-    const mediaControllerId = this.getAttribute(
-      MediaStateReceiverAttributes.MEDIA_CONTROLLER
-    );
-    if (mediaControllerId) {
-      const mediaControllerEl = document.getElementById(mediaControllerId);
-      mediaControllerEl?.unassociateElement?.(this);
-    }
+    // Use cached mediaController, getRootNode() doesn't work if disconnected.
+    this.#mediaController?.unassociateElement?.(this);
+    this.#mediaController = null;
   }
 }
 

--- a/src/js/media-time-display.js
+++ b/src/js/media-time-display.js
@@ -76,6 +76,7 @@ class MediaTimeDisplay extends MediaTextDisplay {
 
   disconnectedCallback() {
     this.disable();
+    super.disconnectedCallback();
   }
 
   attributeChangedCallback(attrName, oldValue, newValue) {

--- a/test/unit/media-controller.spec.js
+++ b/test/unit/media-controller.spec.js
@@ -38,18 +38,118 @@ describe('<media-controller>', () => {
     assert(mediaController.mediaStateReceivers.indexOf(playButton) >= 0, 'registers play button');
   });
 
-  it('registers itself and non-child controls state receivers', async () => {
+  it('registers itself and non-child button state receivers', async () => {
     const mediaController = await fixture(`
       <media-controller id="ctrl"></media-controller>
     `);
-    const playButton = await fixture(`
+    const ui = await fixture(`
       <media-play-button media-controller="ctrl"></media-play-button>
     `);
 
     // Also includes the media-gesture-receiver by default
     assert.equal(mediaController.mediaStateReceivers.length, 3);
     assert(mediaController.mediaStateReceivers.indexOf(mediaController) >= 0, 'registers itself');
-    assert(mediaController.mediaStateReceivers.indexOf(playButton) >= 0, 'registers play button');
+    assert(mediaController.mediaStateReceivers.indexOf(ui) >= 0, 'registers button');
+
+    ui.remove();
+
+    assert.equal(mediaController.mediaStateReceivers.length, 2);
+    assert(!mediaController.mediaStateReceivers.includes(ui), 'unregisters control');
+  });
+
+  it('registers itself and non-child range state receivers', async () => {
+    const mediaController = await fixture(`
+      <media-controller id="ctrl"></media-controller>
+    `);
+    const ui = await fixture(`
+      <media-time-range media-controller="ctrl"></media-time-range>
+    `);
+
+    // Also includes media-gesture-receiver, media-preview-thumbnail, media-preview-time-display
+    assert.equal(mediaController.mediaStateReceivers.length, 5);
+    assert(mediaController.mediaStateReceivers.indexOf(mediaController) >= 0, 'registers itself');
+    assert(mediaController.mediaStateReceivers.indexOf(ui) >= 0, 'registers range');
+
+    ui.remove();
+
+    assert.equal(mediaController.mediaStateReceivers.length, 2);
+    assert(!mediaController.mediaStateReceivers.includes(ui), 'unregisters control');
+  });
+
+  it('registers itself and non-child gesture-receiver state receivers', async () => {
+    const mediaController = await fixture(`
+      <media-controller id="ctrl"></media-controller>
+    `);
+    const ui = await fixture(`
+      <media-gesture-receiver media-controller="ctrl"></media-gesture-receiver>
+    `);
+
+    // Also includes the media-gesture-receiver by default
+    assert.equal(mediaController.mediaStateReceivers.length, 3);
+    assert(mediaController.mediaStateReceivers.indexOf(mediaController) >= 0, 'registers itself');
+    assert(mediaController.mediaStateReceivers.indexOf(ui) >= 0, 'registers gesture-receiver');
+
+    ui.remove();
+
+    assert.equal(mediaController.mediaStateReceivers.length, 2);
+    assert(!mediaController.mediaStateReceivers.includes(ui), 'unregisters control');
+  });
+
+  it('registers itself and non-child loading-indicator state receivers', async () => {
+    const mediaController = await fixture(`
+      <media-controller id="ctrl"></media-controller>
+    `);
+    const ui = await fixture(`
+      <media-loading-indicator media-controller="ctrl"></media-loading-indicator>
+    `);
+
+    // Also includes the media-gesture-receiver by default
+    assert.equal(mediaController.mediaStateReceivers.length, 3);
+    assert(mediaController.mediaStateReceivers.indexOf(mediaController) >= 0, 'registers itself');
+    assert(mediaController.mediaStateReceivers.indexOf(ui) >= 0, 'registers loading-indicator');
+
+    ui.remove();
+
+    assert.equal(mediaController.mediaStateReceivers.length, 2);
+    assert(!mediaController.mediaStateReceivers.includes(ui), 'unregisters control');
+  });
+
+  it('registers itself and non-child preview-thumbnail state receivers', async () => {
+    const mediaController = await fixture(`
+      <media-controller id="ctrl"></media-controller>
+    `);
+    const ui = await fixture(`
+      <media-preview-thumbnail media-controller="ctrl"></media-preview-thumbnail>
+    `);
+
+    // Also includes the media-gesture-receiver by default
+    assert.equal(mediaController.mediaStateReceivers.length, 3);
+    assert(mediaController.mediaStateReceivers.indexOf(mediaController) >= 0, 'registers itself');
+    assert(mediaController.mediaStateReceivers.indexOf(ui) >= 0, 'registers preview-thumbnail');
+
+    ui.remove();
+
+    assert.equal(mediaController.mediaStateReceivers.length, 2);
+    assert(!mediaController.mediaStateReceivers.includes(ui), 'unregisters control');
+  });
+
+  it('registers itself and non-child time-display state receivers', async () => {
+    const mediaController = await fixture(`
+      <media-controller id="ctrl"></media-controller>
+    `);
+    const ui = await fixture(`
+      <media-time-display media-controller="ctrl"></media-time-display>
+    `);
+
+    // Also includes the media-gesture-receiver by default
+    assert.equal(mediaController.mediaStateReceivers.length, 3);
+    assert(mediaController.mediaStateReceivers.indexOf(mediaController) >= 0, 'registers itself');
+    assert(mediaController.mediaStateReceivers.indexOf(ui) >= 0, 'registers time-display');
+
+    ui.remove();
+
+    assert.equal(mediaController.mediaStateReceivers.length, 2);
+    assert(!mediaController.mediaStateReceivers.includes(ui), 'unregisters control');
   });
 
   it('registers itself and child simple element state receivers', async () => {

--- a/test/unit/media-theme.spec.js
+++ b/test/unit/media-theme.spec.js
@@ -91,4 +91,33 @@ describe('<media-theme>', () => {
       'caused a re-render and <hello-world> is available'
     );
   });
+
+  it('registers media-controller and non-child controls state receivers', async () => {
+    await fixture(`
+      <template id="decoupled-controller">
+        <media-controller id="ctrl">
+          <slot name="media" slot="media"></slot>
+        </media-controller>
+        <media-play-button media-controller="ctrl"></media-play-button>
+      </template>
+    `);
+
+    const theme = await fixture(`
+      <media-theme template="decoupled-controller">
+        <video slot="media" muted src="https://stream.mux.com/O6LdRc0112FEJXH00bGsN9Q31yu5EIVHTgjTKRkKtEq1k/low.mp4"></video>
+      </media-theme>
+    `);
+    const mediaController = theme.mediaController;
+    const playButton = theme.shadowRoot.querySelector('media-play-button');
+
+    // Also includes the media-gesture-receiver by default
+    assert.equal(mediaController.mediaStateReceivers.length, 3);
+    assert(mediaController.mediaStateReceivers.includes(mediaController), 'registers itself');
+    assert(mediaController.mediaStateReceivers.includes(playButton), 'registers play button');
+
+    playButton.remove();
+
+    assert.equal(mediaController.mediaStateReceivers.length, 2);
+    assert(!mediaController.mediaStateReceivers.includes(playButton), 'unregisters play button');
+  });
 });


### PR DESCRIPTION
This change fixes an issue with using media controls that are not nested in `media-controller` but connect via the `id` and `media-controller` attribute in the context of a shadow DOM.

The bug is that `document.getElementById` doesn't search in shadow DOM.

The fix implemented here is to use `this.getRootNode().getElementById`. This only works when connected to the DOM.

- [x] add solution to other controller coupled elements when we agree on this method