### PR TITLE
chore: add vscode custom data / autocomplete

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,7 @@
     "dev": "(cd .. && yarn build:esm --watch=forever) & astro dev",
     "start": "astro dev",
     "check": "astro check && tsc",
-    "prebuild": "cd .. && yarn build",
+    "prebuild": "cd .. && yarn && yarn build",
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro"

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@custom-elements-manifest/analyzer": "^0.8.0",
     "@open-wc/testing": "^3.1.6",
     "@web/test-runner": "^0.15.0",
+    "cem-plugin-vs-code-custom-data-generator": "^1.4.1",
     "esbuild": "^0.15.12",
     "eslint": "^8.25.0",
     "npm-run-all": "^4.1.5",

--- a/scripts/custom-elements-manifest.config.js
+++ b/scripts/custom-elements-manifest.config.js
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { generateCustomData } from "cem-plugin-vs-code-custom-data-generator";
 
 const packageData = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
 const { name, description, version, author, homepage, license } = packageData;
@@ -21,5 +22,10 @@ export default {
         };
       },
     },
+    generateCustomData({
+      outdir: 'dist',
+      htmlFileName: 'vscode.html-data.json',
+      cssFileName: 'vscode.css-data.json',
+    })
   ],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -927,6 +927,13 @@ camelcase@^6.2.0:
   resolved "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz"
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
+cem-plugin-vs-code-custom-data-generator@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/cem-plugin-vs-code-custom-data-generator/-/cem-plugin-vs-code-custom-data-generator-1.4.1.tgz#4e2b72b835d2afc929df41e966e1e20f33549346"
+  integrity sha512-mulzg6I2wJVNKCM9ml4ttxTnGK25kHHdkhX979vbrKwSIIplFnPOgGa0Sj14pQWnfDwbGr6pSbLgBmi4nVHFxA==
+  dependencies:
+    prettier "^2.7.1"
+
 chai-a11y-axe@^1.3.2:
   version "1.3.2"
   resolved "https://registry.npmjs.org/chai-a11y-axe/-/chai-a11y-axe-1.3.2.tgz"


### PR DESCRIPTION
Related #388 

Adds a `vscode.html-data.json` file generated from the custom-elements.json.
https://github.com/microsoft/vscode-custom-data

> VS Code ships with rich [language feature support](https://code.visualstudio.com/api/language-extensions/programmatic-language-features) for HTML/CSS, such as auto-completion and hover information. The core of these language support are implemented in [vscode-html-languageservice](https://github.com/microsoft/vscode-html-languageservice) and [vscode-css-languageservice](https://github.com/microsoft/vscode-css-languageservice). In the past, these libraries were coupled to outdated schemas that define HTML/CSS entities. Custom data decouples these libraries from the data they use and allows VS Code to offer up-to-date support for latest HTML/CSS proposals or frameworks built on top of HTML/CSS.

![SCR-20230405-w74](https://user-images.githubusercontent.com/360826/230270159-9144b4fa-f860-4fe7-be89-4ef9cc97384a.png)


requires this in your `.vscode/settings.json`:

```json
{
  "html.customData": [
    "./node_modules/media-chrome/dist/vscode.html-data.json"
  ],
}
```

for Media Chrome devs, probably

```json
{
  "html.customData": [
    "./dist/vscode.html-data.json",
    "./node_modules/media-chrome/dist/vscode.html-data.json"
  ],
}
```
