### PR TITLE
Add control display CSS var

### DIFF
--- a/src/js/experimental/media-chrome-selectmenu.js
+++ b/src/js/experimental/media-chrome-selectmenu.js
@@ -1,7 +1,7 @@
 import '../media-chrome-button.js';
 import './media-chrome-listbox.js';
 import { window, document } from '../utils/server-safe-globals.js';
-import { closestComposedNode } from '../utils/element-utils.js';
+import { closestComposedNode, getOrInsertCSSRule } from '../utils/element-utils.js';
 import { MediaStateReceiverAttributes } from '../constants.js';
 
 const template = document.createElement('template');
@@ -61,6 +61,9 @@ class MediaChromeSelectMenu extends window.HTMLElement {
     this.nativeEl = buttonHTML;
 
     shadow.appendChild(buttonHTML);
+
+    const { style } = getOrInsertCSSRule(this.shadowRoot, ':host');
+    style.setProperty('display', `var(--media-control-display, var(--${this.localName}-display, inline-flex))`);
 
     this.#handleClick = this.#handleClick_.bind(this);
     this.#handleChange = this.#handleChange_.bind(this);

--- a/src/js/media-chrome-button.js
+++ b/src/js/media-chrome-button.js
@@ -95,7 +95,7 @@ class MediaChromeButton extends window.HTMLElement {
     this.shadowRoot.appendChild(buttonHTML);
 
     const { style } = getOrInsertCSSRule(this.shadowRoot, ':host');
-    style.setProperty('display', `var(--${this.localName}-display, inline-flex)`);
+    style.setProperty('display', `var(--media-control-display, var(--${this.localName}-display, inline-flex))`);
   }
 
   #clickListener = (e) => {

--- a/src/js/media-chrome-range.js
+++ b/src/js/media-chrome-range.js
@@ -196,7 +196,7 @@ class MediaChromeRange extends window.HTMLElement {
     this.shadowRoot.appendChild(template.content.cloneNode(true));
 
     const { style } = getOrInsertCSSRule(this.shadowRoot, ':host');
-    style.setProperty('display', `var(--${this.localName}-display, inline-block)`);
+    style.setProperty('display', `var(--media-control-display, var(--${this.localName}-display, inline-block))`);
 
     this.container = this.shadowRoot.querySelector('#container');
     /** @type {Omit<HTMLInputElement, "value" | "min" | "max"> &

--- a/src/js/media-control-bar.js
+++ b/src/js/media-control-bar.js
@@ -13,7 +13,7 @@ template.innerHTML = `
     :host {
       ${/* Need position to display above video for some reason */''}
       box-sizing: border-box;
-      display: var(--media-control-bar-display, inline-flex);
+      display: var(--media-control-display, var(--media-control-bar-display, inline-flex));
       color: var(--media-icon-color, #eee);
       --media-loading-icon-width: 44px;
     }

--- a/src/js/media-gesture-receiver.js
+++ b/src/js/media-gesture-receiver.js
@@ -12,7 +12,7 @@ const template = document.createElement('template');
 template.innerHTML = `
 <style>
   :host {
-    display: var(--media-gesture-receiver-display, inline-block);
+    display: var(--media-control-display, var(--media-gesture-receiver-display, inline-block));
     box-sizing: border-box;
   }
 </style>

--- a/src/js/media-loading-indicator.js
+++ b/src/js/media-loading-indicator.js
@@ -23,7 +23,7 @@ const loadingIndicatorIcon = `
 template.innerHTML = `
 <style>
 :host {
-  display: var(--media-loading-indicator-display, inline-block);
+  display: var(--media-control-display, var(--media-loading-indicator-display, inline-block));
   vertical-align: middle;
   box-sizing: border-box;
 }

--- a/src/js/media-preview-thumbnail.js
+++ b/src/js/media-preview-thumbnail.js
@@ -13,7 +13,7 @@ template.innerHTML = `
   <style>
     :host {
       box-sizing: border-box;
-      display: var(--media-preview-thumbnail-display, inline-block);
+      display: var(--media-control-display, var(--media-preview-thumbnail-display, inline-block));
       overflow: hidden;
     }
 

--- a/src/js/media-text-display.js
+++ b/src/js/media-text-display.js
@@ -62,7 +62,7 @@ class MediaTextDisplay extends window.HTMLElement {
     this.container = this.shadowRoot.querySelector('#container');
 
     const { style } = getOrInsertCSSRule(this.shadowRoot, ':host');
-    style.setProperty('display', `var(--${this.localName}-display, inline-flex)`);
+    style.setProperty('display', `var(--media-control-display, var(--${this.localName}-display, inline-flex))`);
   }
 
   attributeChangedCallback(attrName, oldValue, newValue) {

--- a/src/js/themes/micro.js
+++ b/src/js/themes/micro.js
@@ -221,44 +221,17 @@ template.innerHTML = html`
     width: 7px;
   }
 
-  media-play-button {
-    display: var(--controls, var(--play-button, inline-flex));
-  }
-
+  /* Turn some buttons off by default */
   media-seek-backward-button {
-    display: var(--controls, var(--seek-backward-button, none));
+    display: var(--media-control-display, var(--media-seek-backward-button-display, none));
   }
 
   media-seek-forward-button {
-    display: var(--controls, var(--seek-forward-button, none));
-  }
-
-  media-mute-button {
-    display: var(--controls, var(--mute-button, inline-flex));
-  }
-
-  media-captions-button {
-    display: var(--controls, var(--captions-button, inline-flex));
+    display: var(--media-control-display, var(--media-seek-forward-button-display, none));
   }
 
   media-pip-button {
-    display: var(--controls, var(--pip-button, none));
-  }
-
-  media-airplay-button {
-    display: var(--controls, var(--airplay-button, inline-flex));
-  }
-
-  media-cast-button {
-    display: var(--controls, var(--cast-button, inline-flex));
-  }
-
-  media-fullscreen-button {
-    display: var(--controls, var(--fullscreen-button, inline-flex));
-  }
-
-  media-live-button {
-    display: var(--controls, var(--live-button, inline-flex));
+    display: var(--media-control-display, var(--media-pip-button-display, none));
   }
 </style>
 

--- a/src/js/themes/micro.js
+++ b/src/js/themes/micro.js
@@ -15,30 +15,6 @@ const html = (raw, ...keys) => String.raw({ raw }, ...keys);
 const template = document.createElement('template');
 template.innerHTML = html`
 <style>
-  media-captions-button:not(:is([media-captions-list], [media-subtitles-list])) {
-    display: none;
-  }
-
-  media-volume-range[media-volume-unavailable] {
-    display: none;
-  }
-
-  media-airplay-button[media-airplay-unavailable] {
-    display: none;
-  }
-
-  media-fullscreen-button[media-fullscreen-unavailable] {
-    display: none;
-  }
-
-  media-cast-button[media-cast-unavailable] {
-    display: none;
-  }
-
-  media-pip-button[media-pip-unavailable] {
-    display: none;
-  }
-
   :host {
     --_primary-color: var(--primary-color, #fff);
     --_secondary-color: var(--secondary-color, rgb(0 0 0 / .75));
@@ -62,6 +38,30 @@ template.innerHTML = html`
 
   [breakpoint-md] {
     --media-control-padding: 9px 7px;
+  }
+
+  media-captions-button:not(:is([media-captions-list], [media-subtitles-list])) {
+    display: none;
+  }
+
+  media-volume-range[media-volume-unavailable] {
+    display: none;
+  }
+
+  media-airplay-button[media-airplay-unavailable] {
+    display: none;
+  }
+
+  media-fullscreen-button[media-fullscreen-unavailable] {
+    display: none;
+  }
+
+  media-cast-button[media-cast-unavailable] {
+    display: none;
+  }
+
+  media-pip-button[media-pip-unavailable] {
+    display: none;
   }
 
   media-controller::part(centered-layer) {


### PR DESCRIPTION
This change adds the `--media-control-display` css var and adds the display var also to the selectmenu elements.

Changes the Micro theme to make use of the new CSS vars