### PR TITLE
feat: add experimental media-dialog

### DIFF
--- a/examples/control-elements/media-dialog.html
+++ b/examples/control-elements/media-dialog.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width" />
+
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css" />
+    <style>
+      /** add styles to prevent CLS (Cumulative Layout Shift) */
+      media-controller:not([audio]) {
+        display: block;         /* expands the container if preload=none */
+        max-width: 960px;       /* allows the container to shrink if small */
+        aspect-ratio: 2.4;   /* set container aspect ratio if preload=none */
+      }
+
+      video {
+        width: 100%;      /* prevents video to expand beyond its container */
+      }
+
+      .examples {
+        margin-top: 20px;
+      }
+    </style>
+
+    <script type="module" src="../../dist/index.js"></script>
+    <script type="module" src="../../dist/experimental/media-dialog.js"></script>
+  </head>
+  <body>
+    <h1>Media Dialog</h1>
+    <br>
+
+    <media-controller>
+      <video
+        slot="media"
+        src="https://stream.mux.com/O4h5z00885HEucNNa1rV02wZapcGp01FXXoJd35AHmGX7g/low.mp4"
+        muted
+        crossorigin
+      ></video>
+
+      <media-control-bar>
+        <media-play-button></media-play-button>
+        <media-time-display show-duration></media-time-display>
+        <media-time-range></media-time-range>
+        <media-playback-rate-button></media-playback-rate-button>
+        <media-mute-button></media-mute-button>
+        <media-volume-range></media-volume-range>
+      </media-control-bar>
+
+      <media-dialog open>
+        <style>
+          media-dialog:not(:defined) {
+            display: none;
+          }
+          .dialog-close {
+            background: none;
+            color: inherit;
+            border: none;
+            padding: 0;
+            font: inherit;
+            cursor: pointer;
+            outline: inherit;
+            width: 28px;
+            height: 28px;
+            position: absolute;
+            top: 1rem;
+            right: 1rem;
+          }
+          .dialog-title {
+            color: #fff;
+          }
+        </style>
+
+        <button class="dialog-close" tabindex="0" onclick="this.parentNode.close()">
+          <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+
+        <h3 class="dialog-title">Hello dialog!</h3>
+
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+      </media-dialog>
+
+    </media-controller>
+
+    <br>
+    <br>
+
+    <button id="dialogbtn">Toggle media-dialog</button>
+
+    <script>
+      dialogbtn.onclick = () => {
+        const dialog = document.querySelector('media-dialog');
+        dialog.hasAttribute('open')
+          ? dialog.removeAttribute('open')
+          : dialog.setAttribute('open', '');
+      }
+    </script>
+
+    <div class="examples">
+      <a href="./">View more examples</a>
+    </div>
+  </body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -78,6 +78,9 @@
         <a href="control-elements/media-chrome-selectmenu.html">Selectmenu Button</a>
       </li>
       <li>
+        <a href="control-elements/media-dialog.html">Dialog</a>
+      </li>
+      <li>
         <a href="https://www.media-chrome.org/en/media-play-button">
           Core controls
         </a>

