### PR TITLE
fix: slot for text display, customizable content

### DIFF
--- a/src/js/media-current-time-display.js
+++ b/src/js/media-current-time-display.js
@@ -5,18 +5,21 @@ import { MediaUIAttributes } from './constants.js';
 // Todo: Use data locals: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString
 
 class MediaCurrentTimeDisplay extends MediaTextDisplay {
+  #slot;
+
   static get observedAttributes() {
     return [...super.observedAttributes, MediaUIAttributes.MEDIA_CURRENT_TIME];
   }
 
   constructor() {
     super();
-    this.container.innerHTML = formatTime(0);
+    this.#slot = this.shadowRoot.querySelector('slot');
+    this.#slot.innerHTML = formatTime(0);
   }
 
   attributeChangedCallback(attrName, oldValue, newValue) {
     if (attrName === MediaUIAttributes.MEDIA_CURRENT_TIME) {
-      this.container.innerHTML = formatTime(newValue);
+      this.#slot.innerHTML = formatTime(newValue);
     }
     super.attributeChangedCallback(attrName, oldValue, newValue);
   }

--- a/src/js/media-current-time-display.js
+++ b/src/js/media-current-time-display.js
@@ -14,12 +14,12 @@ class MediaCurrentTimeDisplay extends MediaTextDisplay {
   constructor() {
     super();
     this.#slot = this.shadowRoot.querySelector('slot');
-    this.#slot.innerHTML = formatTime(0);
+    this.#slot.textContent = formatTime(0);
   }
 
   attributeChangedCallback(attrName, oldValue, newValue) {
     if (attrName === MediaUIAttributes.MEDIA_CURRENT_TIME) {
-      this.#slot.innerHTML = formatTime(newValue);
+      this.#slot.textContent = formatTime(newValue);
     }
     super.attributeChangedCallback(attrName, oldValue, newValue);
   }

--- a/src/js/media-duration-display.js
+++ b/src/js/media-duration-display.js
@@ -14,12 +14,12 @@ class MediaDurationDisplay extends MediaTextDisplay {
   constructor() {
     super();
     this.#slot = this.shadowRoot.querySelector('slot');
-    this.#slot.innerHTML = formatTime(0);
+    this.#slot.textContent = formatTime(0);
   }
 
   attributeChangedCallback(attrName, oldValue, newValue) {
     if (attrName === MediaUIAttributes.MEDIA_DURATION) {
-      this.#slot.innerHTML = formatTime(newValue);
+      this.#slot.textContent = formatTime(newValue);
     }
     super.attributeChangedCallback(attrName, oldValue, newValue);
   }

--- a/src/js/media-duration-display.js
+++ b/src/js/media-duration-display.js
@@ -5,18 +5,21 @@ import { MediaUIAttributes } from './constants.js';
 // Todo: Use data locals: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString
 
 class MediaDurationDisplay extends MediaTextDisplay {
+  #slot;
+
   static get observedAttributes() {
     return [...super.observedAttributes, MediaUIAttributes.MEDIA_DURATION];
   }
 
   constructor() {
     super();
-    this.container.innerHTML = formatTime(0);
+    this.#slot = this.shadowRoot.querySelector('slot');
+    this.#slot.innerHTML = formatTime(0);
   }
 
   attributeChangedCallback(attrName, oldValue, newValue) {
     if (attrName === MediaUIAttributes.MEDIA_DURATION) {
-      this.container.innerHTML = formatTime(newValue);
+      this.#slot.innerHTML = formatTime(newValue);
     }
     super.attributeChangedCallback(attrName, oldValue, newValue);
   }

--- a/src/js/media-preview-time-display.js
+++ b/src/js/media-preview-time-display.js
@@ -5,13 +5,21 @@ import { MediaUIAttributes } from './constants.js';
 // Todo: Use data locals: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString
 
 class MediaPreviewTimeDisplay extends MediaTextDisplay {
+  #slot;
+
   static get observedAttributes() {
     return [...super.observedAttributes, MediaUIAttributes.MEDIA_PREVIEW_TIME];
   }
 
+  constructor() {
+    super();
+    this.#slot = this.shadowRoot.querySelector('slot');
+    this.#slot.innerHTML = formatTime(0);
+  }
+
   attributeChangedCallback(attrName, oldValue, newValue) {
     if (attrName === MediaUIAttributes.MEDIA_PREVIEW_TIME && newValue != null) {
-      this.container.textContent = formatTime(newValue);
+      this.#slot.textContent = formatTime(newValue);
     }
     super.attributeChangedCallback(attrName, oldValue, newValue);
   }

--- a/src/js/media-preview-time-display.js
+++ b/src/js/media-preview-time-display.js
@@ -14,7 +14,7 @@ class MediaPreviewTimeDisplay extends MediaTextDisplay {
   constructor() {
     super();
     this.#slot = this.shadowRoot.querySelector('slot');
-    this.#slot.innerHTML = formatTime(0);
+    this.#slot.textContent = formatTime(0);
   }
 
   attributeChangedCallback(attrName, oldValue, newValue) {

--- a/src/js/media-text-display.js
+++ b/src/js/media-text-display.js
@@ -42,9 +42,7 @@ template.innerHTML = `
       outline: 0;
     }
   </style>
-  <span id="container">
   <slot></slot>
-  </span>
 `;
 
 class MediaTextDisplay extends window.HTMLElement {
@@ -59,7 +57,6 @@ class MediaTextDisplay extends window.HTMLElement {
 
     this.attachShadow({ mode: 'open' });
     this.shadowRoot.appendChild(template.content.cloneNode(true));
-    this.container = this.shadowRoot.querySelector('#container');
 
     const { style } = getOrInsertCSSRule(this.shadowRoot, ':host');
     style.setProperty('display', `var(--media-control-display, var(--${this.localName}-display, inline-flex))`);


### PR DESCRIPTION
this change removes the unneeded container span and public container property from the text display elements and uses the slot and private slot property to add the content.

