### PR TITLE
Fix/async tracks defaultsubtitles

### DIFF
--- a/examples/vanilla/media-elements/mux-video.html
+++ b/examples/vanilla/media-elements/mux-video.html
@@ -43,6 +43,7 @@
           <media-volume-range></media-volume-range>
           <media-time-range></media-time-range>
           <media-time-display showduration remaining></media-time-display>
+          <media-captions-button></media-captions-button>
           <media-playback-rate-button></media-playback-rate-button>
           <media-pip-button></media-pip-button>
           <media-fullscreen-button></media-fullscreen-button>

--- a/examples/vanilla/media-elements/mux-video.html
+++ b/examples/vanilla/media-elements/mux-video.html
@@ -17,7 +17,7 @@
   <body>
     <main>
       <h1>Media Chrome <code>&lt;mux-video/&gt;</code> Example</h1>
-      <media-controller>
+      <media-controller defaultsubtitles>
         <mux-video
           slot="media"
           preload="auto"
@@ -42,7 +42,7 @@
           <media-mute-button></media-mute-button>
           <media-volume-range></media-volume-range>
           <media-time-range></media-time-range>
-          <media-time-display show-duration remaining></media-time-display>
+          <media-time-display showduration remaining></media-time-display>
           <media-playback-rate-button></media-playback-rate-button>
           <media-pip-button></media-pip-button>
           <media-fullscreen-button></media-fullscreen-button>

--- a/examples/vanilla/media-elements/mux-video.html
+++ b/examples/vanilla/media-elements/mux-video.html
@@ -21,7 +21,7 @@
         <mux-video
           slot="media"
           preload="auto"
-          playback-id="DS00Spx1CV902MCtPj5WknGlR102V5HFkDe"
+          playback-id="ihZa7qP1zY8oyLSQW9TS602VgwQvNdyIvlk9LInEGU2s"
           metadata-video-id="video-id-12345"
           metadata-video-title="Mad Max: Fury Road Trailer"
           metadata-viewer-user-id="user-id-6789"
@@ -32,7 +32,7 @@
             label="thumbnails"
             default
             kind="metadata"
-            src="https://image.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/storyboard.vtt"
+            src="https://image.mux.com/ihZa7qP1zY8oyLSQW9TS602VgwQvNdyIvlk9LInEGU2s/storyboard.vtt"
           />
         </mux-video>
         <media-control-bar>

--- a/src/js/controller.js
+++ b/src/js/controller.js
@@ -21,6 +21,7 @@ import {
   stringifyTextTrackList,
   getTextTracksList,
   updateTracksModeTo,
+  toggleSubsCaps,
 } from './utils/captions.js';
 
 let volumeSupported;
@@ -424,7 +425,15 @@ export const MediaUIStates = {
   },
   MEDIA_SUBTITLES_SHOWING: {
     get: function (controller) {
-      // TODO: Move to non attr specific values
+      // NOTE: A bit hacky, but this ensures that HAS-style textTracks (e.g. from mux-video)
+      // will also respect `defaultsubtitles` (CJP)
+      if (
+        controller.hasAttribute('defaultsubtitles') &&
+        !controller.hasAttribute(MediaUIAttributes.MEDIA_HAS_PLAYED) &&
+        !controller.hasAttribute(MediaUIAttributes.MEDIA_SUBTITLES_SHOWING)
+      ) {
+        toggleSubsCaps(controller, true);
+      }
       return (
         stringifyTextTrackList(getShowingSubtitleTracks(controller)) ||
         undefined


### PR DESCRIPTION
Updated mux-video example to use `defaultsubtitles` and playback-id with subtitles: https://media-chrome-git-fork-cjpillsbury-fix-async-tracks-d-611bf9-mux.vercel.app/examples/vanilla/media-elements/mux-video.html