### PR TITLE
fix: media-theme element lazy doc append

### DIFF
--- a/examples/experimental/themes/microvideo-theme.html
+++ b/examples/experimental/themes/microvideo-theme.html
@@ -52,7 +52,7 @@
 
       <br>
 
-      <media-theme template="microvideo.html">
+      <media-theme template="./microvideo.html">
         <video
           slot="media"
           src="https://stream.mux.com/O6LdRc0112FEJXH00bGsN9Q31yu5EIVHTgjTKRkKtEq1k/high.mp4"

--- a/examples/experimental/themes/microvideo.html
+++ b/examples/experimental/themes/microvideo.html
@@ -1,13 +1,20 @@
 <style>
   :host {
-    --_primary-color: var(--primary-color, #fff);
-    --_secondary-color: var(--secondary-color, rgb(0 0 0 / .75));
+    --_primary-color: var(--media-primary-color, rgb(255 255 255 / .9));
+    --_secondary-color: var(--media-secondary-color, rgb(0 0 0 / .75));
     --_volume-range-expand-width: 70px;
     --_volume-range-expand-height: 42px;
 
+    --media-icon-color: var(--_primary-color);
+    --media-range-thumb-background: var(--_primary-color);
+    --media-range-bar-color: var(--_primary-color);
+    --media-range-thumb-opacity: 0;
     --media-control-background: transparent;
     --media-control-hover-background: transparent;
     --media-control-padding: 5px 5px;
+    --media-preview-time-text-shadow: none;
+
+    color: var(--_primary-color);
   }
 
   [disabled],
@@ -48,6 +55,14 @@
     display: none;
   }
 
+  media-time-range,
+  media-live-button,
+  media-time-display,
+  media-text-display,
+  media-playback-rate-button[role='button'] {
+    color: inherit;
+  }
+
   media-controller::part(centered-layer) {
     display: grid;
     justify-content: unset;
@@ -61,7 +76,6 @@
 
   media-loading-indicator {
     place-self: center;
-    ${/* Stack the grid items on top of each other */''}
     grid-area: 1 / 1;
   }
 
@@ -79,9 +93,9 @@
   }
 
   .control-group {
+    background: var(--_secondary-color);
     position: relative;
     display: inline-flex;
-    background: var(--_secondary-color);
     border-radius: 5px;
   }
 
@@ -130,23 +144,21 @@
   }
 
   :host([control-bar-vertical]) .volume-range-span {
+    --_volume-range-padding-left: 0 !important;
     display: inline-flex;
     height: 0;
-    --_volume-range-padding-left: 0 !important;
   }
 
   :host([control-bar-vertical]) .volume-group:hover .volume-range-span,
   :host([control-bar-vertical]) [media-keyboard-control] .volume-group:focus-within .volume-range-span {
+    height: var(--_volume-range-expand-height);
     width: auto;
     max-width: 40px;
-    height: var(--_volume-range-expand-height);
   }
 
   media-volume-range {
-    --media-range-thumb-opacity: 0;
     --media-range-track-border-radius: 2px;
     --media-range-track-background: rgba(255, 255, 255, .2);
-    --media-range-bar-color: rgba(255, 255, 255, .9);
 
     width: var(--_volume-range-expand-width);
     display: var(--controls, var(--volume-range, inline-block));
@@ -182,9 +194,7 @@
     --media-range-track-transition: height .1s linear;
     --media-range-track-background: rgba(20, 20, 30, .25);
     --media-time-buffered-color: rgba(20, 20, 30, .3);
-    --media-range-bar-color: rgba(255, 255, 255, .9);
     --media-range-track-box-shadow: 0 -1px 0 rgba(20, 20, 30, .07);
-    --media-range-thumb-opacity: 0;
     --media-range-padding-left: 0;
     --media-range-padding-right: 0;
     --media-preview-time-background: var(--_secondary-color);
@@ -212,7 +222,6 @@
     width: 7px;
   }
 
-  ${/* Turn some buttons off by default */''}
   media-seek-backward-button {
     display: var(--media-control-display, var(--media-seek-backward-button-display, none));
   }
