### PR TITLE
feat: Pip button, Play button, and Playback Rates props

### DIFF
--- a/src/js/media-pip-button.js
+++ b/src/js/media-pip-button.js
@@ -2,6 +2,12 @@ import MediaChromeButton from './media-chrome-button.js';
 import { window, document } from './utils/server-safe-globals.js';
 import { MediaUIEvents, MediaUIAttributes } from './constants.js';
 import { verbs } from './labels/labels.js';
+import {
+  getBooleanAttr,
+  getStringAttr,
+  setBooleanAttr,
+  setStringAttr,
+} from './utils/element-utils';
 
 const pipIcon = `<svg aria-hidden="true" viewBox="0 0 28 24">
   <path d="M24 3H4a1 1 0 0 0-1 1v16a1 1 0 0 0 1 1h20a1 1 0 0 0 1-1V4a1 1 0 0 0-1-1Zm-1 16H5V5h18v14Zm-3-8h-7v5h7v-5Z"/>
@@ -29,8 +35,7 @@ slotTemplate.innerHTML = /*html*/ `
 `;
 
 const updateAriaLabel = (el) => {
-  const isPip = el.getAttribute(MediaUIAttributes.MEDIA_IS_PIP) != null;
-  const label = isPip ? verbs.EXIT_PIP() : verbs.ENTER_PIP();
+  const label = el.mediaIsPip ? verbs.EXIT_PIP() : verbs.ENTER_PIP();
   el.setAttribute('aria-label', label);
 };
 
@@ -68,11 +73,32 @@ class MediaPipButton extends MediaChromeButton {
     super.attributeChangedCallback(attrName, oldValue, newValue);
   }
 
+  /**
+   * @type {string | undefined} Pip unavailability state
+   */
+  get mediaPipUnavailable() {
+    return getStringAttr(this, MediaUIAttributes.MEDIA_PIP_UNAVAILABLE);
+  }
+
+  set mediaPipUnavailable(value) {
+    setStringAttr(this, MediaUIAttributes.MEDIA_PIP_UNAVAILABLE, value);
+  }
+
+  /**
+   * @type {boolean} Is the media currently playing picture-in-picture
+   */
+  get mediaIsPip() {
+    return getBooleanAttr(this, MediaUIAttributes.MEDIA_IS_PIP);
+  }
+
+  set mediaIsPip(value) {
+    setBooleanAttr(this, MediaUIAttributes.MEDIA_IS_PIP, value);
+  }
+
   handleClick() {
-    const eventName =
-      this.getAttribute(MediaUIAttributes.MEDIA_IS_PIP) != null
-        ? MediaUIEvents.MEDIA_EXIT_PIP_REQUEST
-        : MediaUIEvents.MEDIA_ENTER_PIP_REQUEST;
+    const eventName = this.mediaIsPip
+      ? MediaUIEvents.MEDIA_EXIT_PIP_REQUEST
+      : MediaUIEvents.MEDIA_ENTER_PIP_REQUEST;
     this.dispatchEvent(
       new window.CustomEvent(eventName, { composed: true, bubbles: true })
     );

--- a/src/js/media-pip-button.js
+++ b/src/js/media-pip-button.js
@@ -8,7 +8,7 @@ const pipIcon = `<svg aria-hidden="true" viewBox="0 0 28 24">
 </svg>`;
 
 const slotTemplate = document.createElement('template');
-slotTemplate.innerHTML = /*html*/`
+slotTemplate.innerHTML = /*html*/ `
   <style>
   :host([${MediaUIAttributes.MEDIA_IS_PIP}]) slot:not([name=exit]) > *, 
   :host([${MediaUIAttributes.MEDIA_IS_PIP}]) ::slotted(:not([slot=exit])) {
@@ -17,7 +17,9 @@ slotTemplate.innerHTML = /*html*/`
 
   ${/* Double negative, but safer if display doesn't equal 'block' */ ''}
   :host(:not([${MediaUIAttributes.MEDIA_IS_PIP}])) slot:not([name=enter]) > *, 
