### PR TITLE
experiment: selectmenu use inheritance for some CSS props

### DIFF
--- a/examples/control-elements/media-chrome-selectmenu.html
+++ b/examples/control-elements/media-chrome-selectmenu.html
@@ -82,7 +82,7 @@
         <style>
           #cb > * {
             background-color: #900;
-            padding: 10px;
+            padding: 5px;
             border: 1px solid #009;
           }
         </style>

--- a/examples/control-elements/media-chrome-selectmenu.html
+++ b/examples/control-elements/media-chrome-selectmenu.html
@@ -28,21 +28,6 @@
       cursor: not-allowed;
     }
 
-    media-captions-selectmenu::part(button) {
-      background: purple;
-    }
-
-    media-captions-selectmenu::part(listbox) {
-      background: green;
-    }
-
-    media-captions-selectmenu::part(listitem) {
-      color: yellow;
-    }
-    media-captions-listbox::part(listitem) {
-      color: red;
-    }
-
   </style>
 </head>
 <body>
@@ -93,28 +78,21 @@
         <track label="Subs Arabic" kind="subtitles" srclang="ar" src="../vtt/elephantsdream/captions.ar.vtt"></track>
       </video>
       <media-poster-image slot="poster" src="https://d2zihajmogu5jn.cloudfront.net/elephantsdream/poster.png"></media-poster-image>
-      <media-control-bar>
-        <media-chrome-selectmenu aria-label="captions menu button">
-          <media-captions-button default-showing slot="button"></media-captions-button>
-          <media-captions-listbox slot="listbox"></media-captions-listbox>
-        </media-chrome-selectmenu>
+      <media-control-bar id="cb">
+        <style>
+          #cb > * {
+            background-color: #900;
+            padding: 10px;
+            border: 1px solid #009;
+          }
+        </style>
         <media-play-button></media-play-button>
         <media-seek-backward-button seek-offset="15"></media-seek-backward-button>
         <media-seek-forward-button seek-offset="15"></media-seek-forward-button>
         <media-mute-button></media-mute-button>
         <media-time-display show-duration remaining></media-time-display>
-        <media-captions-button></media-captions-button>
-        <media-chrome-selectmenu aria-label="captions menu button">
-          <media-captions-button default-showing slot="button"></media-captions-button>
-          <media-captions-listbox slot="listbox"></media-captions-listbox>
-        </media-chrome-selectmenu>
         <media-playback-rate-button></media-playback-rate-button>
         <media-pip-button></media-pip-button>
-        <media-chrome-selectmenu disabled aria-label="captions menu button">
-          <media-captions-button default-showing slot="button"></media-captions-button>
-          <media-captions-listbox slot="listbox" ></media-captions-listbox>
-        </media-chrome-selectmenu>
-        <media-captions-selectmenu></media-captions-selectmenu>
         <media-fullscreen-button></media-fullscreen-button>
         <media-airplay-button></media-airplay-button>
         <media-captions-selectmenu></media-captions-selectmenu>

--- a/src/js/experimental/media-chrome-selectmenu.js
+++ b/src/js/experimental/media-chrome-selectmenu.js
@@ -12,6 +12,7 @@ template.innerHTML = /*html*/`
     position: relative;
     flex-shrink: .5;
     background: var(--media-control-background, rgba(20,20,30, 0.7));
+    padding: var(--media-control-padding, 10px);
   }
 
   [name="listbox"]::slotted(*),
@@ -25,6 +26,7 @@ template.innerHTML = /*html*/`
 
   [name="button"]::slotted(*),
   [part="button"] {
+    padding: 0;
     background-color: inherit;
   }
   </style>

--- a/src/js/experimental/media-chrome-selectmenu.js
+++ b/src/js/experimental/media-chrome-selectmenu.js
@@ -5,21 +5,27 @@ import { closestComposedNode, getOrInsertCSSRule } from '../utils/element-utils.
 import { MediaStateReceiverAttributes } from '../constants.js';
 
 const template = document.createElement('template');
-template.innerHTML = `
+template.innerHTML = /*html*/`
   <style>
   :host {
     display: inline-flex;
     position: relative;
     flex-shrink: .5;
+    background: var(--media-control-background, rgba(20,20,30, 0.7));
   }
 
   [name="listbox"]::slotted(*),
-  [part=listbox] {
+  [part="listbox"] {
     position: absolute;
     left: 0;
     bottom: 100%;
     max-height: 300px;
     overflow: hidden auto;
+  }
+
+  [name="button"]::slotted(*),
+  [part="button"] {
+    background-color: inherit;
   }
   </style>
 


### PR DESCRIPTION
in reply to https://github.com/muxinc/media-chrome/issues/387#issuecomment-1481546061

for some CSS we could have this workaround
https://media-chrome-git-fork-luwes-css-experiment-inherit-mux.vercel.app/examples/control-elements/media-chrome-selectmenu.html