### PR TITLE
feat: add defaultshowingsubtitles to media-controller

### DIFF
--- a/docs/src/pages/en/media-captions-button.md
+++ b/docs/src/pages/en/media-captions-button.md
@@ -51,12 +51,6 @@ Button to show/disable captions
 </media-captions-button>
 ```
 
-## Attributes
-
-| Name                    | Type      | Default Value | Description                                                                                        |
-| ----------------------- | --------- | ------------- | -------------------------------------------------------------------------------------------------- |
-| `defaultshowing` | `boolean` | `false`       | Controls whether media-chrome will show a subtitle or captions tracks by default |
-
 ## Slots
 
 | Name  | Default Type | Description                                                 |

--- a/docs/src/pages/en/media-captions-selectmenu.md
+++ b/docs/src/pages/en/media-captions-selectmenu.md
@@ -94,12 +94,6 @@ Check out this example for usage, but please try and use better colors as this c
 | `listitem` | A part that targets each listitem of the listbox |
 
 
-## Attributes
-
-| Name                    | Type      | Default Value | Description                                                                                        |
-| ----------------------- | --------- | ------------- | -------------------------------------------------------------------------------------------------- |
-| `defaultshowing` | `boolean` | `false`       | Controls whether media-chrome will show a subtitle or captions tracks by default |
-
 ## Slots
 
 | Name  | Default Type | Description                                                 |

--- a/docs/src/pages/en/media-controller.md
+++ b/docs/src/pages/en/media-controller.md
@@ -59,6 +59,12 @@ as `breakpointx` attributes on media-controller and as `breakpointx`
 </media-controller>
 ```
 
+### defaultshowingsubtitles
+
+`defaultshowingsubtitles` (boolean)
+
+When enabled, this will cause captions or subtitles to be turned on by default, if available.
+
 ### defaultstreamtype
 
 `defaultstreamtype` (values: `live`, `on-demand`)

--- a/examples/vanilla/advanced.html
+++ b/examples/vanilla/advanced.html
@@ -31,7 +31,7 @@
   <body>
     <main>
       <h1>Media Chrome Advanced Video Usage Example</h1>
-      <media-controller>
+      <media-controller defaultshowingsubtitles>
         <video
           slot="media"
           src="https://stream.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/high.mp4"
@@ -66,7 +66,7 @@
           <media-volume-range></media-volume-range>
           <media-time-range></media-time-range>
           <media-time-display showduration remaining></media-time-display>
-          <media-captions-button defaultshowing></media-captions-button>
+          <media-captions-button></media-captions-button>
           <media-playback-rate-button></media-playback-rate-button>
           <media-pip-button></media-pip-button>
           <media-fullscreen-button></media-fullscreen-button>

--- a/examples/vanilla/control-elements/media-chrome-selectmenu.html
+++ b/examples/vanilla/control-elements/media-chrome-selectmenu.html
@@ -88,7 +88,7 @@
 
     <br>
 
-    <media-controller id="mc">
+    <media-controller id="mc" defaultshowingsubtitles>
       <video
         slot="media"
         src="https://d2zihajmogu5jn.cloudfront.net/elephantsdream/ed_hd.mp4"
@@ -111,7 +111,7 @@
       <media-poster-image slot="poster" src="https://d2zihajmogu5jn.cloudfront.net/elephantsdream/poster.png"></media-poster-image>
       <media-control-bar>
         <media-chrome-selectmenu aria-label="captions menu button">
-          <media-captions-button defaultshowing slot="button"></media-captions-button>
+          <media-captions-button slot="button"></media-captions-button>
           <media-captions-listbox slot="listbox"></media-captions-listbox>
         </media-chrome-selectmenu>
         <media-play-button></media-play-button>
@@ -121,14 +121,14 @@
         <media-time-display showduration remaining></media-time-display>
         <media-captions-button></media-captions-button>
         <media-chrome-selectmenu aria-label="captions menu button">
