### PR TITLE
experiment: media-captions-selectmenu like spec

### DIFF
--- a/examples/control-elements/media-chrome-selectmenu.html
+++ b/examples/control-elements/media-chrome-selectmenu.html
@@ -32,27 +32,11 @@
 <body>
   <main>
     <h1>Media Chrome Standard Video Usage Example</h1>
-    <media-chrome-selectmenu>
-      <span slot="button-content">Menu Button</span>
-      <media-chrome-listitem>lorem</media-chrome-listitem>
-      <media-chrome-listitem>ipsum</media-chrome-listitem>
-      <media-chrome-listitem>dolor</media-chrome-listitem>
-      <media-chrome-listitem>sit</media-chrome-listitem>
-    </media-chrome-selectmenu>
-    <media-chrome-selectmenu>
-      <span slot="button-content">Menu Button</span>
-      <media-captions-listbox slot="listbox" media-controller="mc"></media-captions-listbox>
-    </media-chrome-selectmenu>
 
     <br>
     <br>
 
-
-    <media-chrome-selectmenu media-controller="mc" aria-label="captions menu button">
-      <media-captions-button slot="button"></media-captions-button>
-      <media-captions-listbox slot="listbox" ></media-captions-listbox>
-    </media-chrome-selectmenu>
-    <media-captions-selectmenu media-controller="mc" disabled></media-captions-selectmenu>
+    <media-captions-selectmenu media-controller="mc"></media-captions-selectmenu>
 
     <br>
 
@@ -78,34 +62,19 @@
       </video>
       <media-poster-image slot="poster" src="https://d2zihajmogu5jn.cloudfront.net/elephantsdream/poster.png"></media-poster-image>
       <media-control-bar>
-        <media-chrome-selectmenu aria-label="captions menu button">
-          <media-captions-button default-showing slot="button"></media-captions-button>
-          <media-captions-listbox slot="listbox"></media-captions-listbox>
-        </media-chrome-selectmenu>
+        <media-captions-selectmenu></media-captions-selectmenu>
         <media-play-button></media-play-button>
         <media-seek-backward-button seek-offset="15"></media-seek-backward-button>
         <media-seek-forward-button seek-offset="15"></media-seek-forward-button>
         <media-mute-button></media-mute-button>
         <media-time-display show-duration remaining></media-time-display>
         <media-captions-button></media-captions-button>
-        <media-chrome-selectmenu aria-label="captions menu button">
-          <media-captions-button default-showing slot="button"></media-captions-button>
-          <media-captions-listbox slot="listbox"></media-captions-listbox>
-        </media-chrome-selectmenu>
         <media-playback-rate-button></media-playback-rate-button>
         <media-pip-button></media-pip-button>
-        <media-chrome-selectmenu disabled aria-label="captions menu button">
-          <media-captions-button default-showing slot="button"></media-captions-button>
-          <media-captions-listbox slot="listbox" ></media-captions-listbox>
-        </media-chrome-selectmenu>
         <media-captions-selectmenu></media-captions-selectmenu>
         <media-fullscreen-button></media-fullscreen-button>
         <media-airplay-button></media-airplay-button>
         <media-captions-selectmenu></media-captions-selectmenu>
-        <media-chrome-selectmenu aria-label="captions menu button">
-          <media-captions-button default-showing slot="button"></media-captions-button>
-          <media-captions-listbox slot="listbox"></media-captions-listbox>
-        </media-chrome-selectmenu>
       </media-control-bar>
     </media-controller>
     <div class="examples">

--- a/src/js/experimental/media-captions-selectmenu.js
+++ b/src/js/experimental/media-captions-selectmenu.js
@@ -6,21 +6,30 @@ import { window, document, } from '../utils/server-safe-globals.js';
 class MediaCaptionsSelectMenu extends MediaChromeSelectMenu {
   constructor() {
     super();
+  }
 
-    const captionsButton = document.createElement('media-captions-button');
-    const captionsListbox = document.createElement('media-captions-listbox');
+  init() {
+   const captionsButton = document.createElement('media-captions-button');
+    captionsButton.setAttribute('part', 'button');
 
-    captionsButton.setAttribute('slot', 'button');
-    captionsListbox.setAttribute('slot', 'listbox');
+    captionsButton.preventClick = true;
 
     if (this.hasAttribute('default-showing')) {
       captionsButton.setAttribute('default-showing', '');
     }
 
-    this.append(captionsButton);
-    this.append(captionsListbox);
-  }
+    const captionsListbox = document.createElement('media-captions-listbox');
+    captionsListbox.setAttribute('part', 'listbox');
 
+    const buttonSlot = this.shadowRoot.querySelector('slot[name=button]');
+    const listboxSlot = this.shadowRoot.querySelector('slot[name=listbox]');
+
+    buttonSlot.textContent = '';
+    listboxSlot.textContent = '';
+
+    buttonSlot.append(captionsButton);
+    listboxSlot.append(captionsListbox);
+  }
 }
 
 if (!window.customElements.get('media-captions-selectmenu')) {

--- a/src/js/experimental/media-chrome-selectmenu.js
+++ b/src/js/experimental/media-chrome-selectmenu.js
@@ -14,7 +14,7 @@ template.innerHTML = `
   }
 
   [name="listbox"]::slotted(*),
-  media-chrome-listbox {
+  [part=listbox] {
     position: absolute;
     left: 0;
     bottom: 100%;
@@ -24,7 +24,7 @@ template.innerHTML = `
   </style>
 
   <slot name="button">
-    <media-chrome-button aria-haspopup="listbox">
+    <media-chrome-button aria-haspopup="listbox" part="button">
       <slot name="button-content"></slot>
     </media-chrome-button>
   </slot>
@@ -65,8 +65,10 @@ class MediaChromeSelectMenu extends window.HTMLElement {
     this.#handleClick = this.#handleClick_.bind(this);
     this.#handleChange = this.#handleChange_.bind(this);
 
-    this.#button = this.shadowRoot.querySelector('media-chrome-button');
-    this.#listbox = this.shadowRoot.querySelector('media-chrome-listbox');
+    this.init?.();
+
+    this.#button = this.shadowRoot.querySelector('[part=button]');
+    this.#listbox = this.shadowRoot.querySelector('[part=listbox]');
 
     this.#buttonSlot = this.shadowRoot.querySelector('slot[name=button]');
     this.#buttonSlot.addEventListener('slotchange', () => {
@@ -139,8 +141,7 @@ class MediaChromeSelectMenu extends window.HTMLElement {
     if (
       this.hasAttribute('media-controller') ||
       this.#button.hasAttribute('media-controller') ||
-      this.#listbox.hasAttribute('media-controller') ||
-      !this.#buttonSlotted
+      this.#listbox.hasAttribute('media-controller')
     ) {
       this.#listbox.style.zIndex = '1';
       this.#listbox.style.bottom = 'unset';


### PR DESCRIPTION
test url: https://media-chrome-git-fork-luwes-spec-selectmenu-behavior-mux.vercel.app/examples/control-elements/media-chrome-selectmenu.html

like explained in DM I believe we should make selectmenu work similar to spec.

first provide highest level abstractions `<media-captions-selectmenu>`, `<media-playback-rate-selectmenu>` like we do for `<media-play-button>`. it should be as easy as that.

all inner elements should be in the shadow DOM by default. options are added automatically via feature.

if you require more granular styling, special attributes etc. bring the button and / or listbox in the light DOM via slots.

--- 

this is just a rough draft to get it working for showing it's possible.