### PR TITLE
docs: redirect [lang]/ to the [lang]/get-started

### DIFF
--- a/docs/src/pages/[lang]/index.astro
+++ b/docs/src/pages/[lang]/index.astro
@@ -1,0 +1,12 @@
+---
+import { KNOWN_LANGUAGE_CODES } from '../../config';
+export function getStaticPaths() {
+  return KNOWN_LANGUAGE_CODES.map(lang => ({params: { lang }}));
+}
+
+const { lang } = Astro.params;
+// get-started is the "default" page right now via convention
+const htmlString = `<meta http-equiv="refresh" content="0; URL=/${lang}/get-started" />`;
+---
+<Fragment set:html={htmlString} />
+


### PR DESCRIPTION
For example, visiting https://media-chrome-docs-git-fork-gkatsev-redirect-lang-to-0b369f-mux.vercel.app/en redirects to https://media-chrome-docs-git-fork-gkatsev-redirect-lang-to-0b369f-mux.vercel.app/en/get-started

Uses meta direct because we don't currently have SSR enabled.