### PR TITLE
fix: add support for negations

### DIFF
--- a/examples/themes/microvideo-theme.html
+++ b/examples/themes/microvideo-theme.html
@@ -80,7 +80,7 @@
         <div>
           <h3>Choose <code>target-live-window</code>:</h3>
           <label>
-            <input type="radio" name="target-live-window" value="" checked>
+            <input type="radio" name="target-live-window" value="0" checked>
             0
           </label>
           <label>

--- a/src/js/media-theme-element.js
+++ b/src/js/media-theme-element.js
@@ -1,7 +1,7 @@
 import { window, document } from './utils/server-safe-globals.js';
 import { TemplateInstance } from './utils/template-parts.js';
 import { processor } from './utils/template-processor.js';
-import { camelCase } from './utils/utils.js';
+import { camelCase, isNumericString } from './utils/utils.js';
 
 // Export Template parts for players.
 export * from './utils/template-parts.js';
@@ -118,10 +118,21 @@ export class MediaThemeElement extends window.HTMLElement {
 
     const props = {};
     for (let attr of observedAttributes) {
+
       const name = observedMediaAttributes[attr.name] ?? camelCase(attr.name);
-      if (attr.value != null) {
-        props[name] = attr.value === '' ? true : attr.value;
+      let { value } = attr;
+
+      if (value != null) {
+
+        if (isNumericString(value)) {
+          // @ts-ignore
+          value = parseFloat(value);
+        }
+
+        props[name] = value === '' ? true : value;
+
       } else {
+
         props[name] = false;
       }
     }

--- a/src/js/themes/microvideo.js
+++ b/src/js/themes/microvideo.js
@@ -476,7 +476,7 @@ template.innerHTML = /*html*/`
 
   <template if="streamType == 'live'">
 
-    <template if="targetLiveWindow == null">
+    <template if="!targetLiveWindow">
 
       <media-control-bar slot="centered-chrome">
         {{>LiveButton}}

--- a/src/js/themes/minimal.js
+++ b/src/js/themes/minimal.js
@@ -399,7 +399,7 @@ template.innerHTML = /*html*/`
       <media-control-bar>
         <div class="live-controls-left">
           {{>LiveButton}}
-          <template if="targetLiveWindow == null">
+          <template if="!targetLiveWindow">
             <template if="breakpointSm">
               <media-time-display></media-time-display>
             </template>

--- a/test/unit/template-processor.spec.js
+++ b/test/unit/template-processor.spec.js
@@ -5,6 +5,8 @@ import { TemplateInstance } from '../../src/js/utils/template-parts.js';
 describe('evaluateExpression', () => {
   it('can evaluate a simple boolean condition', () => {
     assert(evaluateExpression('true'));
+    assert(evaluateExpression('!false'));
+    assert(evaluateExpression('!!true'));
     assert(evaluateExpression('true == myVar', { myVar: true }));
     assert(evaluateExpression('myVar != false', { myVar: true }));
   });
@@ -12,6 +14,8 @@ describe('evaluateExpression', () => {
   it('can evaluate a simple number condition', async () => {
     assert(!evaluateExpression('0'));
     assert(evaluateExpression('1'));
+    assert(evaluateExpression('!0'));
+    assert(!evaluateExpression('!1'));
     assert(evaluateExpression('5 > 3'));
     assert(evaluateExpression('5 >= 3'));
     assert(evaluateExpression('5 >= 5'));
@@ -24,6 +28,7 @@ describe('evaluateExpression', () => {
 
   it('can evaluate a simple string condition', async () => {
     assert(!evaluateExpression('""'));
+    assert(evaluateExpression('!""'));
     assert(evaluateExpression('"thruthy"'));
     assert(evaluateExpression('myVar == "a string"', { myVar: 'a string' }));
     assert(evaluateExpression('myVar != "a string"', { myVar: 'lalala' }));


### PR DESCRIPTION
this adds support for a negation `!targetLiveWindow` in themes.

it's required as that variable can be either `undefined` or `0` in the condition 

`<template if="targetLiveWindow == 0 or null ">`

