### PR TITLE
fix: custom element manifest imports from dist/

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "author": "@muxinc",
   "license": "MIT",
   "homepage": "https://github.com/muxinc/media-chrome#readme",
-  "bugs": { "url": "https://github.com/muxinc/media-chrome/issues" },
+  "bugs": {
+    "url": "https://github.com/muxinc/media-chrome/issues"
+  },
   "type": "module",
   "main": "dist/index.js",
   "customElements": "dist/custom-elements.json",
@@ -38,7 +40,7 @@
     "url": "git+https://github.com/muxinc/media-chrome.git"
   },
   "devDependencies": {
-    "@custom-elements-manifest/analyzer": "^0.6.6",
+    "@custom-elements-manifest/analyzer": "^0.8.0",
     "@open-wc/testing": "^3.1.6",
     "@web/test-runner": "^0.15.0",
     "esbuild": "^0.15.12",

--- a/scripts/custom-elements-manifest.config.js
+++ b/scripts/custom-elements-manifest.config.js
@@ -4,7 +4,7 @@ const packageData = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
 const { name, description, version, author, homepage, license } = packageData;
 
 export default {
-  globs: ['src/js/media-*', 'src/js/extras'],
+  globs: ['dist/media-*', 'dist/extras'],
   outdir: 'dist',
   plugins: [
     // Append package data

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,10 +23,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@custom-elements-manifest/analyzer@^0.6.6":
-  version "0.6.6"
-  resolved "https://registry.yarnpkg.com/@custom-elements-manifest/analyzer/-/analyzer-0.6.6.tgz#52db8a3f6c575821d05694ff5a0295c0cb4bbb07"
-  integrity sha512-aPBZBdkrGcQPhgPPEucgw66vfOfLpS80GOGzDXE8NZuO/VmTdy3QQNAsuD4MPJmv9eRPV9W2V7ezodS5g8erng==
+"@custom-elements-manifest/analyzer@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@custom-elements-manifest/analyzer/-/analyzer-0.8.0.tgz#757bdd5fd97c8b19ddcec05d2691557df0bc10cc"
+  integrity sha512-w+OMAWW4x04eE6dpEInoVkk6ITEsQTsbx/jv7ofbl5QniXFiY5CFwWCVVAxCd3pTQbXd2Y9VxwefVJuGs/vNWw==
   dependencies:
     "@custom-elements-manifest/find-dependencies" "^0.0.5"
     "@github/catalyst" "^1.6.0"


### PR DESCRIPTION
this fixes the issue that Justin brought up that the import urls should point to the consumable custom element files which are in the dist folder.