### PR TITLE
fix: add default much used styles to theme

### DIFF
--- a/src/js/media-theme-element.js
+++ b/src/js/media-theme-element.js
@@ -11,6 +11,22 @@ const observedMediaAttributes = {
   'media-stream-type': 'streamType',
 };
 
+const prependTemplate = document.createElement('template');
+
+prependTemplate.innerHTML = `
+  <style>
+    :host {
+      display: block;
+      line-height: 0;
+    }
+
+    media-controller {
+      width: 100%;
+      height: 100%;
+    }
+  </style>
+`;
+
 /**
  * @extends {HTMLElement}
  */
@@ -137,7 +153,10 @@ export class MediaThemeElement extends window.HTMLElement {
       );
 
       this.renderRoot.textContent = '';
-      this.renderRoot.append(this.renderer);
+      this.renderRoot.append(
+        prependTemplate.content.cloneNode(true),
+        this.renderer
+      );
     }
   }
 

--- a/src/js/themes/micro.js
+++ b/src/js/themes/micro.js
@@ -48,14 +48,6 @@ template.innerHTML = html`
     --media-control-background: transparent;
     --media-control-hover-background: transparent;
     --media-control-padding: 5px 5px;
-
-    display: inline-block;
-    line-height: 0;
-  }
-
-  media-controller {
-    width: 100%;
-    height: 100%;
   }
 
   [breakpoint-sm] {


### PR DESCRIPTION
while I was writing the theme docs I noticed the multi-layout theme has very little styles
https://media-chrome-docs-git-fork-luwes-theme-docs-mux.vercel.app/en/themes/responsive-themes

should it have any styles at all to get this functionality came to mind?

maybe proper defaults makes sense in the base theme, it's always possible to override them.

