### PR TITLE
feat: Add missing attr getters and setters for media-time-display

### DIFF
--- a/src/js/media-time-display.js
+++ b/src/js/media-time-display.js
@@ -234,6 +234,10 @@ class MediaTimeDisplay extends MediaTextDisplay {
   }
 
   set mediaSeekable(range) {
+    if (range === undefined) {
+      this.removeAttribute(MediaUIAttributes.MEDIA_SEEKABLE);
+      return;
+    }
     this.setAttribute(range.join(':'));
   }
 

--- a/src/js/media-time-display.js
+++ b/src/js/media-time-display.js
@@ -179,6 +179,8 @@ class MediaTimeDisplay extends MediaTextDisplay {
    * @param {boolean} show
    */
   set remaining(show) {
+    // don't set unless needed, could trigger an attr change event
+    if (show === this.remaining) return;
     this.toggleAttribute(Attributes.REMAINING, show);
   }
 
@@ -195,6 +197,8 @@ class MediaTimeDisplay extends MediaTextDisplay {
    * @param {boolean} show
    */
   set showDuration(show) {
+    // don't set unless needed, could trigger an attr change event
+    if (show === this.showDuration) return;
     this.toggleAttribute(Attributes.SHOW_DURATION, show);
   }
 

--- a/src/js/media-time-display.js
+++ b/src/js/media-time-display.js
@@ -76,6 +76,7 @@ const updateAriaValueText = (el) => {
  * @cssproperty --media-control-hover-background - `background` of control hover state.
  */
 class MediaTimeDisplay extends MediaTextDisplay {
+  /** @type {HTMLSlotElement} */
   #slot;
 
   static get observedAttributes() {

--- a/src/js/media-time-display.js
+++ b/src/js/media-time-display.js
@@ -215,15 +215,15 @@ class MediaTimeDisplay extends MediaTextDisplay {
    */
   get mediaCurrentTime() {
     const attrVal = this.getAttribute(MediaUIAttributes.MEDIA_CURRENT_TIME);
-    return attrVal != null ? +attrVal : undefined;
+    return attrVal ? +attrVal : undefined;
   }
 
   set mediaCurrentTime(time) {
-    if (time === undefined) {
+    if (time == null) {
       this.removeAttribute(MediaUIAttributes.MEDIA_CURRENT_TIME);
       return;
     }
-    this.setAttribute(MediaUIAttributes.MEDIA_CURRENT_TIME, time.toString(10));
+    this.setAttribute(MediaUIAttributes.MEDIA_CURRENT_TIME, `${+time}`);
   }
 
   /**

--- a/src/js/media-time-display.js
+++ b/src/js/media-time-display.js
@@ -163,21 +163,104 @@ class MediaTimeDisplay extends MediaTextDisplay {
     this.tabIndex = -1;
   }
 
+  // Own props
+
+  /**
+   * Whether to show the remaining time
+   * @returns {boolean}
+   */
+  get remaining() {
+    return this.hasAttribute(Attributes.REMAINING);
+  }
+
+  /**
+   * Whether to show the remaining time
+   * @param {boolean} show
+   */
+  set remaining(show) {
+    if (show && !this.hasAttribute(Attributes.REMAINING)) {
+      this.setAttribute(Attributes.REMAINING, '');
+    } else if (!show && this.hasAttribute(Attributes.REMAINING)) {
+      this.removeAttribute(Attributes.REMAINING);
+    }
+    this.update();
+  }
+
+  /**
+   * Whether to show the duration
+   * @returns {boolean}
+   */
+  get showDuration() {
+    return this.hasAttribute(Attributes.SHOW_DURATION);
+  }
+
+  /**
+   * Whether to show the duration
+   * @param {boolean} show
+   */
+  set showDuration(show) {
+    if (show && !this.hasAttribute(Attributes.SHOW_DURATION)) {
+      this.setAttribute(Attributes.SHOW_DURATION, '');
+    } else if (!show && this.hasAttribute(Attributes.SHOW_DURATION)) {
+      this.removeAttribute(Attributes.SHOW_DURATION);
+    }
+    this.update();
+  }
+
+  // Props derived from media UI attributes
+
+  /**
+   * Get the duration
+   * @returns {number | undefined}
+   */
   get mediaDuration() {
     const attrVal = this.getAttribute(MediaUIAttributes.MEDIA_DURATION);
     return attrVal != null ? +attrVal : undefined;
   }
 
+  /**
+   * Set the duration
+   * @param {number} time the new duration in seconds
+   */
+  set setMediaDuration(time) {
+    this.setAttribute(MediaUIAttributes.MEDIA_DURATION, time.toString(10));
+  }
+
+  /**
+   * The current time
+   * @returns {number | undefined} Time in seconds or undefined if not available
+   */
   get mediaCurrentTime() {
     const attrVal = this.getAttribute(MediaUIAttributes.MEDIA_CURRENT_TIME);
     return attrVal != null ? +attrVal : undefined;
   }
 
+  /**
+   * The current time
+   * @param {number} time in seconds
+   */
+  set mediaCurrentTime(time) {
+    this.setAttribute(MediaUIAttributes.MEDIA_CURRENT_TIME, time.toString(10));
+  }
+
+  /**
+   * Range of values that can be seeked to
+   * @returns {[number, number] | undefined} An array of two numbers [start, end]
+   * or undefined if not available
+   */
   get mediaSeekable() {
     const seekable = this.getAttribute(MediaUIAttributes.MEDIA_SEEKABLE);
     if (!seekable) return undefined;
     // Only currently supports a single, contiguous seekable range (CJP)
     return seekable.split(':').map((time) => +time);
+  }
+
+  /**
+   * Range of values that can be seeked to
+   * @param {[number, number]} range An array of two numbers [start, end]
+   */
+  set mediaSeekable(range) {
+    this.setAttribute(range.join(':'));
   }
 
   update() {

--- a/src/js/media-time-display.js
+++ b/src/js/media-time-display.js
@@ -1,5 +1,11 @@
 import MediaTextDisplay from './media-text-display.js';
-import { getOrInsertCSSRule } from './utils/element-utils.js';
+import {
+  getBooleanAttr,
+  getNumericAttr,
+  getOrInsertCSSRule,
+  setBooleanAttr,
+  setNumericAttr,
+} from './utils/element-utils.js';
 import { window } from './utils/server-safe-globals.js';
 import { formatAsTimePhrase, formatTime } from './utils/time.js';
 import { MediaUIAttributes } from './constants.js';
@@ -171,13 +177,11 @@ class MediaTimeDisplay extends MediaTextDisplay {
    * @type {boolean}
    */
   get remaining() {
-    return this.hasAttribute(Attributes.REMAINING);
+    return getBooleanAttr(this, Attributes.REMAINING);
   }
 
   set remaining(show) {
-    // don't set unless needed, could trigger an attr change event
-    if (show === this.remaining) return;
-    this.toggleAttribute(Attributes.REMAINING, show);
+    setBooleanAttr(this, Attributes.REMAINING, show);
   }
 
   /**
@@ -185,13 +189,11 @@ class MediaTimeDisplay extends MediaTextDisplay {
    * @type {boolean}
    */
   get showDuration() {
-    return this.hasAttribute(Attributes.SHOW_DURATION);
+    return getBooleanAttr(this, Attributes.SHOW_DURATION);
   }
 
   set showDuration(show) {
-    // don't set unless needed, could trigger an attr change event
-    if (show === this.showDuration) return;
-    this.toggleAttribute(Attributes.SHOW_DURATION, show);
+    setBooleanAttr(this, Attributes.SHOW_DURATION, show);
   }
 
   // Props derived from media UI attributes
@@ -201,16 +203,11 @@ class MediaTimeDisplay extends MediaTextDisplay {
    * @type {number | undefined} In seconds
    */
   get mediaDuration() {
-    const attrVal = this.getAttribute(MediaUIAttributes.MEDIA_DURATION);
-    return attrVal ? +attrVal : undefined;
+    return getNumericAttr(this, MediaUIAttributes.MEDIA_DURATION);
   }
 
   set mediaDuration(time) {
-    if (time == null) {
-      this.removeAttribute(MediaUIAttributes.MEDIA_DURATION);
-      return;
-    }
-    this.setAttribute(MediaUIAttributes.MEDIA_DURATION, `${+time}`);
+    setNumericAttr(this, MediaUIAttributes.MEDIA_DURATION, time);
   }
 
   /**
@@ -218,16 +215,11 @@ class MediaTimeDisplay extends MediaTextDisplay {
    * @type {number | undefined} In seconds
    */
   get mediaCurrentTime() {
-    const attrVal = this.getAttribute(MediaUIAttributes.MEDIA_CURRENT_TIME);
-    return attrVal ? +attrVal : undefined;
+    return getNumericAttr(this, MediaUIAttributes.MEDIA_CURRENT_TIME);
   }
 
   set mediaCurrentTime(time) {
-    if (time == null) {
-      this.removeAttribute(MediaUIAttributes.MEDIA_CURRENT_TIME);
-      return;
-    }
-    this.setAttribute(MediaUIAttributes.MEDIA_CURRENT_TIME, `${+time}`);
+    setNumericAttr(this, MediaUIAttributes.MEDIA_CURRENT_TIME, time);
   }
 
   /**
@@ -242,11 +234,11 @@ class MediaTimeDisplay extends MediaTextDisplay {
   }
 
   set mediaSeekable(range) {
-    if (range === undefined) {
+    if (range == null) {
       this.removeAttribute(MediaUIAttributes.MEDIA_SEEKABLE);
       return;
     }
-    this.setAttribute(range.join(':'));
+    this.setAttribute(MediaUIAttributes.MEDIA_SEEKABLE, range.join(':'));
   }
 
   update() {

--- a/src/js/media-time-display.js
+++ b/src/js/media-time-display.js
@@ -168,16 +168,12 @@ class MediaTimeDisplay extends MediaTextDisplay {
 
   /**
    * Whether to show the remaining time
-   * @returns {boolean}
+   * @type {boolean}
    */
   get remaining() {
     return this.hasAttribute(Attributes.REMAINING);
   }
 
-  /**
-   * Whether to show the remaining time
-   * @param {boolean} show
-   */
   set remaining(show) {
     // don't set unless needed, could trigger an attr change event
     if (show === this.remaining) return;
@@ -186,16 +182,12 @@ class MediaTimeDisplay extends MediaTextDisplay {
 
   /**
    * Whether to show the duration
-   * @returns {boolean}
+   * @type {boolean}
    */
   get showDuration() {
     return this.hasAttribute(Attributes.SHOW_DURATION);
   }
 
-  /**
-   * Whether to show the duration
-   * @param {boolean} show
-   */
   set showDuration(show) {
     // don't set unless needed, could trigger an attr change event
     if (show === this.showDuration) return;
@@ -206,42 +198,33 @@ class MediaTimeDisplay extends MediaTextDisplay {
 
   /**
    * Get the duration
-   * @returns {number | undefined}
+   * @type {number | undefined} In seconds
    */
   get mediaDuration() {
     const attrVal = this.getAttribute(MediaUIAttributes.MEDIA_DURATION);
     return attrVal != null ? +attrVal : undefined;
   }
 
-  /**
-   * Set the duration
-   * @param {number} time the new duration in seconds
-   */
-  set setMediaDuration(time) {
+  set mediaDuration(time) {
     this.setAttribute(MediaUIAttributes.MEDIA_DURATION, time.toString(10));
   }
 
   /**
    * The current time
-   * @returns {number | undefined} Time in seconds or undefined if not available
+   * @type {number | undefined} In seconds
    */
   get mediaCurrentTime() {
     const attrVal = this.getAttribute(MediaUIAttributes.MEDIA_CURRENT_TIME);
     return attrVal != null ? +attrVal : undefined;
   }
 
-  /**
-   * The current time
-   * @param {number} time in seconds
-   */
   set mediaCurrentTime(time) {
     this.setAttribute(MediaUIAttributes.MEDIA_CURRENT_TIME, time.toString(10));
   }
 
   /**
    * Range of values that can be seeked to
-   * @returns {[number, number] | undefined} An array of two numbers [start, end]
-   * or undefined if not available
+   * @type {[number, number] | undefined} An array of two numbers [start, end]
    */
   get mediaSeekable() {
     const seekable = this.getAttribute(MediaUIAttributes.MEDIA_SEEKABLE);
@@ -250,10 +233,6 @@ class MediaTimeDisplay extends MediaTextDisplay {
     return seekable.split(':').map((time) => +time);
   }
 
-  /**
-   * Range of values that can be seeked to
-   * @param {[number, number]} range An array of two numbers [start, end]
-   */
   set mediaSeekable(range) {
     this.setAttribute(range.join(':'));
   }

--- a/src/js/media-time-display.js
+++ b/src/js/media-time-display.js
@@ -184,7 +184,6 @@ class MediaTimeDisplay extends MediaTextDisplay {
     } else if (!show && this.hasAttribute(Attributes.REMAINING)) {
       this.removeAttribute(Attributes.REMAINING);
     }
-    this.update();
   }
 
   /**
@@ -205,7 +204,6 @@ class MediaTimeDisplay extends MediaTextDisplay {
     } else if (!show && this.hasAttribute(Attributes.SHOW_DURATION)) {
       this.removeAttribute(Attributes.SHOW_DURATION);
     }
-    this.update();
   }
 
   // Props derived from media UI attributes

--- a/src/js/media-time-display.js
+++ b/src/js/media-time-display.js
@@ -219,6 +219,10 @@ class MediaTimeDisplay extends MediaTextDisplay {
   }
 
   set mediaCurrentTime(time) {
+    if (time === undefined) {
+      this.removeAttribute(MediaUIAttributes.MEDIA_CURRENT_TIME);
+      return;
+    }
     this.setAttribute(MediaUIAttributes.MEDIA_CURRENT_TIME, time.toString(10));
   }
 

--- a/src/js/media-time-display.js
+++ b/src/js/media-time-display.js
@@ -10,9 +10,7 @@ export const Attributes = {
   SHOW_DURATION: 'showduration',
 };
 
-
 // Todo: Use data locals: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString
-//
 
 const ButtonPressedKeys = ['Enter', ' '];
 

--- a/src/js/media-time-display.js
+++ b/src/js/media-time-display.js
@@ -20,7 +20,8 @@ const formatTimesLabel = (el, { timesSep = DEFAULT_TIMES_SEP } = {}) => {
   const showRemaining = el.hasAttribute(Attributes.REMAINING);
   const showDuration = el.hasAttribute(Attributes.SHOW_DURATION);
   const currentTime = el.mediaCurrentTime ?? 0;
-  const endTime = el.mediaDuration ?? el.mediaSeekableEnd ?? 0;
+  const [, seekableEnd] = el.mediaSeekable ?? [];
+  const endTime = el.mediaDuration ?? seekableEnd ?? 0;
 
   const timeLabel = showRemaining
     ? formatTime(0 - (endTime - currentTime))
@@ -34,7 +35,8 @@ const DEFAULT_MISSING_TIME_PHRASE = 'video not loaded, unknown time.';
 
 const updateAriaValueText = (el) => {
   const currentTime = el.mediaCurrentTime;
-  const endTime = el.mediaDuration || el.mediaSeekableEnd;
+  const [, seekableEnd] = el.mediaSeekable ?? [];
+  const endTime = el.mediaDuration || seekableEnd;
   if (currentTime == null || endTime == null) {
     el.setAttribute('aria-valuetext', DEFAULT_MISSING_TIME_PHRASE);
     return;
@@ -185,16 +187,6 @@ class MediaTimeDisplay extends MediaTextDisplay {
     if (!seekable) return undefined;
     // Only currently supports a single, contiguous seekable range (CJP)
     return seekable.split(':').map((time) => +time);
-  }
-
-  get mediaSeekableEnd() {
-    const [, end] = this.mediaSeekable ?? [];
-    return end;
-  }
-
-  get mediaSeekableStart() {
-    const [start] = this.mediaSeekable ?? [];
-    return start;
   }
 
   update() {

--- a/src/js/media-time-display.js
+++ b/src/js/media-time-display.js
@@ -14,7 +14,7 @@ const CombinedAttributes = [
   ...Object.values(Attributes),
   MediaUIAttributes.MEDIA_CURRENT_TIME,
   MediaUIAttributes.MEDIA_DURATION,
-  MediaUIAttributes.MEDIA_SEEKABLE
+  MediaUIAttributes.MEDIA_SEEKABLE,
 ];
 
 // Todo: Use data locals: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString

--- a/src/js/media-time-display.js
+++ b/src/js/media-time-display.js
@@ -98,9 +98,14 @@ class MediaTimeDisplay extends MediaTextDisplay {
     const { style } = getOrInsertCSSRule(this.shadowRoot, ':host');
     style.setProperty('cursor', 'pointer');
 
-    const { style: hoverStyle } = getOrInsertCSSRule(this.shadowRoot, ':host(:hover)');
-    hoverStyle.setProperty('background', 'var(--media-control-hover-background, rgba(50 50 70 / .7))');
-
+    const { style: hoverStyle } = getOrInsertCSSRule(
+      this.shadowRoot,
+      ':host(:hover)'
+    );
+    hoverStyle.setProperty(
+      'background',
+      'var(--media-control-hover-background, rgba(50 50 70 / .7))'
+    );
   }
 
   connectedCallback() {

--- a/src/js/media-time-display.js
+++ b/src/js/media-time-display.js
@@ -179,11 +179,7 @@ class MediaTimeDisplay extends MediaTextDisplay {
    * @param {boolean} show
    */
   set remaining(show) {
-    if (show && !this.hasAttribute(Attributes.REMAINING)) {
-      this.setAttribute(Attributes.REMAINING, '');
-    } else if (!show && this.hasAttribute(Attributes.REMAINING)) {
-      this.removeAttribute(Attributes.REMAINING);
-    }
+    this.toggleAttribute(Attributes.REMAINING, show);
   }
 
   /**
@@ -199,11 +195,7 @@ class MediaTimeDisplay extends MediaTextDisplay {
    * @param {boolean} show
    */
   set showDuration(show) {
-    if (show && !this.hasAttribute(Attributes.SHOW_DURATION)) {
-      this.setAttribute(Attributes.SHOW_DURATION, '');
-    } else if (!show && this.hasAttribute(Attributes.SHOW_DURATION)) {
-      this.removeAttribute(Attributes.SHOW_DURATION);
-    }
+    this.toggleAttribute(Attributes.SHOW_DURATION, show);
   }
 
   // Props derived from media UI attributes

--- a/src/js/media-time-display.js
+++ b/src/js/media-time-display.js
@@ -10,6 +10,13 @@ export const Attributes = {
   SHOW_DURATION: 'showduration',
 };
 
+const CombinedAttributes = [
+  ...Object.values(Attributes),
+  MediaUIAttributes.MEDIA_CURRENT_TIME,
+  MediaUIAttributes.MEDIA_DURATION,
+  MediaUIAttributes.MEDIA_SEEKABLE
+];
+
 // Todo: Use data locals: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString
 
 const ButtonPressedKeys = ['Enter', ' '];
@@ -72,15 +79,7 @@ class MediaTimeDisplay extends MediaTextDisplay {
   #slot;
 
   static get observedAttributes() {
-    return [
-      ...super.observedAttributes,
-      MediaUIAttributes.MEDIA_CURRENT_TIME,
-      MediaUIAttributes.MEDIA_DURATION,
-      MediaUIAttributes.MEDIA_SEEKABLE,
-      Attributes.REMAINING,
-      Attributes.SHOW_DURATION,
-      'disabled',
-    ];
+    return [...super.observedAttributes, ...CombinedAttributes, 'disabled'];
   }
 
   constructor() {
@@ -143,15 +142,7 @@ class MediaTimeDisplay extends MediaTextDisplay {
   }
 
   attributeChangedCallback(attrName, oldValue, newValue) {
-    if (
-      [
-        Attributes.SHOW_DURATION,
-        Attributes.REMAINING,
-        MediaUIAttributes.MEDIA_CURRENT_TIME,
-        MediaUIAttributes.MEDIA_DURATION,
-        MediaUIAttributes.MEDIA_SEEKABLE,
-      ].includes(attrName)
-    ) {
+    if (CombinedAttributes.includes(attrName)) {
       this.update();
     } else if (attrName === 'disabled' && newValue !== oldValue) {
       if (newValue == null) {

--- a/src/js/media-time-display.js
+++ b/src/js/media-time-display.js
@@ -202,11 +202,15 @@ class MediaTimeDisplay extends MediaTextDisplay {
    */
   get mediaDuration() {
     const attrVal = this.getAttribute(MediaUIAttributes.MEDIA_DURATION);
-    return attrVal != null ? +attrVal : undefined;
+    return attrVal ? +attrVal : undefined;
   }
 
   set mediaDuration(time) {
-    this.setAttribute(MediaUIAttributes.MEDIA_DURATION, time.toString(10));
+    if (time == null) {
+      this.removeAttribute(MediaUIAttributes.MEDIA_DURATION);
+      return;
+    }
+    this.setAttribute(MediaUIAttributes.MEDIA_DURATION, `${+time}`);
   }
 
   /**

--- a/src/js/utils/element-utils.js
+++ b/src/js/utils/element-utils.js
@@ -74,7 +74,7 @@ export function getOrInsertCSSRule(styleParent, selectorText) {
 
 /**
  * Gets the number represented by the attribute
- * @param {HTMLElement} el
+ * @param {any} el (Should be an HTMLElement, but need any for SSR cases)
  * @param {string} attrName
  * @returns {number | undefined} Will return undefined if no attribute set
  */
@@ -84,7 +84,7 @@ export function getNumericAttr(el, attrName) {
 }
 
 /**
- * @param {HTMLElement} el
+ * @param {any} el (Should be an HTMLElement, but need any for SSR cases)
  * @param {string} attrName
  * @param {number} value
  */
@@ -103,7 +103,7 @@ export function setNumericAttr(el, attrName, value) {
 }
 
 /**
- * @param {HTMLElement} el
+ * @param {any} el (Should be an HTMLElement, but need any for SSR cases)
  * @param {string} attrName
  * @returns {boolean}
  */
@@ -113,7 +113,7 @@ export function getBooleanAttr(el, attrName) {
 
 /**
  *
- * @param {HTMLElement} el
+ * @param {any} el (Should be an HTMLElement, but need any for SSR cases)
  * @param {string} attrName
  * @param {boolean} show
  */

--- a/src/js/utils/element-utils.js
+++ b/src/js/utils/element-utils.js
@@ -98,7 +98,7 @@ export function setNumericAttr(el, attrName, value) {
     return;
   }
 
-  // force to a numberic value before setting as a string
+  // force to a numeric value before setting as a string
   el.setAttribute(attrName, `${+value}`);
 }
 

--- a/src/js/utils/element-utils.js
+++ b/src/js/utils/element-utils.js
@@ -67,3 +67,61 @@ export function getOrInsertCSSRule(styleParent, selectorText) {
   style.sheet.insertRule(`${selectorText}{}`, style.sheet.cssRules.length);
   return style.sheet.cssRules[style.sheet.cssRules.length - 1];
 }
+
+/**
+ * Gets the number represented by the attribute
+ * @param {HTMLElement} el
+ * @param {string} attrName
+ * @returns {number | undefined} Will return undefined if no attribute set
+ */
+export function getNumericAttr(el, attrName) {
+  const attrVal = el.getAttribute(attrName);
+  return attrVal != null ? +attrVal : undefined;
+}
+
+/**
+ * @param {HTMLElement} el
+ * @param {string} attrName
+ * @param {number} value
+ */
+export function setNumericAttr(el, attrName, value) {
+  // avoid setting a value that hasn't changed
+  if (getNumericAttr(el, attrName) == value) return;
+
+  // also handles undefined
+  if (value == null) {
+    el.removeAttribute(attrName);
+    return;
+  }
+
+  // force to a numberic value before setting as a string
+  el.setAttribute(attrName, `${+value}`);
+}
+
+/**
+ * @param {HTMLElement} el
+ * @param {string} attrName
+ * @returns {boolean}
+ */
+export function getBooleanAttr(el, attrName) {
+  return el.hasAttribute(attrName);
+}
+
+/**
+ *
+ * @param {HTMLElement} el
+ * @param {string} attrName
+ * @param {boolean} show
+ */
+export function setBooleanAttr(el, attrName, show) {
+  // avoid setting a value that hasn't changed
+  if (getBooleanAttr(el, attrName) == show) return;
+
+  // also handles undefined
+  if (show == null) {
+    el.removeAttribute(attrName);
+    return;
+  }
+
+  el.toggleAttribute(attrName, show);
+}

--- a/src/js/utils/element-utils.js
+++ b/src/js/utils/element-utils.js
@@ -50,7 +50,11 @@ export function getOrInsertCSSRule(styleParent, selectorText) {
     //   Uncaught DOMException: CSSStyleSheet.cssRules getter:
     //   Not allowed to access cross-origin stylesheet
     let cssRules;
-    try { cssRules = style.sheet?.cssRules; } catch { continue; }
+    try {
+      cssRules = style.sheet?.cssRules;
+    } catch {
+      continue;
+    }
     for (let rule of cssRules ?? [])
       if (rule.selectorText === selectorText) return rule;
   }
@@ -59,8 +63,8 @@ export function getOrInsertCSSRule(styleParent, selectorText) {
     return {
       style: {
         setProperty: () => {},
-        removeProperty: () => {}
-      }
+        removeProperty: () => {},
+      },
     };
   }
 

--- a/src/js/utils/element-utils.js
+++ b/src/js/utils/element-utils.js
@@ -115,17 +115,17 @@ export function getBooleanAttr(el, attrName) {
  *
  * @param {any} el (Should be an HTMLElement, but need any for SSR cases)
  * @param {string} attrName
- * @param {boolean} show
+ * @param {boolean} value
  */
-export function setBooleanAttr(el, attrName, show) {
+export function setBooleanAttr(el, attrName, value) {
   // avoid setting a value that hasn't changed
-  if (getBooleanAttr(el, attrName) == show) return;
+  if (getBooleanAttr(el, attrName) == value) return;
 
   // also handles undefined
-  if (show == null) {
+  if (value == null) {
     el.removeAttribute(attrName);
     return;
   }
 
-  el.toggleAttribute(attrName, show);
+  el.toggleAttribute(attrName, value);
 }


### PR DESCRIPTION
This is a first pass at defining getters and setters for all defined attributes. There's also JSDoc comments with the correct types.

I've used the attribute values themselves as the source of truth of the values which simplifies copying values back and forth between attributes and props.

Additionally, the public `mediaSeekableEnd` and `mediaSeekableStart` methods have been removed. These where undocumented and added to the public API of the component but where only used as utilities internally. We can add them back if we think they would be useful and document their usage.

## What should happen if you set a media UI attribute via one of the new setters?

If you set `remaining` or `showDuration` via a setter, the UI updates expectedly. If you set `mediaCurrentTime` the UI does update but the media doesn't actually seek. Clicking play for instance will reset the current time to it's previous value. Is that expected? or should an event be created and fired.