### PR TITLE
fix: nullish coalesce operator, improve process

### DIFF
--- a/src/js/utils/template-processor.js
+++ b/src/js/utils/template-processor.js
@@ -5,27 +5,15 @@ import {
 } from './template-parts.js';
 import { isNumericString } from './utils.js';
 
-// e.g.  myVar | string
-//       > myVar
-//       nilVar ?? 'fallback'
-export const reExpr = /([>&])?\s*(\w+)\s*(.*)/;
-
-// e.g.  | string
-//       ?? 'fallback'
-export const reExprOperation = /^(\?\?|\|)?\s*(['"\w ]*)/;
-
-const operators = {
-  // Filters concept like Nunjucks or Liquid.
-  '|': {
-    string: (value) => String(value),
-  },
-  // Same as nullish coalesce operator in JS.
-  '??': (value, defaults) => value ?? defaults,
+// Filters concept like Nunjucks or Liquid.
+const pipeModifiers = {
+  string: (value) => String(value),
 };
 
 class PartialTemplate {
   constructor(template) {
     this.template = template;
+    this.state = undefined;
   }
 }
 
@@ -37,7 +25,7 @@ const Directives = {
     state[part.expression] = new PartialTemplate(part.template);
   },
   if: (part, state) => {
-    if (evaluateCondition(part.expression, state)) {
+    if (evaluateExpression(part.expression, state)) {
       // If the template did not change for this part we can skip creating
       // a new template instance / parsing and update the inner parts directly.
       if (templates.get(part) !== part.template) {
@@ -65,6 +53,7 @@ export const processor = {
     if (!state) return;
 
     for (const [expression, part] of parts) {
+
       if (part instanceof InnerTemplatePart) {
         if (!part.directive) {
           // Transform short-hand if/partial attributes to directive & expression.
@@ -74,56 +63,33 @@ export const processor = {
             part.expression = part.template.getAttribute(directive);
           }
         }
+
         Directives[part.directive]?.(part, state);
         continue;
       }
 
-      const [, prefix, name, rest] = expression.match(reExpr) ?? [];
-      let value = state[name];
+      let value = evaluateExpression(expression, state);
 
-      // Adds support for:
-      //   - filters (pipe char followed by function) e.g. {{ myVar | string }}
-      //   - nullish coalesce operator e.g. {{ nilVar ?? 'fallback' }}
-      const [, operator, modifier] = rest.match(reExprOperation) ?? [];
-      const op = operators[operator];
+      if (value instanceof PartialTemplate) {
 
-      if (typeof op === 'function') {
-        // Handle `??` operator.
-        value = op(value, getParamValue(modifier, state));
-      } else if (op && value != null) {
-        // Handle `|` operator.
-        const modify = op[modifier];
-        if (modify) value = modify(value);
+        if (templates.get(part) !== value.template) {
+          templates.set(part, value.template);
+
+          value = new TemplateInstance(
+            value.template,
+            value.state,
+            processor
+          );
+          part.value = value;
+          templateInstances.set(part, value);
+        } else {
+          templateInstances.get(part)?.update(value.state);
+        }
+
+        continue;
       }
 
       if (value) {
-        if (value instanceof PartialTemplate) {
-          // Require the partial indicator `>` or ignore this expression.
-          if (prefix !== '>') continue;
-
-          const localState = { ...state };
-          // Adds support for params e.g. {{PlayButton section="center"}}
-          const matches = expression.matchAll(/(\w+)\s*=\s*(['"\w]*)/g);
-          for (let [, paramName, paramValue] of matches) {
-            localState[paramName] = getParamValue(paramValue, state);
-          }
-
-          if (templates.get(part) !== value.template) {
-            templates.set(part, value.template);
-
-            value = new TemplateInstance(
-              value.template,
-              localState,
-              processor
-            );
-            part.value = value;
-            templateInstances.set(part, value);
-          } else {
-            templateInstances.get(part)?.update(localState);
-          }
-
-          continue;
-        }
 
         if (part instanceof AttrPart) {
           if (part.attributeName.startsWith('aria-')) {
@@ -162,57 +128,97 @@ export const processor = {
   },
 };
 
-const conditions = {
+const operators = {
   '==': (a, b) => a == b,
   '!=': (a, b) => a != b,
   '>': (a, b) => a > b,
   '>=': (a, b) => a >= b,
   '<': (a, b) => a < b,
   '<=': (a, b) => a <= b,
+  '??': (a, b) => a ?? b,
+  '|': (a, b) => pipeModifiers[b]?.(a),
 };
 
-// Support minimal conditional expressions e.g.
-//   layout == 'on-demand'
-//   layout != 'live'
-//   title
-export function evaluateCondition(expr, state) {
-  const tokens = tokenize(expr, {
+export function tokenizeExpression(expr) {
+  return tokenize(expr, {
     boolean: /true|false/,
     number: /-?\d+\.?\d*/,
     string: /(["'])((?:\\.|[^\\])*?)\1/,
-    operator: /[!=><]=|[><]/,
+    operator: /[!=><]=|>|<|=|\?\?|\|/,
     ws: /\s+/,
     param: /[$a-z_][$\w]*/i,
-  });
+  }).filter(({ type }) => type !== 'ws');
+}
+
+// Support minimal expressions e.g.
+//   >PlayButton section="center"
+//   section ?? 'bottom'
+//   value | string
+//   streamType == 'on-demand'
+//   streamType != 'live'
+//   breakpointMd
+export function evaluateExpression(expr, state = {}) {
+  const tokens = tokenizeExpression(expr);
 
   if (tokens.length === 0 || tokens.some(({ type }) => !type)) {
-    console.warn(`Warning: invalid expression \`${expr}\``);
-    return false;
+    return invalidExpression(expr);
   }
 
+  // e.g. {{>PlayButton section="center"}}
+  if (tokens[0]?.token === '>') {
+    const partial = state[tokens[1]?.token];
+    if (!partial) {
+      return invalidExpression(expr);
+    }
+
+    const partialState = { ...state };
+    partial.state = partialState;
+
+    // Adds support for arguments e.g. {{>PlayButton section="center"}}
+    const args = tokens.slice(2);
+    for (let i = 0; i < args.length; i += 3) {
+      const name = args[i]?.token;
+      const operator = args[i + 1]?.token;
+      const value = args[i + 2]?.token;
+
+      if (name && operator === '=') {
+        partialState[name] = getParamValue(value, state);
+      }
+    }
+    return partial;
+  }
+
+  // e.g. {{'hello world'}} or {{breakpointMd}}
   if (tokens.length === 1) {
     if (!isValidParam(tokens[0])) {
-      console.warn(`Warning: invalid expression \`${expr}\``);
-      return false;
+      return invalidExpression(expr);
     }
     return getParamValue(tokens[0].token, state);
   }
 
-  const args = tokens.filter(({ type }) => type !== 'ws');
+  // e.g. {{streamType == 'on-demand'}}, {{val | string}}, {{section ?? 'bottom'}}
+  if (tokens.length === 3) {
+    const operator = tokens[1]?.token;
+    const run = operators[operator];
 
-  if (args.length === 3) {
-    let condition = conditions[args[1]?.token];
-
-    if (!condition || !isValidParam(args[0]) || !isValidParam(args[2])) {
-      console.warn(`Warning: invalid expression \`${expr}\``);
-      return false;
+    if (!run || !isValidParam(tokens[0]) || !isValidParam(tokens[2])) {
+      return invalidExpression(expr);
     }
 
-    return condition(
-      getParamValue(args[0].token, state),
-      getParamValue(args[2].token, state)
-    );
+    const a = getParamValue(tokens[0].token, state);
+
+    if (operator === '|') {
+      return run(a, tokens[2].token);
+    }
+
+    const b = getParamValue(tokens[2].token, state);
+    return run(a, b);
   }
+}
+
+function invalidExpression(expr) {
+  console.warn(`Warning: invalid expression \`${expr}\``);
+  return false;
 }
 
 function isValidParam({ type }) {

--- a/test/unit/template-processor.spec.js
+++ b/test/unit/template-processor.spec.js
@@ -1,32 +1,56 @@
 import { assert } from '@open-wc/testing';
-import { evaluateCondition, getParamValue, processor } from '../../src/js/utils/template-processor.js';
+import { evaluateExpression, getParamValue, processor } from '../../src/js/utils/template-processor.js';
 import { TemplateInstance } from '../../src/js/utils/template-parts.js';
 
-describe('evaluateCondition', () => {
+describe('evaluateExpression', () => {
   it('can evaluate a simple boolean condition', () => {
-    assert(evaluateCondition('true'));
-    assert(evaluateCondition('true == myVar', { myVar: true }));
-    assert(evaluateCondition('myVar != false', { myVar: true }));
+    assert(evaluateExpression('true'));
+    assert(evaluateExpression('true == myVar', { myVar: true }));
+    assert(evaluateExpression('myVar != false', { myVar: true }));
   });
 
   it('can evaluate a simple number condition', async () => {
-    assert(!evaluateCondition('0'));
-    assert(evaluateCondition('1'));
-    assert(evaluateCondition('5 > 3'));
-    assert(evaluateCondition('5 >= 3'));
-    assert(evaluateCondition('5 >= 5'));
-    assert(evaluateCondition('2 < 3'));
-    assert(evaluateCondition('2 <= 3'));
-    assert(evaluateCondition('3 <= 3'));
-    assert(evaluateCondition('myVar == 22', { myVar: 22 }));
-    assert(evaluateCondition('myVar != 22', { myVar: 23 }));
+    assert(!evaluateExpression('0'));
+    assert(evaluateExpression('1'));
+    assert(evaluateExpression('5 > 3'));
+    assert(evaluateExpression('5 >= 3'));
+    assert(evaluateExpression('5 >= 5'));
+    assert(evaluateExpression('2 < 3'));
+    assert(evaluateExpression('2 <= 3'));
+    assert(evaluateExpression('3 <= 3'));
+    assert(evaluateExpression('myVar == 22', { myVar: 22 }));
+    assert(evaluateExpression('myVar != 22', { myVar: 23 }));
   });
 
   it('can evaluate a simple string condition', async () => {
-    assert(!evaluateCondition('""'));
-    assert(evaluateCondition('"thruthy"'));
-    assert(evaluateCondition('myVar == "a string"', { myVar: 'a string' }));
-    assert(evaluateCondition('myVar != "a string"', { myVar: 'lalala' }));
+    assert(!evaluateExpression('""'));
+    assert(evaluateExpression('"thruthy"'));
+    assert(evaluateExpression('myVar == "a string"', { myVar: 'a string' }));
+    assert(evaluateExpression('myVar != "a string"', { myVar: 'lalala' }));
+  });
+
+  it('can evaluate the string filter', () => {
+    assert.equal(evaluateExpression('2.34 | string'), '2.34');
+  });
+
+  it('can evaluate nullish coalesce operator', () => {
+    assert.equal(evaluateExpression('myVar ?? "on-demand"'), 'on-demand');
+    assert.equal(evaluateExpression('myVar ?? "hello world"'), 'hello world');
+    assert.equal(evaluateExpression('myVar ?? 99'), 99);
+    assert.equal(evaluateExpression('myVar ?? true'), true);
+    assert.equal(evaluateExpression('null ?? true'), true);
+    assert.equal(evaluateExpression('undefined ?? true'), true);
+  });
+
+  it('can evaluate partial', () => {
+    const MyButton = {};
+    let result = evaluateExpression('>MyButton arg1="hello"', { MyButton });
+    assert.equal(result, MyButton);
+    assert.deepEqual(result.state, { MyButton, arg1: 'hello' });
+
+    result = evaluateExpression(' > MyButton ', { MyButton });
+    assert.equal(result, MyButton);
+    assert.deepEqual(result.state, { MyButton });
   });
 });
 
@@ -35,9 +59,12 @@ describe('getParamValue', () => {
     assert.equal(getParamValue('true'), true);
     assert.equal(getParamValue('false'), false);
     assert.equal(getParamValue('"hello world"'), 'hello world');
+    assert.equal(getParamValue('"hello-world"'), 'hello-world');
+    assert.equal(getParamValue('"hello_world"'), 'hello_world');
     assert.equal(getParamValue("'hello world'"), 'hello world');
     assert.equal(getParamValue('360'), 360);
     assert.equal(getParamValue('myVar', { myVar: 'val' }), 'val');
+    assert.equal(getParamValue('my_var', { my_var: 'val' }), 'val');
   });
 });
 


### PR DESCRIPTION
this change was mainly to fix an issue with the regex of the nullish coalesce operator that @cjpillsbury found.

instead of tweaking the regex I did a small refactor so all expressions are now run through the same tokenizer and evaluator.
this should be more robust, having 1 location for matching the tokens.

