### PR TITLE
docs: remove core concepts and move pages

### DIFF
--- a/docs/src/config.ts
+++ b/docs/src/config.ts
@@ -61,10 +61,6 @@ export const SIDEBAR: Sidebar = {
     Reference: [
       { text: 'Styling', link: 'en/reference/styling' },
     ],
-    'Core Concepts': [
-      { text: 'Design Principles', link: 'en/design-principles' },
-      { text: 'Architecture', link: 'en/architecture' },
-    ],
     'Media Elements': [
       { text: 'Cloudflare Video', link: 'en/media-elements/cloudflare-video' },
       { text: 'DASH Video', link: 'en/media-elements/dash-video' },
@@ -109,6 +105,8 @@ export const SIDEBAR: Sidebar = {
     ],
     "Learn More": [
       { text: 'Showcase', link: 'en/showcase' },
+      { text: 'Design Principles', link: 'en/design-principles' },
+      { text: 'Architecture', link: 'en/architecture' },
     ],
     'Media States': [
       { text: 'Stream Type', link: 'en/stream-type' },

--- a/docs/src/pages/en/prevent-layout-shift.md
+++ b/docs/src/pages/en/prevent-layout-shift.md
@@ -8,7 +8,7 @@ Cumulative Layout Shift is when content on your page shifts. It's a sub-optimal 
 
 Video players are notorious for causing CLS. Use this guide to make sure your Media Chrome player is not causing CLS in your web application.
 
-# Set aspect-ratio
+## Set aspect-ratio
 
 The best way is to set an aspect ratio on `<media-controller>`
 


### PR DESCRIPTION
removes the sidebar category `core concepts`