### PR TITLE
feat: Airplay, Captions, and Cast button props

### DIFF
--- a/src/js/media-airplay-button.js
+++ b/src/js/media-airplay-button.js
@@ -53,7 +53,7 @@ class MediaAirplayButton extends MediaChromeButton {
     // avoid triggering a set if no change
     if (this.mediaAirplayUnavailable === value) return;
 
-    if (value === undefined) {
+    if (value == null) {
       this.removeAttribute(MediaUIAttributes.MEDIA_AIRPLAY_UNAVAILABLE);
       return;
     }

--- a/src/js/media-airplay-button.js
+++ b/src/js/media-airplay-button.js
@@ -58,7 +58,7 @@ class MediaAirplayButton extends MediaChromeButton {
       return;
     }
 
-    this.setAttribute(MediaUIAttributes.MEDIA_AIRPLAY_UNAVAILABLE, value);
+    this.setAttribute(MediaUIAttributes.MEDIA_AIRPLAY_UNAVAILABLE, `${value}`);
   }
 
   handleClick() {

--- a/src/js/media-airplay-button.js
+++ b/src/js/media-airplay-button.js
@@ -2,6 +2,7 @@ import MediaChromeButton from './media-chrome-button.js';
 import { window, document } from './utils/server-safe-globals.js';
 import { MediaUIEvents, MediaUIAttributes } from './constants.js';
 import { verbs } from './labels/labels.js';
+import { getStringAttr, setStringAttr } from './utils/element-utils';
 
 const airplayIcon = `<svg aria-hidden="true" viewBox="0 0 26 24">
   <path d="M22.13 3H3.87a.87.87 0 0 0-.87.87v13.26a.87.87 0 0 0 .87.87h3.4L9 16H5V5h16v11h-4l1.72 2h3.4a.87.87 0 0 0 .87-.87V3.87a.87.87 0 0 0-.86-.87Zm-8.75 11.44a.5.5 0 0 0-.76 0l-4.91 5.73a.5.5 0 0 0 .38.83h9.82a.501.501 0 0 0 .38-.83l-4.91-5.73Z"/>
@@ -43,22 +44,11 @@ class MediaAirplayButton extends MediaChromeButton {
    * @type {string | undefined} Airplay unavailability state
    */
   get mediaAirplayUnavailable() {
-    return (
-      this.getAttribute(MediaUIAttributes.MEDIA_AIRPLAY_UNAVAILABLE) ??
-      undefined
-    );
+    return getStringAttr(this, MediaUIAttributes.MEDIA_AIRPLAY_UNAVAILABLE);
   }
 
   set mediaAirplayUnavailable(value) {
-    // avoid triggering a set if no change
-    if (this.mediaAirplayUnavailable === value) return;
-
-    if (value == null) {
-      this.removeAttribute(MediaUIAttributes.MEDIA_AIRPLAY_UNAVAILABLE);
-      return;
-    }
-
-    this.setAttribute(MediaUIAttributes.MEDIA_AIRPLAY_UNAVAILABLE, `${value}`);
+    setStringAttr(this, MediaUIAttributes.MEDIA_AIRPLAY_UNAVAILABLE, value);
   }
 
   handleClick() {

--- a/src/js/media-airplay-button.js
+++ b/src/js/media-airplay-button.js
@@ -39,6 +39,28 @@ class MediaAirplayButton extends MediaChromeButton {
     super.connectedCallback();
   }
 
+  /**
+   * @type {string | undefined} Airplay unavailability state
+   */
+  get mediaAirplayUnavailable() {
+    return (
+      this.getAttribute(MediaUIAttributes.MEDIA_AIRPLAY_UNAVAILABLE) ??
+      undefined
+    );
+  }
+
+  set mediaAirplayUnavailable(value) {
+    // avoid triggering a set if no change
+    if (this.mediaAirplayUnavailable === value) return;
+
+    if (value === undefined) {
+      this.removeAttribute(MediaUIAttributes.MEDIA_AIRPLAY_UNAVAILABLE);
+      return;
+    }
+
+    this.setAttribute(MediaUIAttributes.MEDIA_AIRPLAY_UNAVAILABLE, value);
+  }
+
   handleClick() {
     const evt = new window.CustomEvent(MediaUIEvents.MEDIA_AIRPLAY_REQUEST, {
       composed: true,

--- a/src/js/media-airplay-button.js
+++ b/src/js/media-airplay-button.js
@@ -2,7 +2,7 @@ import MediaChromeButton from './media-chrome-button.js';
 import { window, document } from './utils/server-safe-globals.js';
 import { MediaUIEvents, MediaUIAttributes } from './constants.js';
 import { verbs } from './labels/labels.js';
-import { getStringAttr, setStringAttr } from './utils/element-utils';
+import { getStringAttr, setStringAttr } from './utils/element-utils.js';
 
 const airplayIcon = `<svg aria-hidden="true" viewBox="0 0 26 24">
   <path d="M22.13 3H3.87a.87.87 0 0 0-.87.87v13.26a.87.87 0 0 0 .87.87h3.4L9 16H5V5h16v11h-4l1.72 2h3.4a.87.87 0 0 0 .87-.87V3.87a.87.87 0 0 0-.86-.87Zm-8.75 11.44a.5.5 0 0 0-.76 0l-4.91 5.73a.5.5 0 0 0 .38.83h9.82a.501.501 0 0 0 .38-.83l-4.91-5.73Z"/>

--- a/src/js/media-captions-button.js
+++ b/src/js/media-captions-button.js
@@ -44,7 +44,7 @@ const updateAriaChecked = (el) => {
  * @slot off - An element that will be shown while closed captions or subtitles are off.
  *
  * @attr {string} mediasubtitleslist - (read-only) A list of all subtitles and captions.
- * @attr {boolean} mediasubtitlesshowing - (read-only) A list of the showing subtitles and captions.
+ * @attr {string} mediasubtitlesshowing - (read-only) A list of the showing subtitles and captions.
  *
  * @cssproperty [--media-captions-button-display = inline-flex] - `display` property of button.
  */

--- a/src/js/media-captions-button.js
+++ b/src/js/media-captions-button.js
@@ -4,7 +4,8 @@ import { MediaUIAttributes } from './constants.js';
 import { nouns } from './labels/labels.js';
 import {
   areSubsOn,
-  splitTextTracksStr,
+  parseTextTracksStr,
+  stringifyTextTrackList,
   toggleSubsCaps,
 } from './utils/captions.js';
 
@@ -42,22 +43,18 @@ const updateAriaChecked = (el) => {
 /**
  * @param {any} el Should be HTMLElement but issues with window shim
  * @param {string} attrName
- * @returns {Array<string>}
+ * @returns {Array<Object>} An array of TextTrack-like objects.
  */
 const getSubtitlesListAttr = (el, attrName) => {
   const attrVal = el.getAttribute(attrName);
-
-  // an empty attribute can return an array with an empty string as an item
-  // e.g. splitTextTracksStr('') will return [""]
-  // so we explicitly return an empty array for falsy values
-  return attrVal ? splitTextTracksStr(attrVal) : [];
+  return attrVal ? parseTextTracksStr(attrVal) : [];
 };
 
 /**
  *
  * @param {any} el Should be HTMLElement but issues with window shim
  * @param {string} attrName
- * @param {Array<string>} list
+ * @param {Array<Object>} list An array of TextTrack-like objects
  */
 const setSubtitlesListAttr = (el, attrName, list) => {
   // null, undefined, and empty arrays are treated as "no value" here
@@ -66,14 +63,12 @@ const setSubtitlesListAttr = (el, attrName, list) => {
     return;
   }
 
-  const newVal = list.join(' ');
-
   // don't set if the new value is the same as existing
-  const oldList = getSubtitlesListAttr(el, attrName);
-  const oldVal = oldList.join(' ');
-  if (oldVal === newVal) return;
+  const newValStr = stringifyTextTrackList(list);
+  const oldValStr = stringifyTextTrackList(el.getAttribute(attrName) ?? '');
+  if (oldValStr === newValStr) return;
 
-  el.setAttribute(attrName, newVal);
+  el.setAttribute(attrName, newValStr);
 };
 
 /**
@@ -117,8 +112,8 @@ class MediaCaptionsButton extends MediaChromeButton {
   }
 
   /**
-   * @type {Array<string>} An array of string serialised text tracks
-   * e.g. ["cc:en:English"]
+   * @type {Array<object>} An array of TextTrack-like objects.
+   * Objects must have the properties: kind, language, and label.
    */
   get mediaSubtitlesList() {
     return getSubtitlesListAttr(this, MediaUIAttributes.MEDIA_SUBTITLES_LIST);
@@ -129,8 +124,8 @@ class MediaCaptionsButton extends MediaChromeButton {
   }
 
   /**
-   * @type {Array<string>} An array of string serialised text tracks
-   * * e.g. ["cc:en:English"]
+   * @type {Array<object>} An array of TextTrack-like objects.
+   * Objects must have the properties: kind, language, and label.
    */
   get mediaSubtitlesShowing() {
     return getSubtitlesListAttr(

--- a/src/js/media-captions-button.js
+++ b/src/js/media-captions-button.js
@@ -40,6 +40,43 @@ const updateAriaChecked = (el) => {
 };
 
 /**
+ * @param {any} el Should be HTMLElement but issues with window shim
+ * @param {string} attrName
+ * @returns {Array<string>}
+ */
+const getCaptionListAttr = (el, attrName) => {
+  const attrVal = el.getAttribute(attrName);
+
+  // an empty attribute can return an array with an empty string as an item
+  // e.g. splitTextTracksStr('') will return [""]
+  // so we explicitly return an empty array for falsy values
+  return attrVal ? splitTextTracksStr(attrVal) : [];
+};
+
+/**
+ *
+ * @param {any} el Should be HTMLElement but issues with window shim
+ * @param {string} attrName
+ * @param {Array<string>} list
+ */
+const setCaptionListAttr = (el, attrName, list) => {
+  // null, undefined, and empty arrays are treated as "no value" here
+  if (!list) {
+    el.removeAttribute(attrName);
+    return;
+  }
+
+  const newVal = list.join(' ');
+
+  // don't set if the new value is the same as existing
+  const oldList = getCaptionListAttr(el, attrName);
+  const oldVal = oldList.join(' ');
+  if (oldVal === newVal) return;
+
+  el.setAttribute(attrName, newVal);
+};
+
+/**
  * @slot on - An element that will be shown while closed captions or subtitles are on.
  * @slot off - An element that will be shown while closed captions or subtitles are off.
  *
@@ -83,45 +120,22 @@ class MediaCaptionsButton extends MediaChromeButton {
    * @type {Array<string>} An array of string serialised text tracks
    */
   get mediaSubtitlesList() {
-    const attrVal = this.getAttribute(MediaUIAttributes.MEDIA_SUBTITLES_LIST);
-    // an empty string can return an array with an empty string as an item
-    // e.g. splitTextTracksStr('') will return [""]
-    // so we explicitly return an empty array for falsy values
-    return attrVal ? splitTextTracksStr(attrVal) : [];
+    return getCaptionListAttr(this, MediaUIAttributes.MEDIA_SUBTITLES_LIST);
   }
 
   set mediaSubtitlesList(list) {
-    if (list == null) {
-      this.removeAttribute(MediaUIAttributes.MEDIA_SUBTITLES_LIST);
-      return;
-    }
-    const newVal = list.join(' ');
-    // avoid triggering a set if no change
-    if (newVal === this.getAttribute(MediaUIAttributes.MEDIA_SUBTITLES_LIST)) {
-      return;
-    }
-    this.setAttribute(MediaUIAttributes.MEDIA_SUBTITLES_LIST, newVal);
+    setCaptionListAttr(this, MediaUIAttributes.MEDIA_SUBTITLES_LIST, list);
   }
 
   /**
-   * @type {string | undefined} A text track represented as a string
+   * @type {Array<string>} An array of string serialised text tracks
    */
   get mediaSubtitlesShowing() {
-    return (
-      this.getAttribute(MediaUIAttributes.MEDIA_SUBTITLES_SHOWING) ?? undefined
-    );
+    return getCaptionListAttr(this, MediaUIAttributes.MEDIA_SUBTITLES_SHOWING);
   }
 
-  set mediaSubtitlesShowing(value) {
-    // avoid triggering a set if no change
-    if (value === this.mediaSubtitlesShowing) return;
-
-    if (value == null) {
-      this.removeAttribute(MediaUIAttributes.MEDIA_SUBTITLES_SHOWING);
-      return;
-    }
-
-    this.setAttribute(MediaUIAttributes.MEDIA_SUBTITLES_SHOWING, `${value}`);
+  set mediaSubtitlesShowing(list) {
+    setCaptionListAttr(this, MediaUIAttributes.MEDIA_SUBTITLES_SHOWING, list);
   }
 
   handleClick() {

--- a/src/js/media-captions-button.js
+++ b/src/js/media-captions-button.js
@@ -44,7 +44,7 @@ const updateAriaChecked = (el) => {
  * @param {string} attrName
  * @returns {Array<string>}
  */
-const getCaptionListAttr = (el, attrName) => {
+const getSubtitlesListAttr = (el, attrName) => {
   const attrVal = el.getAttribute(attrName);
 
   // an empty attribute can return an array with an empty string as an item
@@ -59,7 +59,7 @@ const getCaptionListAttr = (el, attrName) => {
  * @param {string} attrName
  * @param {Array<string>} list
  */
-const setCaptionListAttr = (el, attrName, list) => {
+const setSubtitlesListAttr = (el, attrName, list) => {
   // null, undefined, and empty arrays are treated as "no value" here
   if (!list) {
     el.removeAttribute(attrName);
@@ -69,7 +69,7 @@ const setCaptionListAttr = (el, attrName, list) => {
   const newVal = list.join(' ');
 
   // don't set if the new value is the same as existing
-  const oldList = getCaptionListAttr(el, attrName);
+  const oldList = getSubtitlesListAttr(el, attrName);
   const oldVal = oldList.join(' ');
   if (oldVal === newVal) return;
 
@@ -121,11 +121,11 @@ class MediaCaptionsButton extends MediaChromeButton {
    * e.g. ["cc:en:English"]
    */
   get mediaSubtitlesList() {
-    return getCaptionListAttr(this, MediaUIAttributes.MEDIA_SUBTITLES_LIST);
+    return getSubtitlesListAttr(this, MediaUIAttributes.MEDIA_SUBTITLES_LIST);
   }
 
   set mediaSubtitlesList(list) {
-    setCaptionListAttr(this, MediaUIAttributes.MEDIA_SUBTITLES_LIST, list);
+    setSubtitlesListAttr(this, MediaUIAttributes.MEDIA_SUBTITLES_LIST, list);
   }
 
   /**
@@ -133,11 +133,14 @@ class MediaCaptionsButton extends MediaChromeButton {
    * * e.g. ["cc:en:English"]
    */
   get mediaSubtitlesShowing() {
-    return getCaptionListAttr(this, MediaUIAttributes.MEDIA_SUBTITLES_SHOWING);
+    return getSubtitlesListAttr(
+      this,
+      MediaUIAttributes.MEDIA_SUBTITLES_SHOWING
+    );
   }
 
   set mediaSubtitlesShowing(list) {
-    setCaptionListAttr(this, MediaUIAttributes.MEDIA_SUBTITLES_SHOWING, list);
+    setSubtitlesListAttr(this, MediaUIAttributes.MEDIA_SUBTITLES_SHOWING, list);
   }
 
   handleClick() {

--- a/src/js/media-captions-button.js
+++ b/src/js/media-captions-button.js
@@ -118,6 +118,7 @@ class MediaCaptionsButton extends MediaChromeButton {
 
   /**
    * @type {Array<string>} An array of string serialised text tracks
+   * e.g. ["cc:en:English"]
    */
   get mediaSubtitlesList() {
     return getCaptionListAttr(this, MediaUIAttributes.MEDIA_SUBTITLES_LIST);
@@ -129,6 +130,7 @@ class MediaCaptionsButton extends MediaChromeButton {
 
   /**
    * @type {Array<string>} An array of string serialised text tracks
+   * * e.g. ["cc:en:English"]
    */
   get mediaSubtitlesShowing() {
     return getCaptionListAttr(this, MediaUIAttributes.MEDIA_SUBTITLES_SHOWING);

--- a/src/js/media-captions-button.js
+++ b/src/js/media-captions-button.js
@@ -121,7 +121,7 @@ class MediaCaptionsButton extends MediaChromeButton {
       return;
     }
 
-    this.setAttribute(MediaUIAttributes.MEDIA_SUBTITLES_SHOWING, value);
+    this.setAttribute(MediaUIAttributes.MEDIA_SUBTITLES_SHOWING, `${value}`);
   }
 
   handleClick() {

--- a/src/js/media-captions-button.js
+++ b/src/js/media-captions-button.js
@@ -84,10 +84,17 @@ class MediaCaptionsButton extends MediaChromeButton {
    */
   get mediaSubtitlesList() {
     const attrVal = this.getAttribute(MediaUIAttributes.MEDIA_SUBTITLES_LIST);
+    // an empty string can return an array with an empty string as an item
+    // e.g. splitTextTracksStr('') will return [""]
+    // so we explicitly return an empty array for falsy values
     return attrVal ? splitTextTracksStr(attrVal) : [];
   }
 
   set mediaSubtitlesList(list) {
+    if (list == null) {
+      this.removeAttribute(MediaUIAttributes.MEDIA_SUBTITLES_LIST);
+      return;
+    }
     const newVal = list.join(' ');
     // avoid triggering a set if no change
     if (newVal === this.getAttribute(MediaUIAttributes.MEDIA_SUBTITLES_LIST)) {
@@ -108,10 +115,12 @@ class MediaCaptionsButton extends MediaChromeButton {
   set mediaSubtitlesShowing(value) {
     // avoid triggering a set if no change
     if (value === this.mediaSubtitlesShowing) return;
-    if (value === undefined) {
+
+    if (value == null) {
       this.removeAttribute(MediaUIAttributes.MEDIA_SUBTITLES_SHOWING);
       return;
     }
+
     this.setAttribute(MediaUIAttributes.MEDIA_SUBTITLES_SHOWING, value);
   }
 

--- a/src/js/media-cast-button.js
+++ b/src/js/media-cast-button.js
@@ -69,6 +69,38 @@ class MediaCastButton extends MediaChromeButton {
     super.attributeChangedCallback(attrName, oldValue, newValue);
   }
 
+  /**
+   * @type {boolean} Are we currently casting
+   */
+  get mediaIsCasting() {
+    return this.hasAttribute(MediaUIAttributes.MEDIA_IS_CASTING);
+  }
+
+  set mediaIsCasting(value) {
+    this.toggleAttribute(MediaUIAttributes.MEDIA_IS_CASTING, !!value);
+  }
+
+  /**
+   * @type {string | undefined} Cast unavailability state
+   */
+  get mediaCastUnavailable() {
+    return (
+      this.getAttribute(MediaUIAttributes.MEDIA_CAST_UNAVAILABLE) ?? undefined
+    );
+  }
+
+  set mediaCastUnavailable(value) {
+    // avoid triggering a set if no change
+    if (this.mediaCastUnavailable === value) return;
+
+    if (value == null) {
+      this.removeAttribute(MediaUIAttributes.MEDIA_CAST_UNAVAILABLE);
+      return;
+    }
+
+    this.setAttribute(MediaUIAttributes.MEDIA_CAST_UNAVAILABLE, `${value}`);
+  }
+
   handleClick() {
     const eventName =
       this.getAttribute(MediaUIAttributes.MEDIA_IS_CASTING) != null

--- a/src/js/media-cast-button.js
+++ b/src/js/media-cast-button.js
@@ -2,13 +2,15 @@ import MediaChromeButton from './media-chrome-button.js';
 import { window, document } from './utils/server-safe-globals.js';
 import { MediaUIEvents, MediaUIAttributes } from './constants.js';
 import { verbs } from './labels/labels.js';
+import { getBooleanAttr, setBooleanAttr } from './utils/element-utils';
+import { getStringAttr, setStringAttr } from './utils/element-utils.js';
 
 const enterIcon = `<svg aria-hidden="true" viewBox="0 0 24 24"><g><path class="cast_caf_icon_arch0" d="M1,18 L1,21 L4,21 C4,19.3 2.66,18 1,18 L1,18 Z"/><path class="cast_caf_icon_arch1" d="M1,14 L1,16 C3.76,16 6,18.2 6,21 L8,21 C8,17.13 4.87,14 1,14 L1,14 Z"/><path class="cast_caf_icon_arch2" d="M1,10 L1,12 C5.97,12 10,16.0 10,21 L12,21 C12,14.92 7.07,10 1,10 L1,10 Z"/><path class="cast_caf_icon_box" d="M21,3 L3,3 C1.9,3 1,3.9 1,5 L1,8 L3,8 L3,5 L21,5 L21,19 L14,19 L14,21 L21,21 C22.1,21 23,20.1 23,19 L23,5 C23,3.9 22.1,3 21,3 L21,3 Z"/></g></svg>`;
 
 const exitIcon = `<svg aria-hidden="true" viewBox="0 0 24 24"><g><path class="cast_caf_icon_arch0" d="M1,18 L1,21 L4,21 C4,19.3 2.66,18 1,18 L1,18 Z"/><path class="cast_caf_icon_arch1" d="M1,14 L1,16 C3.76,16 6,18.2 6,21 L8,21 C8,17.13 4.87,14 1,14 L1,14 Z"/><path class="cast_caf_icon_arch2" d="M1,10 L1,12 C5.97,12 10,16.0 10,21 L12,21 C12,14.92 7.07,10 1,10 L1,10 Z"/><path class="cast_caf_icon_box" d="M21,3 L3,3 C1.9,3 1,3.9 1,5 L1,8 L3,8 L3,5 L21,5 L21,19 L14,19 L14,21 L21,21 C22.1,21 23,20.1 23,19 L23,5 C23,3.9 22.1,3 21,3 L21,3 Z"/><path class="cast_caf_icon_boxfill" d="M5,7 L5,8.63 C8,8.6 13.37,14 13.37,17 L19,17 L19,7 Z"/></g></svg>`;
 
 const slotTemplate = document.createElement('template');
-slotTemplate.innerHTML = /*html*/`
+slotTemplate.innerHTML = /*html*/ `
   <style>
   :host([${MediaUIAttributes.MEDIA_IS_CASTING}]) slot:not([name=exit]) > *,
   :host([${MediaUIAttributes.MEDIA_IS_CASTING}]) ::slotted(:not([slot=exit])) {
@@ -16,8 +18,12 @@ slotTemplate.innerHTML = /*html*/`
   }
 
   ${/* Double negative, but safer if display doesn't equal 'block' */ ''}
-  :host(:not([${MediaUIAttributes.MEDIA_IS_CASTING}])) slot:not([name=enter]) > *,
-  :host(:not([${MediaUIAttributes.MEDIA_IS_CASTING}])) ::slotted(:not([slot=enter])) {
+  :host(:not([${
+    MediaUIAttributes.MEDIA_IS_CASTING
+  }])) slot:not([name=enter]) > *,
+  :host(:not([${
+    MediaUIAttributes.MEDIA_IS_CASTING
+  }])) ::slotted(:not([slot=enter])) {
     display: none !important;
   }
   </style>
@@ -27,11 +33,8 @@ slotTemplate.innerHTML = /*html*/`
 `;
 
 const updateAriaLabel = (el) => {
-  const isCast =
-    el.getAttribute(MediaUIAttributes.MEDIA_IS_CASTING) != null;
-  const label = isCast
-    ? verbs.EXIT_CAST()
-    : verbs.ENTER_CAST();
+  const isCast = el.getAttribute(MediaUIAttributes.MEDIA_IS_CASTING) != null;
+  const label = isCast ? verbs.EXIT_CAST() : verbs.ENTER_CAST();
   el.setAttribute('aria-label', label);
 };
 
@@ -73,32 +76,22 @@ class MediaCastButton extends MediaChromeButton {
    * @type {boolean} Are we currently casting
    */
   get mediaIsCasting() {
-    return this.hasAttribute(MediaUIAttributes.MEDIA_IS_CASTING);
+    return getBooleanAttr(this, MediaUIAttributes.MEDIA_IS_CASTING);
   }
 
   set mediaIsCasting(value) {
-    this.toggleAttribute(MediaUIAttributes.MEDIA_IS_CASTING, !!value);
+    setBooleanAttr(this, MediaUIAttributes.MEDIA_IS_CASTING, value);
   }
 
   /**
    * @type {string | undefined} Cast unavailability state
    */
   get mediaCastUnavailable() {
-    return (
-      this.getAttribute(MediaUIAttributes.MEDIA_CAST_UNAVAILABLE) ?? undefined
-    );
+    return getStringAttr(this, MediaUIAttributes.MEDIA_CAST_UNAVAILABLE);
   }
 
   set mediaCastUnavailable(value) {
-    // avoid triggering a set if no change
-    if (this.mediaCastUnavailable === value) return;
-
-    if (value == null) {
-      this.removeAttribute(MediaUIAttributes.MEDIA_CAST_UNAVAILABLE);
-      return;
-    }
-
-    this.setAttribute(MediaUIAttributes.MEDIA_CAST_UNAVAILABLE, `${value}`);
+    setStringAttr(this, MediaUIAttributes.MEDIA_CAST_UNAVAILABLE, value);
   }
 
   handleClick() {

--- a/src/js/media-cast-button.js
+++ b/src/js/media-cast-button.js
@@ -2,8 +2,12 @@ import MediaChromeButton from './media-chrome-button.js';
 import { window, document } from './utils/server-safe-globals.js';
 import { MediaUIEvents, MediaUIAttributes } from './constants.js';
 import { verbs } from './labels/labels.js';
-import { getBooleanAttr, setBooleanAttr } from './utils/element-utils';
-import { getStringAttr, setStringAttr } from './utils/element-utils.js';
+import {
+  getBooleanAttr,
+  setBooleanAttr,
+  getStringAttr,
+  setStringAttr,
+} from './utils/element-utils.js';
 
 const enterIcon = `<svg aria-hidden="true" viewBox="0 0 24 24"><g><path class="cast_caf_icon_arch0" d="M1,18 L1,21 L4,21 C4,19.3 2.66,18 1,18 L1,18 Z"/><path class="cast_caf_icon_arch1" d="M1,14 L1,16 C3.76,16 6,18.2 6,21 L8,21 C8,17.13 4.87,14 1,14 L1,14 Z"/><path class="cast_caf_icon_arch2" d="M1,10 L1,12 C5.97,12 10,16.0 10,21 L12,21 C12,14.92 7.07,10 1,10 L1,10 Z"/><path class="cast_caf_icon_box" d="M21,3 L3,3 C1.9,3 1,3.9 1,5 L1,8 L3,8 L3,5 L21,5 L21,19 L14,19 L14,21 L21,21 C22.1,21 23,20.1 23,19 L23,5 C23,3.9 22.1,3 21,3 L21,3 Z"/></g></svg>`;
 

--- a/src/js/media-cast-button.js
+++ b/src/js/media-cast-button.js
@@ -100,7 +100,7 @@ class MediaCastButton extends MediaChromeButton {
 
   handleClick() {
     const eventName =
-      this.getAttribute(MediaUIAttributes.MEDIA_IS_CASTING) != null
+      this.mediaIsCasting != null
         ? MediaUIEvents.MEDIA_EXIT_CAST_REQUEST
         : MediaUIEvents.MEDIA_ENTER_CAST_REQUEST;
     this.dispatchEvent(

--- a/src/js/media-time-display.js
+++ b/src/js/media-time-display.js
@@ -234,6 +234,10 @@ class MediaTimeDisplay extends MediaTextDisplay {
   }
 
   set mediaSeekable(range) {
+    if (range === undefined) {
+      this.removeAttribute(MediaUIAttributes.MEDIA_SEEKABLE);
+      return;
+    }
     this.setAttribute(range.join(':'));
   }
 

--- a/src/js/media-time-display.js
+++ b/src/js/media-time-display.js
@@ -179,6 +179,8 @@ class MediaTimeDisplay extends MediaTextDisplay {
    * @param {boolean} show
    */
   set remaining(show) {
+    // don't set unless needed, could trigger an attr change event
+    if (show === this.remaining) return;
     this.toggleAttribute(Attributes.REMAINING, show);
   }
 
@@ -195,6 +197,8 @@ class MediaTimeDisplay extends MediaTextDisplay {
    * @param {boolean} show
    */
   set showDuration(show) {
+    // don't set unless needed, could trigger an attr change event
+    if (show === this.showDuration) return;
     this.toggleAttribute(Attributes.SHOW_DURATION, show);
   }
 

--- a/src/js/media-time-display.js
+++ b/src/js/media-time-display.js
@@ -76,6 +76,7 @@ const updateAriaValueText = (el) => {
  * @cssproperty --media-control-hover-background - `background` of control hover state.
  */
 class MediaTimeDisplay extends MediaTextDisplay {
+  /** @type {HTMLSlotElement} */
   #slot;
 
   static get observedAttributes() {

--- a/src/js/media-time-display.js
+++ b/src/js/media-time-display.js
@@ -215,15 +215,15 @@ class MediaTimeDisplay extends MediaTextDisplay {
    */
   get mediaCurrentTime() {
     const attrVal = this.getAttribute(MediaUIAttributes.MEDIA_CURRENT_TIME);
-    return attrVal != null ? +attrVal : undefined;
+    return attrVal ? +attrVal : undefined;
   }
 
   set mediaCurrentTime(time) {
-    if (time === undefined) {
+    if (time == null) {
       this.removeAttribute(MediaUIAttributes.MEDIA_CURRENT_TIME);
       return;
     }
-    this.setAttribute(MediaUIAttributes.MEDIA_CURRENT_TIME, time.toString(10));
+    this.setAttribute(MediaUIAttributes.MEDIA_CURRENT_TIME, `${+time}`);
   }
 
   /**

--- a/src/js/media-time-display.js
+++ b/src/js/media-time-display.js
@@ -163,21 +163,104 @@ class MediaTimeDisplay extends MediaTextDisplay {
     this.tabIndex = -1;
   }
 
+  // Own props
+
+  /**
+   * Whether to show the remaining time
+   * @returns {boolean}
+   */
+  get remaining() {
+    return this.hasAttribute(Attributes.REMAINING);
+  }
+
+  /**
+   * Whether to show the remaining time
+   * @param {boolean} show
+   */
+  set remaining(show) {
+    if (show && !this.hasAttribute(Attributes.REMAINING)) {
+      this.setAttribute(Attributes.REMAINING, '');
+    } else if (!show && this.hasAttribute(Attributes.REMAINING)) {
+      this.removeAttribute(Attributes.REMAINING);
+    }
+    this.update();
+  }
+
+  /**
+   * Whether to show the duration
+   * @returns {boolean}
+   */
+  get showDuration() {
+    return this.hasAttribute(Attributes.SHOW_DURATION);
+  }
+
+  /**
+   * Whether to show the duration
+   * @param {boolean} show
+   */
+  set showDuration(show) {
+    if (show && !this.hasAttribute(Attributes.SHOW_DURATION)) {
+      this.setAttribute(Attributes.SHOW_DURATION, '');
+    } else if (!show && this.hasAttribute(Attributes.SHOW_DURATION)) {
+      this.removeAttribute(Attributes.SHOW_DURATION);
+    }
+    this.update();
+  }
+
+  // Props derived from media UI attributes
+
+  /**
+   * Get the duration
+   * @returns {number | undefined}
+   */
   get mediaDuration() {
     const attrVal = this.getAttribute(MediaUIAttributes.MEDIA_DURATION);
     return attrVal != null ? +attrVal : undefined;
   }
 
+  /**
+   * Set the duration
+   * @param {number} time the new duration in seconds
+   */
+  set setMediaDuration(time) {
+    this.setAttribute(MediaUIAttributes.MEDIA_DURATION, time.toString(10));
+  }
+
+  /**
+   * The current time
+   * @returns {number | undefined} Time in seconds or undefined if not available
+   */
   get mediaCurrentTime() {
     const attrVal = this.getAttribute(MediaUIAttributes.MEDIA_CURRENT_TIME);
     return attrVal != null ? +attrVal : undefined;
   }
 
+  /**
+   * The current time
+   * @param {number} time in seconds
+   */
+  set mediaCurrentTime(time) {
+    this.setAttribute(MediaUIAttributes.MEDIA_CURRENT_TIME, time.toString(10));
+  }
+
+  /**
+   * Range of values that can be seeked to
+   * @returns {[number, number] | undefined} An array of two numbers [start, end]
+   * or undefined if not available
+   */
   get mediaSeekable() {
     const seekable = this.getAttribute(MediaUIAttributes.MEDIA_SEEKABLE);
     if (!seekable) return undefined;
     // Only currently supports a single, contiguous seekable range (CJP)
     return seekable.split(':').map((time) => +time);
+  }
+
+  /**
+   * Range of values that can be seeked to
+   * @param {[number, number]} range An array of two numbers [start, end]
+   */
+  set mediaSeekable(range) {
+    this.setAttribute(range.join(':'));
   }
 
   update() {

--- a/src/js/media-time-display.js
+++ b/src/js/media-time-display.js
@@ -1,5 +1,11 @@
 import MediaTextDisplay from './media-text-display.js';
-import { getOrInsertCSSRule } from './utils/element-utils.js';
+import {
+  getBooleanAttr,
+  getNumericAttr,
+  getOrInsertCSSRule,
+  setBooleanAttr,
+  setNumericAttr,
+} from './utils/element-utils.js';
 import { window } from './utils/server-safe-globals.js';
 import { formatAsTimePhrase, formatTime } from './utils/time.js';
 import { MediaUIAttributes } from './constants.js';
@@ -171,13 +177,11 @@ class MediaTimeDisplay extends MediaTextDisplay {
    * @type {boolean}
    */
   get remaining() {
-    return this.hasAttribute(Attributes.REMAINING);
+    return getBooleanAttr(this, Attributes.REMAINING);
   }
 
   set remaining(show) {
-    // don't set unless needed, could trigger an attr change event
-    if (show === this.remaining) return;
-    this.toggleAttribute(Attributes.REMAINING, show);
+    setBooleanAttr(this, Attributes.REMAINING, show);
   }
 
   /**
@@ -185,13 +189,11 @@ class MediaTimeDisplay extends MediaTextDisplay {
    * @type {boolean}
    */
   get showDuration() {
-    return this.hasAttribute(Attributes.SHOW_DURATION);
+    return getBooleanAttr(this, Attributes.SHOW_DURATION);
   }
 
   set showDuration(show) {
-    // don't set unless needed, could trigger an attr change event
-    if (show === this.showDuration) return;
-    this.toggleAttribute(Attributes.SHOW_DURATION, show);
+    setBooleanAttr(this, Attributes.SHOW_DURATION, show);
   }
 
   // Props derived from media UI attributes
@@ -201,16 +203,11 @@ class MediaTimeDisplay extends MediaTextDisplay {
    * @type {number | undefined} In seconds
    */
   get mediaDuration() {
-    const attrVal = this.getAttribute(MediaUIAttributes.MEDIA_DURATION);
-    return attrVal ? +attrVal : undefined;
+    return getNumericAttr(this, MediaUIAttributes.MEDIA_DURATION);
   }
 
   set mediaDuration(time) {
-    if (time == null) {
-      this.removeAttribute(MediaUIAttributes.MEDIA_DURATION);
-      return;
-    }
-    this.setAttribute(MediaUIAttributes.MEDIA_DURATION, `${+time}`);
+    setNumericAttr(this, MediaUIAttributes.MEDIA_DURATION, time);
   }
 
   /**
@@ -218,16 +215,11 @@ class MediaTimeDisplay extends MediaTextDisplay {
    * @type {number | undefined} In seconds
    */
   get mediaCurrentTime() {
-    const attrVal = this.getAttribute(MediaUIAttributes.MEDIA_CURRENT_TIME);
-    return attrVal ? +attrVal : undefined;
+    return getNumericAttr(this, MediaUIAttributes.MEDIA_CURRENT_TIME);
   }
 
   set mediaCurrentTime(time) {
-    if (time == null) {
-      this.removeAttribute(MediaUIAttributes.MEDIA_CURRENT_TIME);
-      return;
-    }
-    this.setAttribute(MediaUIAttributes.MEDIA_CURRENT_TIME, `${+time}`);
+    setNumericAttr(this, MediaUIAttributes.MEDIA_CURRENT_TIME, time);
   }
 
   /**
@@ -242,11 +234,11 @@ class MediaTimeDisplay extends MediaTextDisplay {
   }
 
   set mediaSeekable(range) {
-    if (range === undefined) {
+    if (range == null) {
       this.removeAttribute(MediaUIAttributes.MEDIA_SEEKABLE);
       return;
     }
-    this.setAttribute(range.join(':'));
+    this.setAttribute(MediaUIAttributes.MEDIA_SEEKABLE, range.join(':'));
   }
 
   update() {

--- a/src/js/media-time-display.js
+++ b/src/js/media-time-display.js
@@ -168,16 +168,12 @@ class MediaTimeDisplay extends MediaTextDisplay {
 
   /**
    * Whether to show the remaining time
-   * @returns {boolean}
+   * @type {boolean}
    */
   get remaining() {
     return this.hasAttribute(Attributes.REMAINING);
   }
 
-  /**
-   * Whether to show the remaining time
-   * @param {boolean} show
-   */
   set remaining(show) {
     // don't set unless needed, could trigger an attr change event
     if (show === this.remaining) return;
@@ -186,16 +182,12 @@ class MediaTimeDisplay extends MediaTextDisplay {
 
   /**
    * Whether to show the duration
-   * @returns {boolean}
+   * @type {boolean}
    */
   get showDuration() {
     return this.hasAttribute(Attributes.SHOW_DURATION);
   }
 
-  /**
-   * Whether to show the duration
-   * @param {boolean} show
-   */
   set showDuration(show) {
     // don't set unless needed, could trigger an attr change event
     if (show === this.showDuration) return;
@@ -206,42 +198,33 @@ class MediaTimeDisplay extends MediaTextDisplay {
 
   /**
    * Get the duration
-   * @returns {number | undefined}
+   * @type {number | undefined} In seconds
    */
   get mediaDuration() {
     const attrVal = this.getAttribute(MediaUIAttributes.MEDIA_DURATION);
     return attrVal != null ? +attrVal : undefined;
   }
 
-  /**
-   * Set the duration
-   * @param {number} time the new duration in seconds
-   */
-  set setMediaDuration(time) {
+  set mediaDuration(time) {
     this.setAttribute(MediaUIAttributes.MEDIA_DURATION, time.toString(10));
   }
 
   /**
    * The current time
-   * @returns {number | undefined} Time in seconds or undefined if not available
+   * @type {number | undefined} In seconds
    */
   get mediaCurrentTime() {
     const attrVal = this.getAttribute(MediaUIAttributes.MEDIA_CURRENT_TIME);
     return attrVal != null ? +attrVal : undefined;
   }
 
-  /**
-   * The current time
-   * @param {number} time in seconds
-   */
   set mediaCurrentTime(time) {
     this.setAttribute(MediaUIAttributes.MEDIA_CURRENT_TIME, time.toString(10));
   }
 
   /**
    * Range of values that can be seeked to
-   * @returns {[number, number] | undefined} An array of two numbers [start, end]
-   * or undefined if not available
+   * @type {[number, number] | undefined} An array of two numbers [start, end]
    */
   get mediaSeekable() {
     const seekable = this.getAttribute(MediaUIAttributes.MEDIA_SEEKABLE);
@@ -250,10 +233,6 @@ class MediaTimeDisplay extends MediaTextDisplay {
     return seekable.split(':').map((time) => +time);
   }
 
-  /**
-   * Range of values that can be seeked to
-   * @param {[number, number]} range An array of two numbers [start, end]
-   */
   set mediaSeekable(range) {
     this.setAttribute(range.join(':'));
   }

--- a/src/js/media-time-display.js
+++ b/src/js/media-time-display.js
@@ -184,7 +184,6 @@ class MediaTimeDisplay extends MediaTextDisplay {
     } else if (!show && this.hasAttribute(Attributes.REMAINING)) {
       this.removeAttribute(Attributes.REMAINING);
     }
-    this.update();
   }
 
   /**
@@ -205,7 +204,6 @@ class MediaTimeDisplay extends MediaTextDisplay {
     } else if (!show && this.hasAttribute(Attributes.SHOW_DURATION)) {
       this.removeAttribute(Attributes.SHOW_DURATION);
     }
-    this.update();
   }
 
   // Props derived from media UI attributes

--- a/src/js/media-time-display.js
+++ b/src/js/media-time-display.js
@@ -219,6 +219,10 @@ class MediaTimeDisplay extends MediaTextDisplay {
   }
 
   set mediaCurrentTime(time) {
+    if (time === undefined) {
+      this.removeAttribute(MediaUIAttributes.MEDIA_CURRENT_TIME);
+      return;
+    }
     this.setAttribute(MediaUIAttributes.MEDIA_CURRENT_TIME, time.toString(10));
   }
 

--- a/src/js/media-time-display.js
+++ b/src/js/media-time-display.js
@@ -20,7 +20,8 @@ const formatTimesLabel = (el, { timesSep = DEFAULT_TIMES_SEP } = {}) => {
   const showRemaining = el.hasAttribute(Attributes.REMAINING);
   const showDuration = el.hasAttribute(Attributes.SHOW_DURATION);
   const currentTime = el.mediaCurrentTime ?? 0;
-  const endTime = el.mediaDuration ?? el.mediaSeekableEnd ?? 0;
+  const [, seekableEnd] = el.mediaSeekable ?? [];
+  const endTime = el.mediaDuration ?? seekableEnd ?? 0;
 
   const timeLabel = showRemaining
     ? formatTime(0 - (endTime - currentTime))
@@ -34,7 +35,8 @@ const DEFAULT_MISSING_TIME_PHRASE = 'video not loaded, unknown time.';
 
 const updateAriaValueText = (el) => {
   const currentTime = el.mediaCurrentTime;
-  const endTime = el.mediaDuration || el.mediaSeekableEnd;
+  const [, seekableEnd] = el.mediaSeekable ?? [];
+  const endTime = el.mediaDuration || seekableEnd;
   if (currentTime == null || endTime == null) {
     el.setAttribute('aria-valuetext', DEFAULT_MISSING_TIME_PHRASE);
     return;
@@ -185,16 +187,6 @@ class MediaTimeDisplay extends MediaTextDisplay {
     if (!seekable) return undefined;
     // Only currently supports a single, contiguous seekable range (CJP)
     return seekable.split(':').map((time) => +time);
-  }
-
-  get mediaSeekableEnd() {
-    const [, end] = this.mediaSeekable ?? [];
-    return end;
-  }
-
-  get mediaSeekableStart() {
-    const [start] = this.mediaSeekable ?? [];
-    return start;
   }
 
   update() {

--- a/src/js/media-time-display.js
+++ b/src/js/media-time-display.js
@@ -14,7 +14,7 @@ const CombinedAttributes = [
   ...Object.values(Attributes),
   MediaUIAttributes.MEDIA_CURRENT_TIME,
   MediaUIAttributes.MEDIA_DURATION,
-  MediaUIAttributes.MEDIA_SEEKABLE
+  MediaUIAttributes.MEDIA_SEEKABLE,
 ];
 
 // Todo: Use data locals: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString

--- a/src/js/media-time-display.js
+++ b/src/js/media-time-display.js
@@ -98,9 +98,14 @@ class MediaTimeDisplay extends MediaTextDisplay {
     const { style } = getOrInsertCSSRule(this.shadowRoot, ':host');
     style.setProperty('cursor', 'pointer');
 
-    const { style: hoverStyle } = getOrInsertCSSRule(this.shadowRoot, ':host(:hover)');
-    hoverStyle.setProperty('background', 'var(--media-control-hover-background, rgba(50 50 70 / .7))');
-
+    const { style: hoverStyle } = getOrInsertCSSRule(
+      this.shadowRoot,
+      ':host(:hover)'
+    );
+    hoverStyle.setProperty(
+      'background',
+      'var(--media-control-hover-background, rgba(50 50 70 / .7))'
+    );
   }
 
   connectedCallback() {

--- a/src/js/media-time-display.js
+++ b/src/js/media-time-display.js
@@ -179,11 +179,7 @@ class MediaTimeDisplay extends MediaTextDisplay {
    * @param {boolean} show
    */
   set remaining(show) {
-    if (show && !this.hasAttribute(Attributes.REMAINING)) {
-      this.setAttribute(Attributes.REMAINING, '');
-    } else if (!show && this.hasAttribute(Attributes.REMAINING)) {
-      this.removeAttribute(Attributes.REMAINING);
-    }
+    this.toggleAttribute(Attributes.REMAINING, show);
   }
 
   /**
@@ -199,11 +195,7 @@ class MediaTimeDisplay extends MediaTextDisplay {
    * @param {boolean} show
    */
   set showDuration(show) {
-    if (show && !this.hasAttribute(Attributes.SHOW_DURATION)) {
-      this.setAttribute(Attributes.SHOW_DURATION, '');
-    } else if (!show && this.hasAttribute(Attributes.SHOW_DURATION)) {
-      this.removeAttribute(Attributes.SHOW_DURATION);
-    }
+    this.toggleAttribute(Attributes.SHOW_DURATION, show);
   }
 
   // Props derived from media UI attributes

--- a/src/js/media-time-display.js
+++ b/src/js/media-time-display.js
@@ -10,6 +10,13 @@ export const Attributes = {
   SHOW_DURATION: 'showduration',
 };
 
+const CombinedAttributes = [
+  ...Object.values(Attributes),
+  MediaUIAttributes.MEDIA_CURRENT_TIME,
+  MediaUIAttributes.MEDIA_DURATION,
+  MediaUIAttributes.MEDIA_SEEKABLE
+];
+
 // Todo: Use data locals: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString
 
 const ButtonPressedKeys = ['Enter', ' '];
@@ -72,15 +79,7 @@ class MediaTimeDisplay extends MediaTextDisplay {
   #slot;
 
   static get observedAttributes() {
-    return [
-      ...super.observedAttributes,
-      MediaUIAttributes.MEDIA_CURRENT_TIME,
-      MediaUIAttributes.MEDIA_DURATION,
-      MediaUIAttributes.MEDIA_SEEKABLE,
-      Attributes.REMAINING,
-      Attributes.SHOW_DURATION,
-      'disabled',
-    ];
+    return [...super.observedAttributes, ...CombinedAttributes, 'disabled'];
   }
 
   constructor() {
@@ -143,15 +142,7 @@ class MediaTimeDisplay extends MediaTextDisplay {
   }
 
   attributeChangedCallback(attrName, oldValue, newValue) {
-    if (
-      [
-        Attributes.SHOW_DURATION,
-        Attributes.REMAINING,
-        MediaUIAttributes.MEDIA_CURRENT_TIME,
-        MediaUIAttributes.MEDIA_DURATION,
-        MediaUIAttributes.MEDIA_SEEKABLE,
-      ].includes(attrName)
-    ) {
+    if (CombinedAttributes.includes(attrName)) {
       this.update();
     } else if (attrName === 'disabled' && newValue !== oldValue) {
       if (newValue == null) {

--- a/src/js/media-time-display.js
+++ b/src/js/media-time-display.js
@@ -202,11 +202,15 @@ class MediaTimeDisplay extends MediaTextDisplay {
    */
   get mediaDuration() {
     const attrVal = this.getAttribute(MediaUIAttributes.MEDIA_DURATION);
-    return attrVal != null ? +attrVal : undefined;
+    return attrVal ? +attrVal : undefined;
   }
 
   set mediaDuration(time) {
-    this.setAttribute(MediaUIAttributes.MEDIA_DURATION, time.toString(10));
+    if (time == null) {
+      this.removeAttribute(MediaUIAttributes.MEDIA_DURATION);
+      return;
+    }
+    this.setAttribute(MediaUIAttributes.MEDIA_DURATION, `${+time}`);
   }
 
   /**

--- a/src/js/utils/element-utils.js
+++ b/src/js/utils/element-utils.js
@@ -112,7 +112,6 @@ export function getBooleanAttr(el, attrName) {
 }
 
 /**
- *
  * @param {any} el (Should be an HTMLElement, but need any for SSR cases)
  * @param {string} attrName
  * @param {boolean} value
@@ -128,4 +127,30 @@ export function setBooleanAttr(el, attrName, value) {
   }
 
   el.toggleAttribute(attrName, value);
+}
+
+/**
+ * @param {any} el (Should be an HTMLElement, but need any for SSR cases)
+ * @param {string} attrName
+ */
+export function getStringAttr(el, attrName) {
+  return el.getAttribute(attrName) ?? undefined;
+}
+
+/**
+ * @param {*} el (Should be an HTMLElement, but need any for SSR cases)
+ * @param {string} attrName
+ * @param {string} value
+ */
+export function setStringAttr(el, attrName, value) {
+  // avoid triggering a set if no change
+  if (getStringAttr(el, attrName) == value) return;
+
+  // also handles undefined
+  if (value == null) {
+    el.removeAttribute(attrName);
+    return;
+  }
+
+  el.setAttribute(attrName, `${value}`);
 }


### PR DESCRIPTION
Adds missing props for the Airplay, Captions, and Cast buttons.

With captions specifically, we have to decide on the prop type for getting and setting a subtitles list. This is currently a simple array of strings. This matches how we store and retrieve the data from the attribute and also makes interacting with the prop similar to how a dev would interact with the attribute directly.

The alternative is to accept `TextTrack`'s (or objects that are a subset with only the data we need). Is this preferable? I can see this being simpler for the developer assuming they have `TextTrack`'s at hand.