### PR TITLE
fix: theme inline-block, improve responsive theme

### DIFF
--- a/examples/themes/responsive-theme.html
+++ b/examples/themes/responsive-theme.html
@@ -8,24 +8,40 @@
     <script src="https://cdn.jsdelivr.net/npm/shadow-container-query-polyfill@1/dist/shadow-container-query-polyfill.modern.js"></script>
     <script type="module" src="../../dist/index.js"></script>
     <script type="module" src="../../src/js/themes/responsive.js"></script>
-  </head>
-  <body>
     <style>
-      body {
-        margin: 0px;
+      /** add styles to prevent CLS (Cumulative Layout Shift) */
+      media-theme-responsive:not([audio]) {
+        display: block;      /* expands the container if preload=none */
+        max-width: 960px;    /* allows the container to shrink if small */
+        aspect-ratio: 2.4;   /* set container aspect ratio if preload=none */
       }
 
-      media-theme-responsive {
-        width: 100vw;
-        height: 100vh;
+      video {
+        width: 100%;      /* prevents video to expand beyond its container */
+      }
+
+      .examples {
+        margin-top: 20px;
       }
     </style>
+  </head>
+  <body>
+    <main>
+      <h1>Media Chrome Responsive Theme Example</h1>
 
-    <main aria-label="Media Chrome Responsive Theme Example">
+      <media-theme-responsive audio>
+        <audio
+          slot="media"
+          src="https://stream.mux.com/O4h5z00885HEucNNa1rV02wZapcGp01FXXoJd35AHmGX7g/audio.m4a"
+        ></audio>
+      </media-theme-responsive>
+
+      <br><br>
+
       <media-theme-responsive>
         <video
           slot="media"
-          src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/high.mp4"
+          src="https://stream.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/high.mp4"
           crossorigin="anonymous"
           muted
           playsinline
@@ -34,15 +50,25 @@
             label="thumbnails"
             default
             kind="metadata"
-            src="https://image.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/storyboard.vtt"
+            src="https://image.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/storyboard.vtt"
+          />
+          <track
+            label="English"
+            kind="captions"
+            srclang="en"
+            src="../vtt/en-cc.vtt"
           />
         </video>
         <media-poster-image
           slot="poster"
-          src="https://image.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/thumbnail.jpg"
-          placeholder-src="data:image/jpeg;base64,/9j/2wBDAAUDBAQEAwUEBAQFBQUGBwwIBwcHBw8LCwkMEQ8SEhEPERETFhwXExQaFRERGCEYGh0dHx8fExciJCIeJBweHx7/2wBDAQUFBQcGBw4ICA4eFBEUHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh7/wAARCAASACADASIAAhEBAxEB/8QAGgABAAIDAQAAAAAAAAAAAAAAAAMEAgUGCP/EACkQAAEDAgMIAgMAAAAAAAAAAAEAAgMEBgUREgcUITFSkZTRQaEiscH/xAAYAQACAwAAAAAAAAAAAAAAAAAABQIDBv/EAB0RAAICAQUAAAAAAAAAAAAAAAABAgMFERUxwfD/2gAMAwEAAhEDEQA/AOZh2P2k/LOhq/Lf7VuPYvZxLQ6iqgXchvrxn9rpY7ojYCBU0IJ5HU3h9rU3NcGJVcVNJh2K4fDPTztlbm5reGRDhnxIzBPwkUc9RJ6dDHaLYojj2HWYeeH1nmSe1OzYXZJ54fW+ZJ7VeWrbO4SPuedpI/IOnB/TgsxJh4yIuGYu+TvAH9UXnafItWJmuTy1oZ0t7JoZ0t7Ii0InGhnS3smhnS3siIA//9k="
+          src="https://image.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/thumbnail.jpg"
+          placeholder-src="data:image/jpeg;base64,/9j/2wBDABQODxIPDRQSEBIXFRQYHjIhHhwcHj0sLiQySUBMS0dARkVQWnNiUFVtVkVGZIhlbXd7gYKBTmCNl4x9lnN+gXz/2wBDARUXFx4aHjshITt8U0ZTfHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHz/wAARCAAUADADASIAAhEBAxEB/8QAGAAAAwEBAAAAAAAAAAAAAAAAAAECBAP/xAAdEAEBAAEEAwAAAAAAAAAAAAAAARECAxITFCFR/8QAGQEAAwADAAAAAAAAAAAAAAAAAAEDAgQF/8QAGBEBAQEBAQAAAAAAAAAAAAAAAAETERL/2gAMAwEAAhEDEQA/ANeC4ldyI1b2EtIzzrrIqYZLvl5FGkGdbfQzGPvo76WsPxXLlfqbaA5va2iVJADgPELACsD/2Q=="
         ></media-poster-image>
       </media-theme-responsive>
+
+      <div class="examples">
+        <a href="../">View more examples</a>
+      </div>
     </main>
   </body>
 </html>

--- a/src/js/media-theme-element.js
+++ b/src/js/media-theme-element.js
@@ -16,7 +16,7 @@ const prependTemplate = document.createElement('template');
 prependTemplate.innerHTML = `
   <style>
     :host {
-      display: block;
+      display: inline-block;
       line-height: 0;
     }
 

--- a/src/js/themes/responsive.js
+++ b/src/js/themes/responsive.js
@@ -13,19 +13,14 @@ import { MediaThemeElement } from '../media-theme-element.js';
 const template = document.createElement('template');
 template.innerHTML = `
 <style>
-  :host {
-    display: inline-block;
-  }
-  media-controller:not([audio]) {
-    display: block;
-    aspect-ratio: 16 / 9;   /* set container aspect ratio if preload=none */
-  }
-  video {
-    width: 100%;      /* prevents video to expand beyond its container */
-  }
 
-  media-controller {
+  :host(:not([audio])) {
+    ${/*
+     * Containers can't be sized by their contents, they require a width
+     * https://stackoverflow.com/a/73980194/268820
+     */''}
     container: media-chrome / inline-size;
+    width: 100%;
   }
 
   .centered-controls-overlay {
@@ -96,29 +91,47 @@ template.innerHTML = `
   }
 </style>
 
-<media-controller>
+<media-controller audio="{{audio}}">
   <slot name="media" slot="media"></slot>
   <slot name="poster" slot="poster"></slot>
-  <media-loading-indicator media-loading slot="centered-chrome" no-auto-hide></media-loading-indicator>
-  <div slot="centered-chrome" class="centered-controls-overlay">
-    <media-seek-backward-button></media-seek-backward-button>
-    <media-play-button></media-play-button>
-    <media-seek-forward-button></media-seek-forward-button>
-  </div>
-  <media-control-bar>
-    <media-play-button></media-play-button>
-    <media-seek-backward-button seek-offset="15"></media-seek-backward-button>
-    <media-seek-forward-button seek-offset="15"></media-seek-forward-button>
-    <media-mute-button></media-mute-button>
-    <media-volume-range></media-volume-range>
-    <media-time-range></media-time-range>
-    <media-time-display show-duration remaining></media-time-display>
-    <media-captions-button default-showing></media-captions-button>
-    <media-playback-rate-button></media-playback-rate-button>
-    <media-pip-button></media-pip-button>
-    <media-fullscreen-button></media-fullscreen-button>
-    <media-airplay-button></media-airplay-button>
-  </media-control-bar>
+
+  <template if="audio">
+    <template if="mediatitle">
+      <media-control-bar>{{mediatitle}}</media-control-bar>
+    </template>
+    <media-control-bar>
+      <media-play-button></media-play-button>
+      <media-time-display show-duration></media-time-display>
+      <media-time-range></media-time-range>
+      <media-playback-rate-button></media-playback-rate-button>
+      <media-mute-button></media-mute-button>
+      <media-volume-range></media-volume-range>
+    </media-control-bar>
+  </template>
+
+  <template if="audio == null">
+    <media-loading-indicator media-loading slot="centered-chrome" no-auto-hide></media-loading-indicator>
+
+    <div slot="centered-chrome" class="centered-controls-overlay">
+      <media-seek-backward-button></media-seek-backward-button>
+      <media-play-button></media-play-button>
+      <media-seek-forward-button></media-seek-forward-button>
+    </div>
+    <media-control-bar>
+      <media-play-button></media-play-button>
+      <media-seek-backward-button seek-offset="15"></media-seek-backward-button>
+      <media-seek-forward-button seek-offset="15"></media-seek-forward-button>
+      <media-mute-button></media-mute-button>
+      <media-volume-range></media-volume-range>
+      <media-time-range></media-time-range>
+      <media-time-display show-duration remaining></media-time-display>
+      <media-captions-button default-showing></media-captions-button>
+      <media-playback-rate-button></media-playback-rate-button>
+      <media-pip-button></media-pip-button>
+      <media-fullscreen-button></media-fullscreen-button>
+      <media-airplay-button></media-airplay-button>
+    </media-control-bar>
+  </template>
 </media-controller>
 `;
 


### PR DESCRIPTION
Made the responsive theme example show a similar state with the basic example for comparison.
`media-theme-element` actually needed a default of `display: inline-block` to match with theme-less out of the box.

Basic: https://media-chrome-git-fork-luwes-responsive-theme-tweaks-mux.vercel.app/examples/basic.html
Theme: https://media-chrome-git-fork-luwes-responsive-theme-tweaks-mux.vercel.app/examples/themes/responsive-theme.html

if the media-theme-element was `display: block` by default the audio player would expand 100% in the theme example 