### PR TITLE
fix: Comparison of text track lists

### DIFF
--- a/src/js/media-captions-button.js
+++ b/src/js/media-captions-button.js
@@ -65,8 +65,8 @@ const setSubtitlesListAttr = (el, attrName, list) => {
 
   // don't set if the new value is the same as existing
   const newValStr = stringifyTextTrackList(list);
-  const oldValStr = stringifyTextTrackList(el.getAttribute(attrName) ?? '');
-  if (oldValStr === newValStr) return;
+  const oldVal = el.getAttribute(attrName);
+  if (oldVal === newValStr) return;
 
   el.setAttribute(attrName, newValStr);
 };


### PR DESCRIPTION
Fixes a utility in the captions button component that wasn't comparing old and new values properly.