### PR TITLE
fix: Use default-stream-type when slotted media streamType is unknown.

### DIFF
--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -1140,7 +1140,19 @@ const getStreamType = (controller) => {
   
   if (!media) return undefined;
   
-  if (media.streamType) return media.streamType;
+  if (media.streamType) {
+    // If the slotted media supports `streamType` but
+    // `streamType` is "unknown", prefer `default-stream-type`
+    // if set (CJP)
+    if (media.streamType === 'unknown' && controller.hasAttribute('default-stream-type')) {
+      const defaultType = controller.getAttribute('default-stream-type');
+
+      if (StreamTypeValues.includes(defaultType)) {
+        return defaultType;
+      }
+    }
+    return media.streamType;
+  }
   const duration = media.duration;
 
   if (duration === Infinity) {


### PR DESCRIPTION
Since `"unknown"` is supposed to represent cases where the slotted media element supports the `streamType` [media-ui-extension](https://github.com/video-dev/media-ui-extensions/issues/3) but cannot derive the stream type yet, updating impl to prefer `default-stream-type` in this case.