### PR TITLE
fix: toggle selectmenu via keyboard

### DIFF
--- a/src/js/experimental/media-chrome-selectmenu.js
+++ b/src/js/experimental/media-chrome-selectmenu.js
@@ -103,10 +103,10 @@ class MediaChromeSelectMenu extends window.HTMLElement {
 
     this.#listboxSlot = this.shadowRoot.querySelector('slot[name=listbox]');
     this.#listboxSlot.addEventListener('slotchange', () => {
-      this.#listbox.removeEventListener('change', this.#handleChange);
+      this.disable();
       // update listbox reference if necessary
       this.#listbox = this.#listboxSlot.assignedElements()[0] || this.#listbox;
-      this.#listbox.addEventListener('change', this.#handleChange);
+      this.enable();
     });
   }
 

--- a/src/js/experimental/media-chrome-selectmenu.js
+++ b/src/js/experimental/media-chrome-selectmenu.js
@@ -137,6 +137,7 @@ class MediaChromeSelectMenu extends window.HTMLElement {
       this.removeEventListener('keyup', this.#keyupListener);
       return;
     }
+    e.preventDefault();
     this.addEventListener('keyup', this.#keyupListener, {once: true});
   }
 

--- a/src/js/experimental/media-chrome-selectmenu.js
+++ b/src/js/experimental/media-chrome-selectmenu.js
@@ -141,6 +141,15 @@ class MediaChromeSelectMenu extends window.HTMLElement {
     this.addEventListener('keyup', this.#keyupListener, {once: true});
   }
 
+  #documentClickHandler = (e) => {
+    // if we clicked inside the selectmenu, don't handle it here
+    if (e.composedPath().includes(this)) return;
+
+    if (!this.#listboxSlot.hidden) {
+      this.#toggle();
+    }
+  }
+
   #handleClick_() {
     this.#toggle();
   }
@@ -209,6 +218,7 @@ class MediaChromeSelectMenu extends window.HTMLElement {
     this.#listbox.addEventListener('keydown', this.#keydownListener);
     this.#toggleExpanded();
     this.#listbox.addEventListener('change', this.#handleChange);
+    document.addEventListener('click', this.#documentClickHandler);
   }
 
   disable() {
@@ -219,6 +229,7 @@ class MediaChromeSelectMenu extends window.HTMLElement {
     this.#listbox.removeEventListener('keydown', this.#keydownListener);
     this.#listbox.removeEventListener('keyup', this.#keyupListener);
     this.#listbox.addEventListener('change', this.#handleChange);
+    document.removeEventListener('click', this.#documentClickHandler);
   }
 
   attributeChangedCallback(attrName, oldValue, newValue) {

--- a/src/js/media-chrome-button.js
+++ b/src/js/media-chrome-button.js
@@ -113,7 +113,9 @@ class MediaChromeButton extends window.HTMLElement {
       return;
     }
 
-    this.handleClick(e);
+    if (!this.preventClick) {
+      this.handleClick(e);
+    }
   }
 
   #keydownListener = (e) => {
@@ -133,6 +135,7 @@ class MediaChromeButton extends window.HTMLElement {
 
   disable() {
     this.removeEventListener('click', this.#clickListener);
+    this.removeEventListener('keydown', this.#keydownListener);
     this.removeEventListener('keyup', this.#keyupListener);
     this.removeAttribute('tabindex');
   }

--- a/src/js/utils/server-safe-globals.js
+++ b/src/js/utils/server-safe-globals.js
@@ -27,6 +27,8 @@ const documentShim = {
   createElement: function () {
     return new windowShim.HTMLElement();
   },
+  addEventListener() {},
+  removeEventListener() {},
 };
 
 export const isServer =
@@ -66,6 +68,8 @@ export const Window = isServer ? windowShim : window;
   * exitPictureInPicture?,
   * pictureInPictureEnabled?,
   * requestPictureInPicture?,
+  * addEventListener?,
+  * removeEventListener?,
   * } }
   */
 export const Document = isServer ? documentShim : window.document;


### PR DESCRIPTION
This makes preventClick apply to keypresses in media-chrome-button.

It also has selectmenu listen to keypress events on the button and the listbox so that it can open and close the menu as expected via Enter/Space and Escape.