### PR TITLE
fix: create theme template on construction

### DIFF
--- a/src/js/media-theme-element.js
+++ b/src/js/media-theme-element.js
@@ -58,6 +58,22 @@ export class MediaThemeElement extends window.HTMLElement {
       attributes: true,
       subtree: true,
     });
+
+    this.createRenderer();
+
+    // In case the template prop was set before custom element upgrade.
+    // https://web.dev/custom-elements-best-practices/#make-properties-lazy
+    this.#upgradeProperty('template');
+  }
+
+  #upgradeProperty(prop) {
+    if (Object.prototype.hasOwnProperty.call(this, prop)) {
+      const value = this[prop];
+      // Delete the set property from this instance.
+      delete this[prop];
+      // Set the value again via the (prototype) setter on this class.
+      this[prop] = value;
+    }
   }
 
   get mediaController() {
@@ -106,24 +122,6 @@ export class MediaThemeElement extends window.HTMLElement {
   attributeChangedCallback(attrName, oldValue, newValue) {
     if (attrName === 'template' && oldValue != newValue) {
       this.createRenderer();
-    }
-  }
-
-  connectedCallback() {
-    this.createRenderer();
-
-    // In case the template prop was set before custom element upgrade.
-    // https://web.dev/custom-elements-best-practices/#make-properties-lazy
-    this.#upgradeProperty('template');
-  }
-
-  #upgradeProperty(prop) {
-    if (Object.prototype.hasOwnProperty.call(this, prop)) {
-      const value = this[prop];
-      // Delete the set property from this instance.
-      delete this[prop];
-      // Set the value again via the (prototype) setter on this class.
-      this[prop] = value;
     }
   }
 


### PR DESCRIPTION
turns out the template in the theme element has to be rendered on construction so that the controller is available right away.

otherwise we get an error `<media-controller> failed to upgrade!`