### PR TITLE
feat: introduce a playback rates selectmenu

### DIFF
--- a/docs/src/layouts/MainLayout.astro
+++ b/docs/src/layouts/MainLayout.astro
@@ -130,6 +130,7 @@ const githubEditUrl = `${CONFIG.GITHUB_EDIT_URL}/${currentFile}`;
       import 'media-chrome';
       import 'media-chrome/dist/media-theme-element';
       import 'media-chrome/dist/experimental/media-captions-selectmenu';
+      import 'media-chrome/dist/experimental/media-playback-rate-selectmenu';
     </script>
   </head>
   <body>

--- a/docs/src/pages/en/media-playback-rate-selectmenu.md
+++ b/docs/src/pages/en/media-playback-rate-selectmenu.md
@@ -1,0 +1,98 @@
+---
+title: <media-playback-rate-selectmenu> (Experimental)
+description: Experimental Media Playback Rate Selectmenu
+layout: ../../layouts/MainLayout.astro
+source: https://github.com/muxinc/media-chrome/tree/main/src/js/experimental/media-playback-rate-selectmenu.js
+---
+
+A menu-button for playback rates.
+
+### Default
+
+Defaults to the same values as the [media-playback-rate-button](./media-playback-rate-button).
+
+<media-playback-rate-selectmenu></media-playback-rate-selectmenu>
+
+```html
+<media-playback-rate-selectmenu></media-playback-rate-selectmenu>
+```
+
+### Setting rates
+
+<media-playback-rate-selectmenu rates="1 2 3"></media-playback-rate-selectmenu>
+
+```html
+<media-playback-rate-selectmenu rates="1 2 3"></media-playback-rate-selectmenu>
+```
+
+### Alternate Content
+
+For alternative content for the button, slot a [media-playback-rate-button](./media-playback-rate-button).
+
+<media-playback-rate-selectmenu>
+    <media-playback-rate-button slot="button"></media-playback-rate-button>
+</media-playback-rate-selectmenu>
+
+```html
+<media-playback-rate-selectmenu>
+    <media-playback-rate-button slot="button"></media-playback-rate-button>
+</media-playback-rate-selectmenu>
+```
+
+## Styling
+
+media-playback-rate-listbox puts all the children in its shadow DOM, which makes it a bit harder to style. One alternative is to slot a button or listbox element and then style them directly. However, this component also [exposes three parts](#exposed-parts) that can be targeted for styling.
+
+Check out this example for usage, but please try and use better colors as this color scheme is for demonstration purposes only.
+
+<style>
+#mpr-sm-1::part(button) {
+    background-color: purple;
+}
+#mpr-sm-1::part(listbox) {
+    background-color: yellow;
+    --media-listbox-background: transparent;
+}
+#mpr-sm-1::part(listitem) {
+    background-color: blue;
+}
+</style>
+<media-playback-rate-selectmenu id="mpr-sm-1"></media-playback-rate-selectmenu>
+
+```html
+<style>
+#mpr-sm-1::part(button) {
+    background-color: purple;
+}
+#mpr-sm-1::part(listbox) {
+    background-color: yellow;
+    --media-listbox-background: transparent;
+}
+#mpr-sm-1::part(listitem) {
+    background-color: blue;
+}
+</style>
+<media-playback-rate-selectmenu id="mpr-sm-1"></media-playback-rate-selectmenu>
+```
+
+### Exposed Parts
+
+| Name | Description |
+|------|-------------|
+| `button` | The default [media-playback-rate-button](./media-playback-rate-button) that's in the shadow DOM |
+| `listbox` | The default listbox that's in the shadow DOM |
+| `listitem` | A part that targets each listitem of the listbox |
+
+
+## Attributes
+
+| Name                    | Type      | Default Value | Description                                                                                        |
+| ----------------------- | --------- | ------------- | -------------------------------------------------------------------------------------------------- |
+| `rates` | `list` | `1 1.25 1.5 1.75 2` | List of playback rates to toggle through when pressing the button |
+
+## Slots
+
+| Name  | Default Type | Description                                                 |
+| ----- | ------------ | ----------------------------------------------------------- |
+| `button`  | [`media-playback-rate-button`](./media-playback-rate-button)        | A button element that reflects the current playback rate  |
+| `listbox` | `media-playback-rate-listbox`        | An element that displays the list of playback rate options |