-  :host(:not([${MediaUIAttributes.MEDIA_IS_PIP}])) ::slotted(:not([slot=enter])) {
+  :host(:not([${
+    MediaUIAttributes.MEDIA_IS_PIP
+  }])) ::slotted(:not([slot=enter])) {
     display: none !important;
   }
   </style>
@@ -43,7 +45,11 @@ const updateAriaLabel = (el) => {
  */
 class MediaPipButton extends MediaChromeButton {
   static get observedAttributes() {
-    return [...super.observedAttributes, MediaUIAttributes.MEDIA_IS_PIP, MediaUIAttributes.MEDIA_PIP_UNAVAILABLE];
+    return [
+      ...super.observedAttributes,
+      MediaUIAttributes.MEDIA_IS_PIP,
+      MediaUIAttributes.MEDIA_PIP_UNAVAILABLE,
+    ];
   }
 
   constructor(options = {}) {

--- a/src/js/media-pip-button.js
+++ b/src/js/media-pip-button.js
@@ -7,7 +7,7 @@ import {
   getStringAttr,
   setBooleanAttr,
   setStringAttr,
-} from './utils/element-utils';
+} from './utils/element-utils.js';
 
 const pipIcon = `<svg aria-hidden="true" viewBox="0 0 28 24">
   <path d="M24 3H4a1 1 0 0 0-1 1v16a1 1 0 0 0 1 1h20a1 1 0 0 0 1-1V4a1 1 0 0 0-1-1Zm-1 16H5V5h18v14Zm-3-8h-7v5h7v-5Z"/>

--- a/src/js/media-play-button.js
+++ b/src/js/media-play-button.js
@@ -2,6 +2,7 @@ import MediaChromeButton from './media-chrome-button.js';
 import { window, document } from './utils/server-safe-globals.js';
 import { MediaUIEvents, MediaUIAttributes } from './constants.js';
 import { verbs } from './labels/labels.js';
+import { getBooleanAttr, setBooleanAttr } from './utils/element-utils';
 
 const playIcon = `<svg aria-hidden="true" viewBox="0 0 24 24">
   <path d="m6 21 15-9L6 3v18Z"/>
@@ -30,8 +31,7 @@ slotTemplate.innerHTML = /*html*/ `
 `;
 
 const updateAriaLabel = (el) => {
-  const paused = el.getAttribute(MediaUIAttributes.MEDIA_PAUSED) != null;
-  const label = paused ? verbs.PLAY() : verbs.PAUSE();
+  const label = el.mediaPaused ? verbs.PLAY() : verbs.PAUSE();
   el.setAttribute('aria-label', label);
 };
 
@@ -64,11 +64,21 @@ class MediaPlayButton extends MediaChromeButton {
     super.attributeChangedCallback(attrName, oldValue, newValue);
   }
 
+  /**
+   * @type {boolean} Is the media paused
+   */
+  get mediaPaused() {
+    return getBooleanAttr(this, MediaUIAttributes.MEDIA_PAUSED);
+  }
+
+  set mediaPaused(value) {
+    setBooleanAttr(this, MediaUIAttributes.MEDIA_PAUSED, value);
+  }
+
   handleClick() {
-    const eventName =
-      this.getAttribute(MediaUIAttributes.MEDIA_PAUSED) != null
-        ? MediaUIEvents.MEDIA_PLAY_REQUEST
-        : MediaUIEvents.MEDIA_PAUSE_REQUEST;
+    const eventName = this.mediaPaused
+      ? MediaUIEvents.MEDIA_PLAY_REQUEST
+      : MediaUIEvents.MEDIA_PAUSE_REQUEST;
     this.dispatchEvent(
       new window.CustomEvent(eventName, { composed: true, bubbles: true })
     );

--- a/src/js/media-play-button.js
+++ b/src/js/media-play-button.js
@@ -2,7 +2,7 @@ import MediaChromeButton from './media-chrome-button.js';
 import { window, document } from './utils/server-safe-globals.js';
 import { MediaUIEvents, MediaUIAttributes } from './constants.js';
 import { verbs } from './labels/labels.js';
-import { getBooleanAttr, setBooleanAttr } from './utils/element-utils';
+import { getBooleanAttr, setBooleanAttr } from './utils/element-utils.js';
 
 const playIcon = `<svg aria-hidden="true" viewBox="0 0 24 24">
   <path d="m6 21 15-9L6 3v18Z"/>

--- a/src/js/media-play-button.js
+++ b/src/js/media-play-button.js
@@ -12,7 +12,7 @@ const pauseIcon = `<svg aria-hidden="true" viewBox="0 0 24 24">
 </svg>`;
 
 const slotTemplate = document.createElement('template');
-slotTemplate.innerHTML = /*html*/`
+slotTemplate.innerHTML = /*html*/ `
   <style>
   :host([${MediaUIAttributes.MEDIA_PAUSED}]) slot[name=pause] > *, 
   :host([${MediaUIAttributes.MEDIA_PAUSED}]) ::slotted([slot=pause]) {

--- a/src/js/media-playback-rate-button.js
+++ b/src/js/media-playback-rate-button.js
@@ -111,9 +111,10 @@ class MediaPlaybackRateButton extends MediaChromeButton {
   }
 
   handleClick() {
+    const availableRates = this._rates ?? DEFAULT_RATES;
     const detail =
-      this._rates.find((r) => r > this.mediaPlaybackRate) ??
-      this._rates[0] ??
+      availableRates.find((r) => r > this.mediaPlaybackRate) ??
+      availableRates[0] ??
       DEFAULT_RATE;
     const evt = new window.CustomEvent(
       MediaUIEvents.MEDIA_PLAYBACK_RATE_REQUEST,

--- a/src/js/utils/attribute-token-list.js
+++ b/src/js/utils/attribute-token-list.js
@@ -45,10 +45,6 @@ export class AttributeTokenList {
     return this.#tokens.values();
   }
 
-  keys() {
-    return this.#tokens.keys();
-  }
-
   forEach(callback) {
     this.#tokens.forEach(callback);
   }

--- a/src/js/utils/attribute-token-list.js
+++ b/src/js/utils/attribute-token-list.js
@@ -1,15 +1,22 @@
+/** @implements {Pick<DOMTokenList, 'length' | 'value' | 'toString' | 'item' | 'add' | 'remove' | 'contains' | 'toggle' | 'replace'>} */
 export class AttributeTokenList {
   #el;
   #attr;
-  #tokens = new Set();
+  #defaultSet;
+  #tokenSet = new Set();
 
-  constructor(el, attr) {
+  constructor(el, attr, { defaultValue } = { defaultValue: undefined }) {
     this.#el = el;
     this.#attr = attr;
+    this.#defaultSet = new Set(defaultValue);
   }
 
   [Symbol.iterator]() {
     return this.#tokens.values();
+  }
+
+  get #tokens() {
+    return this.#tokenSet.size ? this.#tokenSet : this.#defaultSet;
   }
 
   get length() {
@@ -22,7 +29,7 @@ export class AttributeTokenList {
 
   set value(val) {
     if (val === this.value) return;
-    this.#tokens = new Set();
+    this.#tokenSet = new Set();
     this.add(...(val?.split(' ') ?? []));
   }
 
@@ -47,7 +54,7 @@ export class AttributeTokenList {
   }
 
   add(...tokens) {
-    tokens.forEach((t) => this.#tokens.add(t));
+    tokens.forEach((t) => this.#tokenSet.add(t));
     // if the attribute was removed don't try to add it again.
     if (this.value === '' && !this.#el?.hasAttribute(`${this.#attr}`)) {
       return;
@@ -56,7 +63,7 @@ export class AttributeTokenList {
   }
 
   remove(...tokens) {
-    tokens.forEach((t) => this.#tokens.delete(t));
+    tokens.forEach((t) => this.#tokenSet.delete(t));
     this.#el?.setAttribute(`${this.#attr}`, `${this.value}`);
   }
 
@@ -87,5 +94,6 @@ export class AttributeTokenList {
   replace(oldToken, newToken) {
     this.remove(oldToken);
     this.add(newToken);
+    return oldToken === newToken;
   }
 }


### PR DESCRIPTION
Adds missing props.

Also fixes the playback rate click handler which seemed to not work on page load where `_rates` was undefined and would throw an error. Falls back to DEFAULT_RATES correctly now.