### PR TITLE
fix: font numeric uniform width

### DIFF
--- a/src/js/experimental/media-chrome-listbox.js
+++ b/src/js/experimental/media-chrome-listbox.js
@@ -14,7 +14,7 @@ template.innerHTML = `
     padding: 0.5em;
     background-color: var(--media-listbox-background, var(--media-control-background, rgba(10,10,15, .8)));
     color: var(--media-text-color, white);
-    font-family: Arial, sans-serif;
+    font-family: "Helvetica Neue", Arial, sans-serif;
   }
 
   ::slotted(media-chrome-listitem[tabindex="0"]:focus-visible),

--- a/src/js/experimental/media-chrome-listbox.js
+++ b/src/js/experimental/media-chrome-listbox.js
@@ -14,7 +14,7 @@ template.innerHTML = `
     padding: 0.5em;
     background-color: var(--media-listbox-background, var(--media-control-background, rgba(10,10,15, .8)));
     color: var(--media-text-color, white);
-    font-family: "Helvetica Neue", Arial, sans-serif;
+    font-family: helvetica neue, segoe ui, roboto, arial, sans-serif;
   }
 
   ::slotted(media-chrome-listitem[tabindex="0"]:focus-visible),

--- a/src/js/media-chrome-button.js
+++ b/src/js/media-chrome-button.js
@@ -26,7 +26,7 @@ template.innerHTML = `
 
     pointer-events: auto;
     cursor: pointer;
-    font-family: "Helvetica Neue", Arial, sans-serif;
+    font-family: helvetica neue, segoe ui, roboto, arial, sans-serif;
   }
 
   ${/*

--- a/src/js/media-chrome-button.js
+++ b/src/js/media-chrome-button.js
@@ -26,7 +26,7 @@ template.innerHTML = `
 
     pointer-events: auto;
     cursor: pointer;
-    font-family: Arial, sans-serif;
+    font-family: "Helvetica Neue", Arial, sans-serif;
   }
 
   ${/*

--- a/src/js/media-text-display.js
+++ b/src/js/media-text-display.js
@@ -19,7 +19,7 @@ template.innerHTML = `
 
       font-size: 14px;
       line-height: var(--media-text-content-height, var(--media-control-height, 24px));
-      font-family: "Helvetica Neue", Arial, sans-serif;
+      font-family: helvetica neue, segoe ui, roboto, arial, sans-serif;
       text-align: center;
       color: #ffffff;
       pointer-events: auto;

--- a/src/js/media-text-display.js
+++ b/src/js/media-text-display.js
@@ -19,7 +19,7 @@ template.innerHTML = `
 
       font-size: 14px;
       line-height: var(--media-text-content-height, var(--media-control-height, 24px));
-      font-family: Arial, sans-serif;
+      font-family: "Helvetica Neue", Arial, sans-serif;
       text-align: center;
       color: #ffffff;
       pointer-events: auto;


### PR DESCRIPTION
this glitch has been bugging us for a while and today I saw it in the Mux blog post again. had to do a quick fix attempt.

the issue is that the font Arial has not the same width for each number the number `1` for example is more narrow making the time display jump left right and making the time range or volume range also jump. that sucks!

![5LmN9w8IGD](https://user-images.githubusercontent.com/360826/230473925-0b3b77a1-633e-4933-8453-27feb01df3ec.gif)

I did a bunch of tests, `font-variant-numeric: tabular-nums;` doesn't work for Arial unfortunately.

luckily the default `Helvetica Neue` that is supported on all MacOS and iOS has even width numbers.

Also Helvetica Neue looks very similar to Arial so it seemed like an okay solution.

no more jumpy time codes!

for example check these examples and let play until -0:11

Old: https://media-chrome.mux.dev/examples/vanilla/vertical.html
New: https://media-chrome-git-fork-luwes-fix-numeric-glitch-mux.vercel.app/examples/vanilla/vertical.html

