### PR TITLE
Fix/improve inferred media-ui-extension values

### DIFF
--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -152,4 +152,5 @@ export const AvailabilityStates = {
 export const StreamTypes = {
   LIVE: 'live',
   ON_DEMAND: 'on-demand',
+  UNKNOWN: 'unknown',
 };

--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -1138,23 +1138,21 @@ const getShowingCaptionTracks = (controller) => {
 const getStreamType = (controller) => {
   const { media } = controller;
 
-  if (!media) return StreamTypes.UNKNOWN;
+  if (!media) return undefined;
 
-  if (media.streamType) {
+  const { streamType } = media;
+  if (StreamTypeValues.includes(streamType)) {
     // If the slotted media supports `streamType` but
     // `streamType` is "unknown", prefer `default-stream-type`
     // if set (CJP)
-    if (
-      media.streamType === 'unknown' &&
-      controller.hasAttribute('default-stream-type')
-    ) {
+    if (streamType === StreamTypes.UNKNOWN) {
       const defaultType = controller.getAttribute('default-stream-type');
-
-      if (StreamTypeValues.includes(defaultType)) {
+      if ([StreamTypes.LIVE, StreamTypes.ON_DEMAND].includes(defaultType)) {
         return defaultType;
       }
+      return undefined;
     }
-    return media.streamType;
+    return streamType;
   }
   const duration = media.duration;
 
@@ -1165,12 +1163,12 @@ const getStreamType = (controller) => {
   } else {
     const defaultType = controller.getAttribute('default-stream-type');
 
-    if (StreamTypeValues.includes(defaultType)) {
+    if ([StreamTypes.LIVE, StreamTypes.ON_DEMAND].includes(defaultType)) {
       return defaultType;
     }
   }
 
-  return StreamTypes.UNKNOWN;
+  return undefined;
 };
 
 const getTargetLiveWindow = (controller) => {

--- a/src/js/media-theme-element.js
+++ b/src/js/media-theme-element.js
@@ -1,4 +1,4 @@
-import { window } from './utils/server-safe-globals.js';
+import { window, document } from './utils/server-safe-globals.js';
 import { TemplateInstance } from './utils/template-parts.js';
 import { processor } from './utils/template-processor.js';
 import { camelCase } from './utils/utils.js';


### PR DESCRIPTION
This ensures that `<media-controller>`'s state representation for `streamType` and `targetLiveWindow` are more predictable, even for cases where the slotted media element has no/partial support for these media-ui-extension values. This will allow for more predictable UI design, including (especially) with Media Chrome themes.