-          <media-captions-button defaultshowing slot="button"></media-captions-button>
+          <media-captions-button slot="button"></media-captions-button>
           <media-captions-listbox slot="listbox"></media-captions-listbox>
         </media-chrome-selectmenu>
         <!-- <media-playback-rate-button></media-playback-rate-button> -->
         <media-playback-rate-selectmenu></media-playback-rate-selectmenu>
         <media-pip-button></media-pip-button>
         <media-chrome-selectmenu disabled aria-label="captions menu button">
-          <media-captions-button defaultshowing slot="button"></media-captions-button>
+          <media-captions-button slot="button"></media-captions-button>
           <media-captions-listbox slot="listbox" ></media-captions-listbox>
         </media-chrome-selectmenu>
         <media-captions-selectmenu></media-captions-selectmenu>
@@ -136,7 +136,7 @@
         <media-airplay-button></media-airplay-button>
         <media-captions-selectmenu></media-captions-selectmenu>
         <media-chrome-selectmenu aria-label="captions menu button">
-          <media-captions-button defaultshowing slot="button"></media-captions-button>
+          <media-captions-button slot="button"></media-captions-button>
           <media-captions-listbox slot="listbox"></media-captions-listbox>
         </media-chrome-selectmenu>
       </media-control-bar>

--- a/src/js/experimental/media-captions-listbox.js
+++ b/src/js/experimental/media-captions-listbox.js
@@ -210,7 +210,7 @@ class MediaCaptionsListbox extends MediaChromeListbox {
     const selectedOption = this.selectedOptions[0]?.value;
 
     // turn off currently selected tracks
-    toggleSubsCaps(this, true);
+    toggleSubsCaps(this, false);
 
     if (!selectedOption) return;
 

--- a/src/js/experimental/media-captions-selectmenu.js
+++ b/src/js/experimental/media-captions-selectmenu.js
@@ -3,10 +3,6 @@ import '../media-captions-button.js';
 import './media-captions-listbox.js';
 import { window, document, } from '../utils/server-safe-globals.js';
 
-export const Attributes = {
-  DEFAULT_SHOWING: 'defaultshowing',
-};
-
 class MediaCaptionsSelectMenu extends MediaChromeSelectMenu {
   constructor() {
     super();
@@ -17,11 +13,6 @@ class MediaCaptionsSelectMenu extends MediaChromeSelectMenu {
     captionsButton.part.add('button');
 
     captionsButton.preventClick = true;
-
-    /** @TODO This should probably be an observedAttribute and updated in attributeChangedCallback() (CJP) */
-    if (this.hasAttribute(Attributes.DEFAULT_SHOWING)) {
-      captionsButton.setAttribute(Attributes.DEFAULT_SHOWING, '');
-    }
 
     const captionsListbox = document.createElement('media-captions-listbox');
     captionsListbox.part.add('listbox');

--- a/src/js/media-captions-button.js
+++ b/src/js/media-captions-button.js
@@ -4,11 +4,6 @@ import { MediaUIAttributes } from './constants.js';
 import { nouns } from './labels/labels.js';
 import { areSubsOn, toggleSubsCaps } from './utils/captions.js';
 
-export const Attributes = {
-  DEFAULT_SHOWING: 'defaultshowing',
-  NO_SUBTITLES_FALLBACK: 'nosubtitlesfallback',
-};
-
 const ccIconOn = `<svg aria-hidden="true" viewBox="0 0 26 24">
   <path d="M22.83 5.68a2.58 2.58 0 0 0-2.3-2.5c-3.62-.24-11.44-.24-15.06 0a2.58 2.58 0 0 0-2.3 2.5c-.23 4.21-.23 8.43 0 12.64a2.58 2.58 0 0 0 2.3 2.5c3.62.24 11.44.24 15.06 0a2.58 2.58 0 0 0 2.3-2.5c.23-4.21.23-8.43 0-12.64Zm-11.39 9.45a3.07 3.07 0 0 1-1.91.57 3.06 3.06 0 0 1-2.34-1 3.75 3.75 0 0 1-.92-2.67 3.92 3.92 0 0 1 .92-2.77 3.18 3.18 0 0 1 2.43-1 2.94 2.94 0 0 1 2.13.78c.364.359.62.813.74 1.31l-1.43.35a1.49 1.49 0 0 0-1.51-1.17 1.61 1.61 0 0 0-1.29.58 2.79 2.79 0 0 0-.5 1.89 3 3 0 0 0 .49 1.93 1.61 1.61 0 0 0 1.27.58 1.48 1.48 0 0 0 1-.37 2.1 2.1 0 0 0 .59-1.14l1.4.44a3.23 3.23 0 0 1-1.07 1.69Zm7.22 0a3.07 3.07 0 0 1-1.91.57 3.06 3.06 0 0 1-2.34-1 3.75 3.75 0 0 1-.92-2.67 3.88 3.88 0 0 1 .93-2.77 3.14 3.14 0 0 1 2.42-1 3 3 0 0 1 2.16.82 2.8 2.8 0 0 1 .73 1.31l-1.43.35a1.49 1.49 0 0 0-1.51-1.21 1.61 1.61 0 0 0-1.29.58A2.79 2.79 0 0 0 15 12a3 3 0 0 0 .49 1.93 1.61 1.61 0 0 0 1.27.58 1.44 1.44 0 0 0 1-.37 2.1 2.1 0 0 0 .6-1.15l1.4.44a3.17 3.17 0 0 1-1.1 1.7Z"/>
 </svg>`;
@@ -45,7 +40,6 @@ class MediaCaptionsButton extends MediaChromeButton {
   static get observedAttributes() {
     return [
       ...super.observedAttributes,
-      Attributes.DEFAULT_SHOWING,
       MediaUIAttributes.MEDIA_SUBTITLES_LIST,
       MediaUIAttributes.MEDIA_SUBTITLES_SHOWING,
     ];
@@ -70,28 +64,6 @@ class MediaCaptionsButton extends MediaChromeButton {
       updateAriaChecked(this);
     }
 
-    if (
-      this.hasAttribute(Attributes.DEFAULT_SHOWING) && // we want to show captions by default
-      this.getAttribute('aria-checked') !== 'true' && // and we aren't currently showing them
-      attrName === MediaUIAttributes.MEDIA_SUBTITLES_LIST // and we have subtitles or captions
-    ) {
-      // check if we went
-      // a) from captions (/subs) not ready to captions (/subs) ready
-      // b) from captions (/subs) ready to captions (/subs) not ready.
-      // by using a simple truthy (empty or non-empty) string check on the relevant values
-      // NOTE: We're using `getAttribute` here instead of `newValue` because we may care about
-      // multiple attributes.
-      const nextCaptionsReady = newValue
-      // If the value changed, (re)set the internal prop
-      if (this._captionsReady !== nextCaptionsReady) {
-        this._captionsReady = nextCaptionsReady;
-        // If captions are currently ready, that means we went from unready to ready, so
-        // use the click handler to dispatch a request to turn captions on
-        if (this._captionsReady) {
-          toggleSubsCaps(this);
-        }
-      }
-    }
     super.attributeChangedCallback(attrName, oldValue, newValue);
   }
 

--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -25,6 +25,7 @@ const DEFAULT_SEEK_OFFSET = 10;
 const DEFAULT_TIME = 0;
 
 export const Attributes = {
+  DEFAULT_SHOWING_SUBTITLES: 'defaultshowingsubtitles',
   DEFAULT_STREAM_TYPE: 'defaultstreamtype',
   FULLSCREEN_ELEMENT: 'fullscreenelement',
   HOTKEYS: 'hotkeys',
@@ -40,7 +41,12 @@ export const Attributes = {
  */
 class MediaController extends MediaContainer {
   static get observedAttributes() {
-    return super.observedAttributes.concat(Attributes.NO_HOTKEYS, Attributes.HOTKEYS, Attributes.DEFAULT_STREAM_TYPE);
+    return super.observedAttributes.concat(
+      Attributes.NO_HOTKEYS,
+      Attributes.HOTKEYS,
+      Attributes.DEFAULT_STREAM_TYPE,
+      Attributes.DEFAULT_SHOWING_SUBTITLES
+    );
   }
 
   #hotKeys = new AttributeTokenList(this, Attributes.HOTKEYS);
@@ -117,13 +123,23 @@ class MediaController extends MediaContainer {
           console.warn('Both `hotkeys` and `nohotkeys` have been set. All hotkeys will be disabled.');
         }
         this.disableHotkeys();
+
       } else if (newValue !== oldValue && newValue === null) {
         this.enableHotkeys();
       }
     } else if (attrName === Attributes.HOTKEYS) {
         this.#hotKeys.value = newValue;
+
+    } else if (
+      attrName === Attributes.DEFAULT_SHOWING_SUBTITLES &&
+      newValue !== oldValue &&
+      newValue === ''
+    ) {
+      toggleSubsCaps(this, true);
+
     } else if (attrName === Attributes.DEFAULT_STREAM_TYPE) {
       this.propagateMediaState(MediaUIAttributes.MEDIA_STREAM_TYPE);
+
     } else if (attrName === Attributes.FULLSCREEN_ELEMENT) {
       const el = newValue
         // @ts-ignore

--- a/src/js/themes/microvideo.js
+++ b/src/js/themes/microvideo.js
@@ -302,7 +302,6 @@ template.innerHTML = /*html*/`
 
 <template partial="CaptionsButton">
   <media-captions-button
-    default-showing="{{defaultShowingCaptions}}"
     part="captions button"
     disabled="{{disabled}}"
     aria-disabled="{{disabled}}"
@@ -416,6 +415,7 @@ template.innerHTML = /*html*/`
 </template>
 
 <media-controller
+  defaultshowingsubtitles="{{defaultShowingSubtitles}}"
   style="--_control-bar-place-self:{{controlbarplace ?? 'unset'}}"
   gestures-disabled="{{disabled}}"
   hotkeys="{{hotkeys}}"

--- a/src/js/themes/minimal.js
+++ b/src/js/themes/minimal.js
@@ -139,7 +139,6 @@ template.innerHTML = /*html*/`
 
   <template partial="CaptionsButton">
     <media-captions-button
-      default-showing="{{defaultShowingCaptions}}"
       part="captions button"
       disabled="{{disabled}}"
       aria-disabled="{{disabled}}"
@@ -323,6 +322,7 @@ template.innerHTML = /*html*/`
   </template>
 
   <media-controller
+    defaultshowingsubtitles="{{defaultShowingSubtitles}}"
     gestures-disabled="{{disabled}}"
     hotkeys="{{hotkeys}}"
     nohotkeys="{{nohotkeys}}"

--- a/src/js/utils/captions.js
+++ b/src/js/utils/captions.js
@@ -250,10 +250,12 @@ export const areSubsOn = (el) => {
  * This was originally in media-captions-button.
  *
  * @param {HTMLElement} el - An HTMLElement that has caption related attributes on it.
- * @param {boolean} [forceOff] - An optional boolean that will force captions to always turn off.
+ * @param {boolean} [force] - An optional boolean that will force captions to the given state. True for on and false for off
  */
-export const toggleSubsCaps = (el, forceOff = false) => {
-  if (areSubsOn(el)) {
+export const toggleSubsCaps = (el, force) => {
+  const subsOn = areSubsOn(el);
+
+  if (subsOn || force === false) {
     // Subtitles are on. Clicking should disable any currently showing captions (and subtitles, if relevant)
     // For why we are requesting tracks to `mode="disabled"` and not `mode="hidden"`, see: https://github.com/muxinc/media-chrome/issues/60
     const subtitlesShowingStr = el.getAttribute(
@@ -267,7 +269,7 @@ export const toggleSubsCaps = (el, forceOff = false) => {
       );
       el.dispatchEvent(evt);
     }
-  } else if (!forceOff) {
+  } else if (!subsOn || force === true) {
     // Subtitles are off. Clicking should show the first relevant captions track or subtitles track (true/"on" by default)
     const [subTrackStr] =
       splitTextTracksStr(


### PR DESCRIPTION
This removes defaultshowing for the captions button and selectmenu to centralize it on the media-controller.

BREAKING CHANGE: remove defaultshowing attribute from media-captions-button and media-captions-selectmenu.