@@ -451,7 +460,7 @@
 
   <template if="streamType == 'live'">
 
-    <template if="targetLiveWindow == null">
+    <template if="!targetLiveWindow">
 
       <media-control-bar slot="centered-chrome">
         {{>LiveButton}}

--- a/src/js/media-theme-element.js
+++ b/src/js/media-theme-element.js
@@ -181,14 +181,8 @@ export class MediaThemeElement extends window.HTMLElement {
           this.#template = template;
           this.createRenderer();
         })
-        .catch(() => {
-          console.warn(`"${templateId}" is not a valid URL to a template file.`);
-        });
-
-      return;
+        .catch(console.error);
     }
-
-    console.warn(`"${templateId}" is not a valid template element ID or a valid URL to a template file.`);
   }
 
   createRenderer() {

--- a/src/js/themes/demuxed-2022.js
+++ b/src/js/themes/demuxed-2022.js
@@ -387,7 +387,7 @@ class MediaThemeDemuxed extends MediaThemeElement {
     resizeObserver.observe(this.shadowRoot.querySelector('media-controller'));
   }
 
-  async attributeChangedCallback(name, _oldValue, newValue) {
+  attributeChangedCallback(name, _oldValue, newValue) {
     if(name === "stream-type" && newValue === "live") {
       /** @type {HTMLMediaElement} */
       const media = this.querySelector('[slot="media"]');

--- a/test/unit/media-theme.spec.js
+++ b/test/unit/media-theme.spec.js
@@ -3,6 +3,27 @@ import '../../src/js/media-theme-element.js';
 import '../../src/js/index.js';
 
 describe('<media-theme>', () => {
+  it(`<media-theme> with template attribute works w/ delayed document append`, async () => {
+
+    const template = document.createElement('template');
+    template.id = 'not-yet';
+    template.innerHTML = /*html*/`
+      <media-controller>
+        <slot name="media" slot="media"></slot>
+        <media-control-bar>
+          <media-play-button></media-play-button>
+        </media-control-bar>
+      </media-controller>
+    `;
+
+    const theme = document.createElement('media-theme');
+    theme.setAttribute('template', 'not-yet');
+
+    document.body.append(template, theme);
+
+    assert(theme.shadowRoot.innerHTML.includes('media-play-button'), 'shadow root contains a play button');
+  });
+
   it('can change media between media themes and media controllers', async () => {
     await fixture(`
       <template id="netflix">

--- a/test/unit/media-theme.spec.js
+++ b/test/unit/media-theme.spec.js
@@ -24,6 +24,24 @@ describe('<media-theme>', () => {
     assert(theme.shadowRoot.innerHTML.includes('media-play-button'), 'shadow root contains a play button');
   });
 
+  it(`<media-theme> w/ template HTML file URL doesn't duplicate fetch/render `, async function() {
+    this.timeout(5000);
+
+    const theme = document.createElement('media-theme');
+    theme.setAttribute('template', 'https://gist.githubusercontent.com/luwes/5812c419830fee000d3463c496d18e19/raw/c295dad03a33ea8ad93870fa55de40a3308c8f45/media-theme-micro.html');
+
+    await waitUntil(() => theme.shadowRoot.querySelector('media-controller'), 5000);
+    const mediaController = theme.shadowRoot.querySelector('media-controller');
+
+    document.body.append(theme);
+
+    assert.equal(
+      mediaController,
+      theme.shadowRoot.querySelector('media-controller'),
+      'should have not re-rendered and media-controller stayed the same'
+    );
+  });
+
   it('can change media between media themes and media controllers', async () => {
     await fixture(`
       <template id="netflix">


### PR DESCRIPTION
this change fixes a bug where if the media-theme element was not added to the document yet it would throw a type error.

- adds support for rendering the template on connectedCallback if it didn't happen yet
- makes the template URL fetching a bit more strict on valid URL's so it doesn't try to request on just word URL's
  it requires a `/` somewhere in the URL. `./`, `/`, `https://`