### PR TITLE
example: improve captions experience w/ CSS snippet

### DIFF
--- a/examples/vanilla/advanced.html
+++ b/examples/vanilla/advanced.html
@@ -23,6 +23,21 @@
         display: none;
       }
 
+      video::-webkit-media-text-track-container {
+        transition: transform .25s;
+      }
+
+      media-controller:is([media-paused],:not([user-inactive])) video::-webkit-media-text-track-container {
+        transform: translateY(-50px);
+      }
+
+      video::-webkit-media-text-track-display {
+        width: auto !important;
+        left: 50% !important;
+        transform: translateX(-50%);
+        padding: .4em;
+      }
+
       .examples {
         margin-top: 20px;
       }


### PR DESCRIPTION
TEST URL: https://media-chrome-git-fork-luwes-improve-cc-example-mux.vercel.app/examples/vanilla/advanced.html

- this makes the native captions look better and make them less intrusive on Chrome. More uniform w/ Safari.
- moves the captions up when the control bar is visible for Chrome and Safari.

this seemed like a nice quick thing to do to improve the experience and covers +85% of browser usage!
this could also be a guide in the docs maybe.

![SCR-20230412-jx2](https://user-images.githubusercontent.com/360826/231564269-85c26e6e-bbe1-40fa-808d-88bdf5e53794.jpeg)