### PR TITLE
fix: add lazy template prop to theme el

### DIFF
--- a/src/js/media-theme-element.js
+++ b/src/js/media-theme-element.js
@@ -57,9 +57,7 @@ export class MediaThemeElement extends window.HTMLElement {
     observer.observe(this.renderRoot, {
       attributes: true,
       subtree: true,
-    })
-
-    this.createRenderer();
+    });
   }
 
   get mediaController() {
@@ -108,6 +106,24 @@ export class MediaThemeElement extends window.HTMLElement {
   attributeChangedCallback(attrName, oldValue, newValue) {
     if (attrName === 'template' && oldValue != newValue) {
       this.createRenderer();
+    }
+  }
+
+  connectedCallback() {
+    this.createRenderer();
+
+    // In case the template prop was set before custom element upgrade.
+    // https://web.dev/custom-elements-best-practices/#make-properties-lazy
+    this.#upgradeProperty('template');
+  }
+
+  #upgradeProperty(prop) {
+    if (Object.prototype.hasOwnProperty.call(this, prop)) {
+      const value = this[prop];
+      // Delete the set property from this instance.
+      delete this[prop];
+      // Set the value again via the (prototype) setter on this class.
+      this[prop] = value;
     }
   }
 

--- a/src/js/themes/media-theme-demuxed-2022.js
+++ b/src/js/themes/media-theme-demuxed-2022.js
@@ -7,7 +7,7 @@
 </media-theme-demuxed-2022>
 */
 
-import { window } from '../utils/server-safe-globals.js';
+import { window, document } from '../utils/server-safe-globals.js';
 import { MediaThemeElement } from '../media-theme-element.js';
 
 const template = document.createElement('template');

--- a/src/js/themes/media-theme-netflix.js
+++ b/src/js/themes/media-theme-netflix.js
@@ -7,7 +7,7 @@
 </media-theme-netflix>
 */
 
-import { window } from '../utils/server-safe-globals.js';
+import { window, document } from '../utils/server-safe-globals.js';
 import { MediaThemeElement } from '../media-theme-element.js';
 
 const template = document.createElement('template');

--- a/src/js/themes/media-theme-responsive.js
+++ b/src/js/themes/media-theme-responsive.js
@@ -7,7 +7,7 @@
 </media-theme-responsive>
 */
 
-import { window } from '../utils/server-safe-globals.js';
+import { window, document } from '../utils/server-safe-globals.js';
 import { MediaThemeElement } from '../media-theme-element.js';
 
 const template = document.createElement('template');

--- a/src/js/themes/media-theme-winamp.js
+++ b/src/js/themes/media-theme-winamp.js
@@ -1,4 +1,4 @@
-import { window } from '../utils/server-safe-globals.js';
+import { window, document } from '../utils/server-safe-globals.js';
 import { MediaThemeElement } from '../media-theme-element.js';
 
 const template = document.createElement('template');

--- a/src/js/themes/media-theme-youtube.js
+++ b/src/js/themes/media-theme-youtube.js
@@ -7,7 +7,7 @@
 </media-theme-youtube>
 */
 
-import { window } from '../utils/server-safe-globals.js';
+import { window, document } from '../utils/server-safe-globals.js';
 import { MediaThemeElement } from '../media-theme-element.js';
 
 const template = document.createElement('template');


### PR DESCRIPTION
this is required for (Mux Player) React because sometimes the `media-theme` element is not upgrade yet so the template property will be set on an HTMLElement. After the upgrade we have to re-set it on the instance of the custom element...

https://web.dev/custom-elements-best-practices/#make-properties-lazy