### PR TITLE
fix: add display CSS vars

### DIFF
--- a/src/js/media-chrome-button.js
+++ b/src/js/media-chrome-button.js
@@ -1,4 +1,5 @@
 import { MediaStateReceiverAttributes } from './constants.js';
+import { getOrInsertCSSRule } from './utils/element-utils.js';
 import { window, document } from './utils/server-safe-globals.js';
 
 const template = document.createElement('template');
@@ -76,7 +77,7 @@ class MediaChromeButton extends window.HTMLElement {
   constructor(options = {}) {
     super();
 
-    const shadow = this.attachShadow({ mode: 'open' });
+    this.attachShadow({ mode: 'open' });
 
     const buttonHTML = template.content.cloneNode(true);
     this.nativeEl = buttonHTML;
@@ -91,7 +92,10 @@ class MediaChromeButton extends window.HTMLElement {
 
     this.nativeEl.appendChild(slotTemplate.content.cloneNode(true));
 
-    shadow.appendChild(buttonHTML);
+    this.shadowRoot.appendChild(buttonHTML);
+
+    const { style } = getOrInsertCSSRule(this.shadowRoot, ':host');
+    style.setProperty('display', `var(--${this.localName}-display, inline-flex)`);
   }
 
   #clickListener = (e) => {

--- a/src/js/media-chrome-range.js
+++ b/src/js/media-chrome-range.js
@@ -195,6 +195,9 @@ class MediaChromeRange extends window.HTMLElement {
     this.attachShadow({ mode: 'open' });
     this.shadowRoot.appendChild(template.content.cloneNode(true));
 
+    const { style } = getOrInsertCSSRule(this.shadowRoot, ':host');
+    style.setProperty('display', `var(--${this.localName}-display, inline-block)`);
+
     this.container = this.shadowRoot.querySelector('#container');
     /** @type {Omit<HTMLInputElement, "value" | "min" | "max"> &
       * {value: number, min: number, max: number}} */

--- a/src/js/media-control-bar.js
+++ b/src/js/media-control-bar.js
@@ -13,7 +13,7 @@ template.innerHTML = `
     :host {
       ${/* Need position to display above video for some reason */''}
       box-sizing: border-box;
-      display: inline-flex;
+      display: var(--media-control-bar-display, inline-flex);
       color: var(--media-icon-color, #eee);
       --media-loading-icon-width: 44px;
     }

--- a/src/js/media-gesture-receiver.js
+++ b/src/js/media-gesture-receiver.js
@@ -12,7 +12,7 @@ const template = document.createElement('template');
 template.innerHTML = `
 <style>
   :host {
-    display: inline-block;
+    display: var(--media-gesture-receiver-display, inline-block);
     box-sizing: border-box;
   }
 </style>

--- a/src/js/media-loading-indicator.js
+++ b/src/js/media-loading-indicator.js
@@ -23,7 +23,7 @@ const loadingIndicatorIcon = `
 template.innerHTML = `
 <style>
 :host {
-  display: inline-block;
+  display: var(--media-loading-indicator-display, inline-block);
   vertical-align: middle;
   box-sizing: border-box;
 }

--- a/src/js/media-poster-image.js
+++ b/src/js/media-poster-image.js
@@ -6,7 +6,7 @@ template.innerHTML = `
   <style>
     :host {
       pointer-events: none;
-      display: inline-block;
+      display: var(--media-poster-image-display, inline-block);
       box-sizing: border-box;
     }
 

--- a/src/js/media-preview-thumbnail.js
+++ b/src/js/media-preview-thumbnail.js
@@ -13,7 +13,7 @@ template.innerHTML = `
   <style>
     :host {
       box-sizing: border-box;
-      display: inline-block;
+      display: var(--media-preview-thumbnail-display, inline-block);
       overflow: hidden;
     }
 

--- a/src/js/media-text-display.js
+++ b/src/js/media-text-display.js
@@ -1,4 +1,5 @@
 import { MediaStateReceiverAttributes } from './constants.js';
+import { getOrInsertCSSRule } from './utils/element-utils.js';
 import { window, document } from './utils/server-safe-globals.js';
 // Todo: Use data locals: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString
 
@@ -59,6 +60,9 @@ class MediaTextDisplay extends window.HTMLElement {
     this.attachShadow({ mode: 'open' });
     this.shadowRoot.appendChild(template.content.cloneNode(true));
     this.container = this.shadowRoot.querySelector('#container');
+
+    const { style } = getOrInsertCSSRule(this.shadowRoot, ':host');
+    style.setProperty('display', `var(--${this.localName}-display, inline-flex)`);
   }
 
   attributeChangedCallback(attrName, oldValue, newValue) {


### PR DESCRIPTION
this adds CSS vars for the control's `display` property.
it's handy for when using a theme to show/hide specific controls.

```html
  <media-theme-responsive style="--media-fullscreen-button-display: none"></media-theme-responsive>
```

a theme or player can also easily create higher level CSS vars by forwarding

```css
media-controller::part(top) {
  --media-play-button-display: var(--top-controls, var(--top-play-button, inline-flex));
  --media-mute-button-display: var(--top-controls, var(--top-mute-button, inline-flex));
}
```