### PR TITLE
fix: catch play promise internally

### DIFF
--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -97,7 +97,7 @@ class MediaController extends MediaContainer {
           mediaUIEventHandlers['MEDIA_SEEK_TO_LIVE_REQUEST'](e, media);
         }
 
-        this.media.play();
+        this.media.play().catch(() => {});
       },
       MEDIA_PAUSE_REQUEST: () => this.media.pause(),
       MEDIA_MUTE_REQUEST: () => (this.media.muted = true),


### PR DESCRIPTION
Was seeing a bunch of uncaught promise rejects in tests and realized it stemmed from here. We should be catching this rejected promise as it happens internally and isn't actionable by users of media-chrome.