--- a/src/js/experimental/media-dialog.js
+++ b/src/js/experimental/media-dialog.js
@@ -1,0 +1,199 @@
+import { window, document } from '../utils/server-safe-globals.js';
+
+/* Inspired by HTMLDialogElement &
+   https://github.com/GoogleChrome/dialog-polyfill/blob/master/index.js */
+
+const styles = `
+  :host {
+    z-index: 100;
+    display: var(--media-dialog-display, flex);
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    color: var(--media-dialog-color, #fff);
+    padding: var(--media-dialog-backdrop-padding, 0);
+    background: var(--media-dialog-backdrop-background,
+      linear-gradient(to bottom, rgba(20, 20, 30, 0.5) 50%, rgba(20, 20, 30, 0.7))
+    );
+    transition: var(--media-dialog-transition-open, visibility .2s, opacity .2s) !important;
+    transform: var(--media-dialog-transform-open, none) !important;
+    visibility: visible !important;
+    opacity: 1 !important;
+    pointer-events: auto !important;
+  }
+
+  :host(:not([open])) {
+    transition: var(--media-dialog-transition-close, visibility .1s, opacity .1s) !important;
+    transform: var(--media-dialog-transform-close, none) !important;
+    visibility: hidden !important;
+    opacity: 0 !important;
+    pointer-events: none !important;
+  }
+
+  :focus-visible {
+    box-shadow: 0 0 0 2px rgba(27, 127, 204, 0.9);
+  }
+
+  .dialog {
+    position: relative;
+    box-sizing: border-box;
+    background: var(--media-dialog-background, none);
+    padding: var(--media-dialog-padding, 10px);
+    width: min(320px, 100%);
+    word-wrap: break-word;
+    max-height: 100%;
+    overflow: auto;
+    text-align: center;
+    line-height: 1.4;
+  }
+`;
+
+const template = document.createElement('template');
+template.innerHTML = `
+  <style>
+    ${styles}
+  </style>
+  <div class="dialog">
+    <slot></slot>
+  </div>
+`;
+
+class MediaDialog extends window.HTMLElement {
+  static styles= styles;
+  static template = template;
+  static observedAttributes = ['open'];
+
+  #previouslyFocused;
+
+  constructor() {
+    super();
+
+    this.attachShadow({ mode: 'open' });
+    // @ts-ignore
+    this.shadowRoot?.appendChild(this.constructor.template.content.cloneNode(true));
+  }
+
+  show() {
+    this.setAttribute('open', '');
+    this.dispatchEvent(new CustomEvent('open', { composed: true, bubbles: true }));
+    this.#focus();
+  }
+
+  close() {
+    if (!this.hasAttribute('open')) return;
+
+    this.removeAttribute('open');
+    this.dispatchEvent(new CustomEvent('close', { composed: true, bubbles: true }));
+    this.#previouslyFocused?.focus?.();
+  }
+
+  attributeChangedCallback(attrName, oldValue, newValue) {
+    if (attrName === 'open' && oldValue !== newValue) {
+      newValue != null ? this.show() : this.close();
+    }
+  }
+
+  connectedCallback() {
+    if (!this.hasAttribute('role')) {
+      this.setAttribute('role', 'dialog');
+    }
+
+    if (this.hasAttribute('open')) {
+      this.#focus();
+    }
+  }
+
+  #focus() {
+    const initFocus = new CustomEvent('initfocus', { composed: true, bubbles: true, cancelable: true });
+    this.dispatchEvent(initFocus);
+
+    // If `event.preventDefault()` was called in a listener prevent focusing.
+    if (initFocus.defaultPrevented) return;
+
+    // Find element with `autofocus` attribute, or fall back to the first form/tabindex control.
+    let target = this.querySelector('[autofocus]:not([disabled])');
+
+    if (!target && this.tabIndex >= 0) {
+      target = this;
+    }
+
+    if (!target) {
+      target = findFocusableElementWithin(this.shadowRoot);
+    }
+
+    this.#previouslyFocused = getActiveElement();
+    this.#previouslyFocused?.blur?.();
+
+    this.addEventListener(
+      'transitionend',
+      () => {
+        if (target instanceof HTMLElement) {
+          target.focus({ preventScroll: true });
+        }
+      },
+      { once: true }
+    );
+  }
+}
+
+function findFocusableElementWithin(hostElement) {
+  // Note that this is 'any focusable area'. This list is probably not exhaustive, but the
+  // alternative involves stepping through and trying to focus everything.
+  const opts = ['button', 'input', 'keygen', 'select', 'textarea'];
+  const query = opts.map(function (el) {
+    return el + ':not([disabled])';
+  });
+  // TODO(samthor): tabindex values that are not numeric are not focusable.
+  query.push('[tabindex]:not([disabled]):not([tabindex=""])'); // tabindex != "", not disabled
+  let target = hostElement?.querySelector(query.join(', '));
+
+  if (!target && 'attachShadow' in Element.prototype) {
+    // If we haven't found a focusable target, see if the host element contains an element
+    // which has a shadowRoot.
+    // Recursively search for the first focusable item in shadow roots.
+    const elems = hostElement?.querySelectorAll('*') || [];
+    for (let i = 0; i < elems.length; i++) {
+      if (elems[i].tagName && elems[i].shadowRoot) {
+        target = findFocusableElementWithin(elems[i].shadowRoot);
+        if (target) {
+          break;
+        }
+      }
+    }
+  }
+
+  return target;
+}
+
+/**
+ * Get the active element, accounting for Shadow DOM subtrees.
+ * @author Cory LaViska
+ * @see https://www.abeautifulsite.net/posts/finding-the-active-element-in-a-shadow-root/
+ */
+export function getActiveElement(root = document) {
+  // @ts-ignore
+  const activeEl = root.activeElement;
+
+  if (!activeEl) return null;
+
+  // If there’s a shadow root, recursively find the active element within it.
+  // If the recursive call returns null, return the active element
+  // of the top-level Document.
+  if (activeEl.shadowRoot) {
+    // @ts-ignore
+    return getActiveElement(activeEl.shadowRoot) || document.activeElement;
+  }
+
+  // If not, we can just return the active element
+  return activeEl;
+}
+
+if (!window.customElements.get('media-dialog')) {
+  window.customElements.define('media-dialog', MediaDialog);
+}
+
+export default MediaDialog;


### PR DESCRIPTION
Related to https://github.com/muxinc/elements/pull/489
Test url: https://media-chrome-git-fork-luwes-media-dialog-mux.vercel.app/examples/control-elements/media-dialog.html

it's currently one of the few custom Mux player media-elements and we'd like to have it live here in Media Chrome.

- [ ] should the default media-dialog have a concept of a close button?
- [ ] when open make the rest of the controls inert 

something like this for each control or control-bar

```js
    if (openDialog) {
      this.api?.setAttribute('inert', '');
      this.api?.setAttribute('tabindex', '-1');
      this.api?.setAttribute('aria-hidden', 'true');
    } else {
      this.api?.removeAttribute('inert');
      this.api?.removeAttribute('tabindex');
      this.api?.removeAttribute('aria-hidden');
    }
```