### PR TITLE
fix: add default unavailable CSS to themes

### DIFF
--- a/src/js/media-theme-element.js
+++ b/src/js/media-theme-element.js
@@ -13,7 +13,7 @@ const observedMediaAttributes = {
 
 const prependTemplate = document.createElement('template');
 
-prependTemplate.innerHTML = `
+prependTemplate.innerHTML = /*html*/`
   <style>
     :host {
       display: inline-block;
@@ -23,6 +23,16 @@ prependTemplate.innerHTML = `
     media-controller {
       width: 100%;
       height: 100%;
+    }
+
+    media-controller:not(:where([mediacaptionslist], [mediasubtitleslist])) media-captions-selectmenu,
+    media-captions-button:not(:where([mediacaptionslist], [mediasubtitleslist])),
+    media-volume-range[mediavolumeunavailable],
+    media-airplay-button[mediaairplayunavailable],
+    media-fullscreen-button[mediafullscreenunavailable],
+    media-cast-button[mediacastunavailable],
+    media-pip-button[mediapipunavailable] {
+      display: none;
     }
   </style>
 `;

--- a/src/js/themes/microvideo.js
+++ b/src/js/themes/microvideo.js
@@ -44,30 +44,6 @@ template.innerHTML = /*html*/`
     --media-control-padding: 9px 7px;
   }
 
-  media-captions-button:not(:is([mediacaptionslist], [mediasubtitleslist])) {
-    display: none;
-  }
-
-  media-volume-range[mediavolumeunavailable] {
-    display: none;
-  }
-
-  media-airplay-button[mediaairplayunavailable] {
-    display: none;
-  }
-
-  media-fullscreen-button[mediafullscreenunavailable] {
-    display: none;
-  }
-
-  media-cast-button[mediacastunavailable] {
-    display: none;
-  }
-
-  media-pip-button[mediapipunavailable] {
-    display: none;
-  }
-
   media-time-range,
   media-live-button,
   media-time-display,

--- a/src/js/themes/minimal.js
+++ b/src/js/themes/minimal.js
@@ -75,30 +75,6 @@ template.innerHTML = /*html*/`
       cursor: not-allowed;
     }
 
-    media-captions-button:not(:is([mediacaptionslist], [mediasubtitleslist])) {
-      display: none;
-    }
-
-    media-volume-range[mediavolumeunavailable] {
-      display: none;
-    }
-
-    media-airplay-button[mediaairplayunavailable] {
-      display: none;
-    }
-
-    media-fullscreen-button[mediafullscreenunavailable] {
-      display: none;
-    }
-
-    media-cast-button[mediacastunavailable] {
-      display: none;
-    }
-
-    media-pip-button[mediapipunavailable] {
-      display: none;
-    }
-
     ${/* Turn some buttons off by default */''}
     media-seek-backward-button {
       display: var(--media-control-display, var(--media-seek-backward-button-display, none));

--- a/src/js/themes/responsive.js
+++ b/src/js/themes/responsive.js
@@ -11,7 +11,7 @@ import { window, document } from '../utils/server-safe-globals.js';
 import { MediaThemeElement } from '../media-theme-element.js';
 
 const template = document.createElement('template');
-template.innerHTML = `
+template.innerHTML = /*html*/`
 <style>
 
   :host(:not([audio])) {
@@ -81,13 +81,6 @@ template.innerHTML = `
   media-loading-indicator {
     position: absolute;
     inset: 0;
-  }
-
-  media-airplay-button[mediaairplayunavailable],
-  media-fullscreen-button[mediafullscreenunavailable],
-  media-volume-range[mediavolumeunavailable],
-  media-pip-button[mediapipunavailable] {
-    display: none;
   }
 </style>
 

--- a/test/unit/media-controller.spec.js
+++ b/test/unit/media-controller.spec.js
@@ -254,7 +254,7 @@ describe('receiving state / dispatching (bubbling) events', () => {
       bubbles: true
     }));
 
-    await waitUntil(() => mediaController.getAttribute(MediaUIAttributes.MEDIA_VOLUME) == 0.73, 3000);
+    await waitUntil(() => mediaController.getAttribute(MediaUIAttributes.MEDIA_VOLUME) == 0.73, 5000);
     assert(true, 'mediavolume is 0.73');
   });
 


### PR DESCRIPTION
I had hoped we could add this CSS to media-container but it's not possible :( 

because those control elements are in the light DOM which could be nested in divs and not reachable via CSS in the shadow DOM.

still nice to have out of the box for themes I think.