### PR TITLE
fix: make DSD (declarative shadow dom) compatible

### DIFF
--- a/src/js/experimental/media-chrome-listbox.js
+++ b/src/js/experimental/media-chrome-listbox.js
@@ -55,21 +55,24 @@ class MediaChromeListbox extends window.HTMLElement {
   constructor(options = {}) {
     super();
 
-    const shadow = this.attachShadow({ mode: 'open' });
+    if (!this.shadowRoot) {
+      // Set up the Shadow DOM if not using Declarative Shadow DOM.
+      const shadow = this.attachShadow({ mode: 'open' });
 
-    const listboxHTML = template.content.cloneNode(true);
-    this.nativeEl = listboxHTML;
+      const listboxHTML = template.content.cloneNode(true);
+      this.nativeEl = listboxHTML;
 
-    let slotTemplate = options.slotTemplate;
+      let slotTemplate = options.slotTemplate;
 
-    if (!slotTemplate) {
-      slotTemplate = document.createElement('template');
-      slotTemplate.innerHTML = `<slot>${options.defaultContent || ''}</slot>`;
+      if (!slotTemplate) {
+        slotTemplate = document.createElement('template');
+        slotTemplate.innerHTML = `<slot>${options.defaultContent || ''}</slot>`;
+      }
+
+      this.nativeEl.appendChild(slotTemplate.content.cloneNode(true));
+
+      shadow.appendChild(listboxHTML);
     }
-
-    this.nativeEl.appendChild(slotTemplate.content.cloneNode(true));
-
-    shadow.appendChild(listboxHTML);
 
     this.#slot = this.shadowRoot.querySelector('slot');
 

--- a/src/js/experimental/media-chrome-listitem.js
+++ b/src/js/experimental/media-chrome-listitem.js
@@ -35,12 +35,15 @@ class MediaChromeListitem extends window.HTMLElement {
   constructor() {
     super();
 
-    const shadow = this.attachShadow({ mode: 'open' });
+    if (!this.shadowRoot) {
+      // Set up the Shadow DOM if not using Declarative Shadow DOM.
+      const shadow = this.attachShadow({ mode: 'open' });
 
-    const listitemHTML = template.content.cloneNode(true);
-    this.nativeEl = listitemHTML;
+      const listitemHTML = template.content.cloneNode(true);
+      this.nativeEl = listitemHTML;
 
-    shadow.appendChild(listitemHTML);
+      shadow.appendChild(listitemHTML);
+    }
   }
 
   set value(value) {

--- a/src/js/experimental/media-chrome-selectmenu.js
+++ b/src/js/experimental/media-chrome-selectmenu.js
@@ -54,12 +54,15 @@ class MediaChromeSelectMenu extends window.HTMLElement {
   constructor() {
     super();
 
-    const shadow = this.attachShadow({ mode: 'open' });
+    if (!this.shadowRoot) {
+      // Set up the Shadow DOM if not using Declarative Shadow DOM.
+      const shadow = this.attachShadow({ mode: 'open' });
 
-    const buttonHTML = template.content.cloneNode(true);
-    this.nativeEl = buttonHTML;
+      const buttonHTML = template.content.cloneNode(true);
+      this.nativeEl = buttonHTML;
 
-    shadow.appendChild(buttonHTML);
+      shadow.appendChild(buttonHTML);
+    }
 
     const { style } = getOrInsertCSSRule(this.shadowRoot, ':host');
     style.setProperty('display', `var(--media-control-display, var(--${this.localName}-display, inline-flex))`);

--- a/src/js/extras/media-clip-selector/index.js
+++ b/src/js/extras/media-clip-selector/index.js
@@ -150,9 +150,12 @@ class MediaClipSelector extends window.HTMLElement {
   constructor() {
     super();
 
-    this.attachShadow({ mode: 'open' });
-    // @ts-ignore
-    this.shadowRoot.appendChild(template.content.cloneNode(true));
+    if (!this.shadowRoot) {
+      // Set up the Shadow DOM if not using Declarative Shadow DOM.
+      this.attachShadow({ mode: 'open' });
+      // @ts-ignore
+      this.shadowRoot.appendChild(template.content.cloneNode(true));
+    }
 
     this.draggingEl = null;
 

--- a/src/js/media-chrome-button.js
+++ b/src/js/media-chrome-button.js
@@ -77,22 +77,25 @@ class MediaChromeButton extends window.HTMLElement {
   constructor(options = {}) {
     super();
 
-    this.attachShadow({ mode: 'open' });
+    if (!this.shadowRoot) {
+      // Set up the Shadow DOM if not using Declarative Shadow DOM.
+      this.attachShadow({ mode: 'open' });
 
-    const buttonHTML = template.content.cloneNode(true);
-    this.nativeEl = buttonHTML;
+      const buttonHTML = template.content.cloneNode(true);
+      this.nativeEl = buttonHTML;
 
-    // Slots
-    let slotTemplate = options.slotTemplate;
+      // Slots
+      let slotTemplate = options.slotTemplate;
 
-    if (!slotTemplate) {
-      slotTemplate = document.createElement('template');
-      slotTemplate.innerHTML = `<slot>${options.defaultContent || ''}</slot>`;
+      if (!slotTemplate) {
+        slotTemplate = document.createElement('template');
+        slotTemplate.innerHTML = `<slot>${options.defaultContent || ''}</slot>`;
+      }
+
+      this.nativeEl.appendChild(slotTemplate.content.cloneNode(true));
+
+      this.shadowRoot.appendChild(buttonHTML);
     }
-
-    this.nativeEl.appendChild(slotTemplate.content.cloneNode(true));
-
-    this.shadowRoot.appendChild(buttonHTML);
 
     const { style } = getOrInsertCSSRule(this.shadowRoot, ':host');
     style.setProperty('display', `var(--media-control-display, var(--${this.localName}-display, inline-flex))`);

--- a/src/js/media-chrome-range.js
+++ b/src/js/media-chrome-range.js
@@ -192,8 +192,11 @@ class MediaChromeRange extends window.HTMLElement {
   constructor() {
     super();
 
-    this.attachShadow({ mode: 'open' });
-    this.shadowRoot.appendChild(template.content.cloneNode(true));
+    if (!this.shadowRoot) {
+      // Set up the Shadow DOM if not using Declarative Shadow DOM.
+      this.attachShadow({ mode: 'open' });
+      this.shadowRoot.appendChild(template.content.cloneNode(true));
+    }
 
     const { style } = getOrInsertCSSRule(this.shadowRoot, ':host');
     style.setProperty('display', `var(--media-control-display, var(--${this.localName}-display, inline-block))`);

--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -188,9 +188,11 @@ class MediaContainer extends window.HTMLElement {
   constructor() {
     super();
 
-    // Set up the Shadow DOM
-    this.attachShadow({ mode: 'open' });
-    this.shadowRoot.appendChild(template.content.cloneNode(true));
+    if (!this.shadowRoot) {
+      // Set up the Shadow DOM if not using Declarative Shadow DOM.
+      this.attachShadow({ mode: 'open' });
+      this.shadowRoot.appendChild(template.content.cloneNode(true));
+    }
 
     // Watch for child adds/removes and update the media element if necessary
     const mutationCallback = (mutationsList) => {

--- a/src/js/media-control-bar.js
+++ b/src/js/media-control-bar.js
@@ -39,8 +39,11 @@ class MediaControlBar extends window.HTMLElement {
   constructor() {
     super();
 
-    this.attachShadow({ mode: 'open' });
-    this.shadowRoot.appendChild(template.content.cloneNode(true));
+    if (!this.shadowRoot) {
+      // Set up the Shadow DOM if not using Declarative Shadow DOM.
+      this.attachShadow({ mode: 'open' });
+      this.shadowRoot.appendChild(template.content.cloneNode(true));
+    }
   }
 
   attributeChangedCallback(attrName, oldValue, newValue) {

--- a/src/js/media-gesture-receiver.js
+++ b/src/js/media-gesture-receiver.js
@@ -30,21 +30,24 @@ class MediaGestureReceiver extends window.HTMLElement {
   constructor(options = {}) {
     super();
 
-    const shadow = this.attachShadow({ mode: 'open' });
+    if (!this.shadowRoot) {
+      // Set up the Shadow DOM if not using Declarative Shadow DOM.
+      const shadow = this.attachShadow({ mode: 'open' });
 
-    const buttonHTML = template.content.cloneNode(true);
-    this.nativeEl = buttonHTML;
+      const buttonHTML = template.content.cloneNode(true);
+      this.nativeEl = buttonHTML;
 
-    // Slots
-    let slotTemplate = options.slotTemplate;
+      // Slots
+      let slotTemplate = options.slotTemplate;
 
-    if (!slotTemplate) {
-      slotTemplate = document.createElement('template');
-      slotTemplate.innerHTML = `<slot>${options.defaultContent || ''}</slot>`;
+      if (!slotTemplate) {
+        slotTemplate = document.createElement('template');
+        slotTemplate.innerHTML = `<slot>${options.defaultContent || ''}</slot>`;
+      }
+
+      this.nativeEl.appendChild(slotTemplate.content.cloneNode(true));
+      shadow.appendChild(buttonHTML);
     }
-
-    this.nativeEl.appendChild(slotTemplate.content.cloneNode(true));
-    shadow.appendChild(buttonHTML);
   }
 
   attributeChangedCallback(attrName, oldValue, newValue) {

--- a/src/js/media-loading-indicator.js
+++ b/src/js/media-loading-indicator.js
@@ -78,9 +78,12 @@ class MediaLoadingIndicator extends window.HTMLElement {
   constructor() {
     super();
 
-    const shadow = this.attachShadow({ mode: 'open' });
-    const indicatorHTML = template.content.cloneNode(true);
-    shadow.appendChild(indicatorHTML);
+    if (!this.shadowRoot) {
+      // Set up the Shadow DOM if not using Declarative Shadow DOM.
+      const shadow = this.attachShadow({ mode: 'open' });
+      const indicatorHTML = template.content.cloneNode(true);
+      shadow.appendChild(indicatorHTML);
+    }
   }
 
   attributeChangedCallback(attrName, oldValue, newValue) {

--- a/src/js/media-poster-image.js
+++ b/src/js/media-poster-image.js
@@ -41,8 +41,11 @@ class MediaPosterImage extends window.HTMLElement {
   constructor() {
     super();
 
-    this.attachShadow({ mode: 'open' });
-    this.shadowRoot.appendChild(template.content.cloneNode(true));
+    if (!this.shadowRoot) {
+      // Set up the Shadow DOM if not using Declarative Shadow DOM.
+      this.attachShadow({ mode: 'open' });
+      this.shadowRoot.appendChild(template.content.cloneNode(true));
+    }
 
     this.image = this.shadowRoot.querySelector('#image');
   }

--- a/src/js/media-preview-thumbnail.js
+++ b/src/js/media-preview-thumbnail.js
@@ -43,8 +43,11 @@ class MediaPreviewThumbnail extends window.HTMLElement {
   constructor() {
     super();
 
-    this.attachShadow({ mode: 'open' });
-    this.shadowRoot.appendChild(template.content.cloneNode(true));
+    if (!this.shadowRoot) {
+      // Set up the Shadow DOM if not using Declarative Shadow DOM.
+      this.attachShadow({ mode: 'open' });
+      this.shadowRoot.appendChild(template.content.cloneNode(true));
+    }
   }
 
   connectedCallback() {

--- a/src/js/media-text-display.js
+++ b/src/js/media-text-display.js
@@ -55,8 +55,11 @@ class MediaTextDisplay extends window.HTMLElement {
   constructor() {
     super();
 
-    this.attachShadow({ mode: 'open' });
-    this.shadowRoot.appendChild(template.content.cloneNode(true));
+    if (!this.shadowRoot) {
+      // Set up the Shadow DOM if not using Declarative Shadow DOM.
+      this.attachShadow({ mode: 'open' });
+      this.shadowRoot.appendChild(template.content.cloneNode(true));
+    }
 
     const { style } = getOrInsertCSSRule(this.shadowRoot, ':host');
     style.setProperty('display', `var(--media-control-display, var(--${this.localName}-display, inline-flex))`);

--- a/src/js/media-theme-element.js
+++ b/src/js/media-theme-element.js
@@ -43,7 +43,14 @@ export class MediaThemeElement extends window.HTMLElement {
 
   constructor() {
     super();
-    this.renderRoot = this.attachShadow({ mode: 'open' });
+
+    if (this.shadowRoot) {
+      this.renderRoot = this.shadowRoot;
+    } else {
+      // Set up the Shadow DOM if not using Declarative Shadow DOM.
+      this.renderRoot = this.attachShadow({ mode: 'open' });
+      this.createRenderer();
+    }
 
     const observer = new MutationObserver((mutationList) => {
       if (mutationList.some((mutation) => {
@@ -75,8 +82,6 @@ export class MediaThemeElement extends window.HTMLElement {
       attributes: true,
       subtree: true,
     });
-
-    this.createRenderer();
 
     // In case the template prop was set before custom element upgrade.
     // https://web.dev/custom-elements-best-practices/#make-properties-lazy


### PR DESCRIPTION
Related #184

This makes Media Chrome DSD compatible in case anyone is putting in declarative shadow dom.
It creates shadow DOM without any JS needed. See example:

```html
<host-element>
  <template shadowrootmode="open">
    <slot></slot>
  </template>
  <h2>Light content</h2>
</host-element>
```

Supported now by Chrome and Safari 16.4! 

https://developer.chrome.com/en/articles/declarative-shadow-dom/
https://webkit.org/blog/13966/webkit-features-in-safari-16-4/#web-components