--- a/examples/vanilla/control-elements/media-chrome-selectmenu.html
+++ b/examples/vanilla/control-elements/media-chrome-selectmenu.html
@@ -6,6 +6,7 @@
   <script type="module" src="../../../dist/index.js"></script>
   <script type="module" src="../../../dist/experimental/media-chrome-selectmenu.js"></script>
   <script type="module" src="../../../dist/experimental/media-captions-selectmenu.js"></script>
+  <script type="module" src="../../../dist/experimental/media-playback-rate-listbox.js"></script>
   <style>
     media-controller {
       margin-top: 2em;
@@ -48,6 +49,12 @@
 <body>
   <main>
     <h1>Media Chrome Standard Video Usage Example</h1>
+    <media-playback-rate-listbox media-controller="mc">
+      <media-chrome-listitem value="1">1x</media-chrome-listitem>
+      <media-chrome-listitem value="1.5">1.5x</media-chrome-listitem>
+      <media-chrome-listitem value="2">2x</media-chrome-listitem>
+      <media-chrome-listitem value="3">3x</media-chrome-listitem>
+    </media-playback-rate-listbox>
     <media-chrome-selectmenu>
       <span slot="button-content">Menu Button</span>
       <media-chrome-listitem>lorem</media-chrome-listitem>

--- a/examples/vanilla/control-elements/media-chrome-selectmenu.html
+++ b/examples/vanilla/control-elements/media-chrome-selectmenu.html
@@ -6,7 +6,7 @@
   <script type="module" src="../../../dist/index.js"></script>
   <script type="module" src="../../../dist/experimental/media-chrome-selectmenu.js"></script>
   <script type="module" src="../../../dist/experimental/media-captions-selectmenu.js"></script>
-  <script type="module" src="../../../dist/experimental/media-playback-rate-listbox.js"></script>
+  <script type="module" src="../../../dist/experimental/media-playback-rate-selectmenu.js"></script>
   <style>
     media-controller {
       margin-top: 2em;
@@ -115,7 +115,8 @@
           <media-captions-button default-showing slot="button"></media-captions-button>
           <media-captions-listbox slot="listbox"></media-captions-listbox>
         </media-chrome-selectmenu>
-        <media-playback-rate-button></media-playback-rate-button>
+        <!-- <media-playback-rate-button></media-playback-rate-button> -->
+        <media-playback-rate-selectmenu></media-playback-rate-selectmenu>
         <media-pip-button></media-pip-button>
         <media-chrome-selectmenu disabled aria-label="captions menu button">
           <media-captions-button default-showing slot="button"></media-captions-button>

--- a/examples/vanilla/control-elements/media-chrome-selectmenu.html
+++ b/examples/vanilla/control-elements/media-chrome-selectmenu.html
@@ -55,6 +55,15 @@
       <media-chrome-listitem value="2">2x</media-chrome-listitem>
       <media-chrome-listitem value="3">3x</media-chrome-listitem>
     </media-playback-rate-listbox>
+    <media-playback-rate-selectmenu rates="1 2 3 4" media-controller="mc">
+      <media-playback-rate-listbox slot="listbox">
+        <media-chrome-listitem value="1">1x</media-chrome-listitem>
+        <media-chrome-listitem value="1.5">1.5x</media-chrome-listitem>
+        <media-chrome-listitem value="2">2x</media-chrome-listitem>
+        <media-chrome-listitem value="3">3x</media-chrome-listitem>
+      </media-playback-rate-listbox>
+    </media-playback-rate-selectmenu>
+    <media-playback-rate-selectmenu rates="1 2 3 4" media-controller="mc"></media-playback-rate-selectmenu>
     <media-chrome-selectmenu>
       <span slot="button-content">Menu Button</span>
       <media-chrome-listitem>lorem</media-chrome-listitem>

--- a/src/js/experimental/media-captions-listbox.js
+++ b/src/js/experimental/media-captions-listbox.js
@@ -227,7 +227,7 @@ class MediaCaptionsListbox extends MediaChromeListbox {
     const [newType, selectedOption] = this.selectedOptions[0]?.value?.split('!') ?? [];
 
     // turn off currently selected tracks
-    toggleSubsCaps(this);
+    toggleSubsCaps(this, true);
 
     if (!selectedOption) return;
 

--- a/src/js/experimental/media-chrome-listbox.js
+++ b/src/js/experimental/media-chrome-listbox.js
@@ -135,8 +135,9 @@ class MediaChromeListbox extends window.HTMLElement {
 
   set value(newValue) {
     const item = this.#items.filter(el => el.value === newValue || el.textContent === newValue)[0];
-    console.log(item);
+
     if (!item) return;
+
     this.#selectItem(item);
   }
 

--- a/src/js/experimental/media-chrome-listbox.js
+++ b/src/js/experimental/media-chrome-listbox.js
@@ -154,7 +154,7 @@ class MediaChromeListbox extends window.HTMLElement {
     const { key } = e;
 
     if (key === 'Enter' || key === ' ') {
-      this.handleSelection(e, this.hasAttribute('aria-multiselectable'));
+      this.handleSelection(e, this.hasAttribute('aria-multiselectable') && this.getAttribute('aria-multiselectable') === 'true');
     } else {
       this.handleMovement(e);
     }
@@ -286,7 +286,7 @@ class MediaChromeListbox extends window.HTMLElement {
   }
 
   #selectItem(item, toggle) {
-    if (this.getAttribute('aria-multiselectable') !== 'true') {
+    if (!this.hasAttribute('aria-multiselectable') || this.getAttribute('aria-multiselectable') !== 'true') {
       this.#assignedElements.forEach(el => el.setAttribute('aria-selected', 'false'));
     }
 
@@ -359,7 +359,7 @@ class MediaChromeListbox extends window.HTMLElement {
     this.#items.forEach(el => el.setAttribute('tabindex', '-1'));
     item.setAttribute('tabindex', '0');
 
-    this.handleSelection(e, e.metaKey || e.ctrlKey);
+    this.handleSelection(e, this.hasAttribute('aria-multiselectable') && this.getAttribute('aria-multiselectable') === 'true');
   }
 
   #searchItem(key) {

--- a/src/js/experimental/media-chrome-listbox.js
+++ b/src/js/experimental/media-chrome-listbox.js
@@ -179,7 +179,7 @@ class MediaChromeListbox extends window.HTMLElement {
   }
 
   #keydownListener = (e) => {
-    const { key, metaKey, altKey } = e;
+    const { key, altKey } = e;
 
     if (altKey) {
       this.removeEventListener('keyup', this.#keyupListener);
@@ -188,6 +188,7 @@ class MediaChromeListbox extends window.HTMLElement {
 
     if (key === 'Meta') {
       this.#metaPressed = true;
+      return;
     }
 
     // only prevent default on used keys

--- a/src/js/experimental/media-chrome-listbox.js
+++ b/src/js/experimental/media-chrome-listbox.js
@@ -129,6 +129,17 @@ class MediaChromeListbox extends window.HTMLElement {
     return this.#items.filter(el => el.getAttribute('aria-selected') === 'true');
   }
 
+  get value() {
+    return this.selectedOptions[0].value || this.selectedOptions[0].textContent;
+  }
+
+  set value(newValue) {
+    const item = this.#items.filter(el => el.value === newValue || el.textContent === newValue)[0];
+    console.log(item);
+    if (!item) return;
+    this.#selectItem(item);
+  }
+
   focus() {
     this.selectedOptions[0]?.focus();
   }
@@ -242,6 +253,10 @@ class MediaChromeListbox extends window.HTMLElement {
 
     if (!item) return;
 
+    this.#selectItem(item);
+  }
+
+  #selectItem(item) {
     const selected = item.getAttribute('aria-selected') === 'true';
 
     if (this.getAttribute('aria-multiselectable') !== 'true') {

--- a/src/js/experimental/media-chrome-listbox.js
+++ b/src/js/experimental/media-chrome-listbox.js
@@ -135,7 +135,7 @@ class MediaChromeListbox extends window.HTMLElement {
   }
 
   set value(newValue) {
-    const item = this.#items.filter(el => el.value === newValue || el.textContent === newValue)[0];
+    const item = this.#items.find(el => el.value === newValue || el.textContent === newValue);
 
     if (!item) return;
 

--- a/src/js/experimental/media-chrome-listbox.js
+++ b/src/js/experimental/media-chrome-listbox.js
@@ -159,7 +159,7 @@ class MediaChromeListbox extends window.HTMLElement {
     }
 
     if (key === 'Enter' || key === ' ') {
-      this.handleSelection(e);
+      this.handleSelection(e, true);
     } else {
       this.handleMovement(e);
     }
@@ -248,23 +248,27 @@ class MediaChromeListbox extends window.HTMLElement {
     return composedPath[index];
   }
 
-  handleSelection(e) {
+  handleSelection(e, toggle) {
     const item = this.#getItem(e);
 
     if (!item) return;
 
-    this.#selectItem(item);
+    this.#selectItem(item, toggle);
   }
 
-  #selectItem(item) {
-    const selected = item.getAttribute('aria-selected') === 'true';
-
+  #selectItem(item, toggle) {
     if (this.getAttribute('aria-multiselectable') !== 'true') {
       this.#assignedElements.forEach(el => el.setAttribute('aria-selected', 'false'));
     }
 
-    if (selected) {
-      item.setAttribute('aria-selected', 'false');
+    if (toggle) {
+      const selected = item.getAttribute('aria-selected') === 'true';
+
+      if (selected) {
+        item.setAttribute('aria-selected', 'false');
+      } else {
+        item.setAttribute('aria-selected', 'true');
+      }
     } else {
       item.setAttribute('aria-selected', 'true');
     }
@@ -326,7 +330,7 @@ class MediaChromeListbox extends window.HTMLElement {
     this.#items.forEach(el => el.setAttribute('tabindex', '-1'));
     item.setAttribute('tabindex', '0');
 
-    this.handleSelection(e);
+    this.handleSelection(e, e.metaKey || e.ctrlKey);
   }
 
   #searchItem(key) {

--- a/src/js/experimental/media-chrome-selectmenu.js
+++ b/src/js/experimental/media-chrome-selectmenu.js
@@ -209,7 +209,7 @@ class MediaChromeSelectMenu extends window.HTMLElement {
     this.#listbox.style.transform = `translateX(${position}px)`;
   }
 
-  #toggleExpanded(closeOnly) {
+  #toggleExpanded(closeOnly = false) {
     this.#expanded = !this.#expanded || closeOnly;
     this.#button.setAttribute('aria-expanded', this.#expanded);
   }

--- a/src/js/experimental/media-chrome-selectmenu.js
+++ b/src/js/experimental/media-chrome-selectmenu.js
@@ -168,7 +168,7 @@ class MediaChromeSelectMenu extends window.HTMLElement {
     if (!this.#listboxSlot.hidden) {
       this.#listbox.focus();
       this.#updateMenuPosition();
-    } else {
+    } else if (this.shadowRoot.activeElement === this.#listbox || this.#listbox.contains(this.shadowRoot.activeElement)) {
       this.#button.focus();
     }
   }

--- a/src/js/experimental/media-chrome-selectmenu.js
+++ b/src/js/experimental/media-chrome-selectmenu.js
@@ -158,12 +158,12 @@ class MediaChromeSelectMenu extends window.HTMLElement {
   }
 
   #handleChange_() {
-    this.#toggle();
+    this.#toggle(true);
   }
 
-  #toggle() {
-    this.#listboxSlot.hidden = !this.#listboxSlot.hidden;
-    this.#toggleExpanded();
+  #toggle(closeOnly) {
+    this.#listboxSlot.hidden = !this.#listboxSlot.hidden || closeOnly;
+    this.#toggleExpanded(closeOnly);
 
     if (!this.#listboxSlot.hidden) {
       this.#listbox.focus();
@@ -209,8 +209,8 @@ class MediaChromeSelectMenu extends window.HTMLElement {
     this.#listbox.style.transform = `translateX(${position}px)`;
   }
 
-  #toggleExpanded() {
-    this.#expanded = !this.#expanded;
+  #toggleExpanded(closeOnly) {
+    this.#expanded = !this.#expanded || closeOnly;
     this.#button.setAttribute('aria-expanded', this.#expanded);
   }
 

--- a/src/js/experimental/media-playback-rate-listbox.js
+++ b/src/js/experimental/media-playback-rate-listbox.js
@@ -23,7 +23,8 @@ class MediaPlaybackrateListbox extends MediaChromeListbox {
   static get observedAttributes() {
     return [
       ...super.observedAttributes,
-      'aria-multiselectable'
+      'aria-multiselectable',
+      MediaUIAttributes.MEDIA_PLAYBACK_RATE
     ];
   }
 
@@ -41,7 +42,9 @@ class MediaPlaybackrateListbox extends MediaChromeListbox {
   }
 
   attributeChangedCallback(attrName, oldValue, newValue) {
-    if (attrName === 'aria-multiselectable') {
+    if (attrName === MediaUIAttributes.MEDIA_PLAYBACK_RATE && oldValue !== newValue) {
+      this.value = newValue;
+    } else if (attrName === 'aria-multiselectable') {
       // diallow aria-multiselectable
       this.removeAttribute('aria-multiselectable');
       console.warn("Captions List doesn't currently support multiple selections. You can enable multiple items via the media.textTrack API.");

--- a/src/js/experimental/media-playback-rate-listbox.js
+++ b/src/js/experimental/media-playback-rate-listbox.js
@@ -1,0 +1,97 @@
+import MediaChromeListbox from './media-chrome-listbox.js';
+import './media-chrome-listitem.js';
+import { window, document } from '../utils/server-safe-globals.js';
+import { MediaUIAttributes, MediaUIEvents } from '../constants.js';
+
+const slotTemplate = document.createElement('template');
+slotTemplate.innerHTML = `
+  <style>
+    media-chrome-listitem {
+      white-space: var(--media-captions-listbox-white-space, nowrap);
+    }
+
+  </style>
+`;
+
+const compareTracks = (a, b) => {
+  return a.label === b.label && a.language === b.language;
+}
+
+class MediaCaptionsListbox extends MediaChromeListbox {
+  #offOption;
+
+  static get observedAttributes() {
+    return [
+      ...super.observedAttributes,
+      'aria-multiselectable'
+    ];
+  }
+
+  constructor() {
+    super({slotTemplate});
+
+    const offOption = document.createElement('media-chrome-listitem');
+
+    offOption.part.add('listitem');
+    offOption.value = 'off';
+    offOption.textContent = 'Off';
+    this.#offOption = offOption;
+
+    this.#render();
+  }
+
+  attributeChangedCallback(attrName, oldValue, newValue) {
+    if (attrName === 'aria-multiselectable') {
+      // diallow aria-multiselectable
+      this.removeAttribute('aria-multiselectable');
+      console.warn("Captions List doesn't currently support multiple selections. You can enable multiple items via the media.textTrack API.");
+    }
+
+    super.attributeChangedCallback(attrName, oldValue, newValue);
+  }
+
+  connectedCallback() {
+    this.#render();
+
+    this.addEventListener('change', this.#onChange);
+
+    super.connectedCallback();
+  }
+
+  disconnectedCallback() {
+    this.removeEventListener('change', this.#onChange);
+
+    super.disconnectedCallback();
+  }
+
+  #render() {
+    const container = this.shadowRoot.querySelector('ul slot');
+    if (!container.contains(this.#offOption)) {
+      container.append(this.#offOption);
+    }
+  }
+
+  #onChange() {
+    const selectedOption = this.selectedOptions[0]?.value;
+
+    console.log(selectedOption);
+
+    if (!selectedOption) return;
+
+    const event = new window.CustomEvent(
+      MediaUIEvents.MEDIA_PLAYBACK_RATE_REQUEST,
+      {
+        composed: true,
+        bubbles: true,
+        detail: selectedOption,
+      }
+    );
+    this.dispatchEvent(event);
+  }
+}
+
+if (!window.customElements.get('media-playback-rate-listbox')) {
+  window.customElements.define('media-playback-rate-listbox', MediaCaptionsListbox);
+}
+
+export default MediaCaptionsListbox;

--- a/src/js/experimental/media-playback-rate-listbox.js
+++ b/src/js/experimental/media-playback-rate-listbox.js
@@ -17,7 +17,7 @@ const compareTracks = (a, b) => {
   return a.label === b.label && a.language === b.language;
 }
 
-class MediaCaptionsListbox extends MediaChromeListbox {
+class MediaPlaybackrateListbox extends MediaChromeListbox {
   #offOption;
 
   static get observedAttributes() {
@@ -91,7 +91,7 @@ class MediaCaptionsListbox extends MediaChromeListbox {
 }
 
 if (!window.customElements.get('media-playback-rate-listbox')) {
-  window.customElements.define('media-playback-rate-listbox', MediaCaptionsListbox);
+  window.customElements.define('media-playback-rate-listbox', MediaPlaybackrateListbox);
 }
 
-export default MediaCaptionsListbox;
+export default MediaPlaybackrateListbox;

--- a/src/js/experimental/media-playback-rate-listbox.js
+++ b/src/js/experimental/media-playback-rate-listbox.js
@@ -1,5 +1,4 @@
 import MediaChromeListbox from './media-chrome-listbox.js';
-import './media-chrome-listitem.js';
 import { window, document } from '../utils/server-safe-globals.js';
 import { MediaUIAttributes, MediaUIEvents } from '../constants.js';
 
@@ -18,8 +17,6 @@ const compareTracks = (a, b) => {
 }
 
 class MediaPlaybackrateListbox extends MediaChromeListbox {
-  #offOption;
-
   static get observedAttributes() {
     return [
       ...super.observedAttributes,
@@ -30,15 +27,6 @@ class MediaPlaybackrateListbox extends MediaChromeListbox {
 
   constructor() {
     super({slotTemplate});
-
-    const offOption = document.createElement('media-chrome-listitem');
-
-    offOption.part.add('listitem');
-    offOption.value = 'off';
-    offOption.textContent = 'Off';
-    this.#offOption = offOption;
-
-    this.#render();
   }
 
   attributeChangedCallback(attrName, oldValue, newValue) {
@@ -54,8 +42,6 @@ class MediaPlaybackrateListbox extends MediaChromeListbox {
   }
 
   connectedCallback() {
-    this.#render();
-
     this.addEventListener('change', this.#onChange);
 
     super.connectedCallback();
@@ -67,17 +53,8 @@ class MediaPlaybackrateListbox extends MediaChromeListbox {
     super.disconnectedCallback();
   }
 
-  #render() {
-    const container = this.shadowRoot.querySelector('ul slot');
-    if (!container.contains(this.#offOption)) {
-      container.append(this.#offOption);
-    }
-  }
-
   #onChange() {
     const selectedOption = this.selectedOptions[0]?.value;
-
-    console.log(selectedOption);
 
     if (!selectedOption) return;
 

--- a/src/js/experimental/media-playback-rate-listbox.js
+++ b/src/js/experimental/media-playback-rate-listbox.js
@@ -12,10 +12,6 @@ slotTemplate.innerHTML = `
   </style>
 `;
 
-const compareTracks = (a, b) => {
-  return a.label === b.label && a.language === b.language;
-}
-
 class MediaPlaybackrateListbox extends MediaChromeListbox {
   static get observedAttributes() {
     return [

--- a/src/js/experimental/media-playback-rate-listbox.js
+++ b/src/js/experimental/media-playback-rate-listbox.js
@@ -31,7 +31,7 @@ class MediaPlaybackrateListbox extends MediaChromeListbox {
     } else if (attrName === 'aria-multiselectable') {
       // diallow aria-multiselectable
       this.removeAttribute('aria-multiselectable');
-      console.warn("Captions List doesn't currently support multiple selections. You can enable multiple items via the media.textTrack API.");
+      console.warn("Playback rate listbox doesn't support multiple selections.");
     }
 
     super.attributeChangedCallback(attrName, oldValue, newValue);

--- a/src/js/experimental/media-playback-rate-selectmenu.js
+++ b/src/js/experimental/media-playback-rate-selectmenu.js
@@ -56,7 +56,7 @@ class MediaPlaybackrateSelectMenu extends MediaChromeSelectMenu {
 
       listbox.textContent = '';
 
-      const rates = newValue.trim().split(' ');
+      const rates = newValue ? newValue.trim().split(' ') : DEFAULT_RATES;
 
       rates.forEach(rate => {
         listbox.append(createItem(rate));

--- a/src/js/experimental/media-playback-rate-selectmenu.js
+++ b/src/js/experimental/media-playback-rate-selectmenu.js
@@ -1,0 +1,74 @@
+import MediaChromeSelectMenu from './media-chrome-selectmenu.js';
+import './media-chrome-listitem.js';
+import {DEFAULT_RATE, DEFAULT_RATES } from '../media-playback-rate-button.js';
+import './media-playback-rate-listbox.js';
+import { window, document, } from '../utils/server-safe-globals.js';
+
+const createItem = (rate) => {
+  const item = document.createElement('media-chrome-listitem');
+  item.value = rate;
+  item.textContent = rate + 'x';
+
+  return item;
+}
+
+class MediaPlaybackrateSelectMenu extends MediaChromeSelectMenu {
+  static get observedAttributes() {
+    return [
+      ...super.observedAttributes,
+      'rates'
+    ];
+  }
+
+  constructor() {
+    super();
+  }
+
+  init() {
+    const playbackrateButton = document.createElement('media-playback-rate-button');
+    playbackrateButton.part.add('button');
+
+    playbackrateButton.preventClick = true;
+
+    const playbackrateListbox = document.createElement('media-playback-rate-listbox');
+    playbackrateListbox.part.add('listbox');
+    playbackrateListbox.setAttribute('exportparts', 'listitem');
+
+    DEFAULT_RATES.forEach(rate => {
+      playbackrateListbox.append(createItem(rate));
+    });
+
+    const buttonSlot = this.shadowRoot.querySelector('slot[name=button]');
+    const listboxSlot = this.shadowRoot.querySelector('slot[name=listbox]');
+
+    buttonSlot.textContent = '';
+    listboxSlot.textContent = '';
+
+    buttonSlot.append(playbackrateButton);
+    listboxSlot.append(playbackrateListbox);
+  }
+
+  attributeChangedCallback(attrName, oldValue, newValue) {
+
+    if (attrName === 'rates' && oldValue !== newValue) {
+      const listbox = this.shadowRoot.querySelector('media-playback-rate-listbox');
+
+      listbox.textContent = '';
+
+      const rates = newValue.trim().split(' ');
+
+      rates.forEach(rate => {
+        listbox.append(createItem(rate));
+
+      });
+    }
+
+    super.attributeChangedCallback(attrName, oldValue, newValue);
+  }
+}
+
+if (!window.customElements.get('media-playback-rate-selectmenu')) {
+  window.customElements.define('media-playback-rate-selectmenu', MediaPlaybackrateSelectMenu);
+}
+
+export default MediaPlaybackrateSelectMenu;

--- a/src/js/experimental/media-playback-rate-selectmenu.js
+++ b/src/js/experimental/media-playback-rate-selectmenu.js
@@ -1,6 +1,6 @@
 import MediaChromeSelectMenu from './media-chrome-selectmenu.js';
 import './media-chrome-listitem.js';
-import {DEFAULT_RATE, DEFAULT_RATES } from '../media-playback-rate-button.js';
+import { DEFAULT_RATES } from '../media-playback-rate-button.js';
 import './media-playback-rate-listbox.js';
 import { window, document, } from '../utils/server-safe-globals.js';
 

--- a/src/js/experimental/media-playback-rate-selectmenu.js
+++ b/src/js/experimental/media-playback-rate-selectmenu.js
@@ -6,6 +6,7 @@ import { window, document, } from '../utils/server-safe-globals.js';
 
 const createItem = (rate) => {
   const item = document.createElement('media-chrome-listitem');
+  item.part.add('listitem');
   item.value = rate;
   item.textContent = rate + 'x';
 

--- a/src/js/experimental/media-playback-rate-selectmenu.js
+++ b/src/js/experimental/media-playback-rate-selectmenu.js
@@ -59,7 +59,6 @@ class MediaPlaybackrateSelectMenu extends MediaChromeSelectMenu {
 
       rates.forEach(rate => {
         listbox.append(createItem(rate));
-
       });
     }
 

--- a/src/js/media-playback-rate-button.js
+++ b/src/js/media-playback-rate-button.js
@@ -7,8 +7,8 @@ import { nouns } from './labels/labels.js';
   <media-playback-rate-button rates="1 1.5 2">
 */
 
-const DEFAULT_RATES = [1, 1.25, 1.5, 1.75, 2];
-const DEFAULT_RATE = 1;
+export const DEFAULT_RATES = [1, 1.25, 1.5, 1.75, 2];
+export const DEFAULT_RATE = 1;
 
 const slotTemplate = document.createElement('template');
 slotTemplate.innerHTML = `

--- a/src/js/utils/captions.js
+++ b/src/js/utils/captions.js
@@ -250,8 +250,9 @@ export const isCCOn = (el) => {
  * This was originally in media-captions-button.
  *
  * @param {HTMLElement} el - An HTMLElement that has caption related attributes on it.
+ * @param {boolean} [forceOff] - An optional boolean that will force captions to always turn off.
  */
-export const toggleSubsCaps = (el) => {
+export const toggleSubsCaps = (el, forceOff = false) => {
   const ccIsOn = isCCOn(el);
   if (ccIsOn) {
     // Closed Captions is on. Clicking should disable any currently showing captions (and subtitles, if relevant)
@@ -278,7 +279,7 @@ export const toggleSubsCaps = (el) => {
       );
       el.dispatchEvent(evt);
     }
-  } else {
+  } else if (!forceOff) {
     // Closed Captions is off. Clicking should show the first relevant captions track or subtitles track if we're using subtitle fallback (true/"on" by default)
     const [ccTrackStr] =
       splitTextTracksStr(


### PR DESCRIPTION
This uses a playback-rate-listbox under the hood which accepts items *declaratively* only.
```html
<media-playback-rate-listbox media-controller="mc">
  <media-chrome-listitem value="1">1x</media-chrome-listitem>
  <media-chrome-listitem value="1.5">1.5x</media-chrome-listitem>
  <media-chrome-listitem value="2">2x</media-chrome-listitem>
  <media-chrome-listitem value="3">3x</media-chrome-listitem>
</media-playback-rate-listbox>
```

The selectmenu itself accepts a `rates` property like the `playback-rate-button` does. It also defaults to the same defaults.

```html
<media-playback-rate-selectmenu rates="1 2 3 4"></media-playback-rate-selectmenu>
```

This also has some updates to the main listbox class such has the `value` getter/setter, which is available on the HTMLSelectElement as a both as well.

In addition, it changes the behavior of the listitem toggling to only toggle on ctrl-click or command-click, which @luwes pointed out may be confusing in a selectmenu context. Thus, it's still available on a multi-select listbox, but essentially not available in selectmenu.