### PR TITLE
docs: improve Sandpack styles

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -42,7 +42,11 @@ export default defineConfig({
     // Enable Preact to support Preact JSX components.
     preact(), // Enable React for the Algolia search component.
     react(),
-    tailwind(),
+    tailwind({
+      // Example: Disable injecting a basic `base.css` import on every page.
+      // Useful if you need to define and/or import your own custom `base.css`.
+      config: { applyBaseStyles: false },
+    }),
     mdx(),
     markdownIntegration(),
   ],

--- a/docs/src/components/PageContent/CopyToClipboard.astro
+++ b/docs/src/components/PageContent/CopyToClipboard.astro
@@ -76,6 +76,10 @@
     border: 1px solid #999;
   }
 
+  .hidden {
+    display: none;
+  }
+
   .copy {
     fill: #454457;
   }

--- a/docs/src/components/PageContent/CopyToClipboard.astro
+++ b/docs/src/components/PageContent/CopyToClipboard.astro
@@ -3,36 +3,32 @@
   <div class="btn-container">
     <button class="copy-to-clipboard">
       <svg
-        class="copy"
-        fill="currentColor"
-        viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
-        aria-hidden="true"
-      >
-        <path
-          clip-rule="evenodd"
-          fill-rule="evenodd"
-          d="M7.502 6h7.128A3.375 3.375 0 0118 9.375v9.375a3 3 0 003-3V6.108c0-1.505-1.125-2.811-2.664-2.94a48.972 48.972 0 00-.673-.05A3 3 0 0015 1.5h-1.5a3 3 0 00-2.663 1.618c-.225.015-.45.032-.673.05C8.662 3.295 7.554 4.542 7.502 6zM13.5 3A1.5 1.5 0 0012 4.5h4.5A1.5 1.5 0 0015 3h-1.5z"
-        ></path>
-        <path
-          clip-rule="evenodd"
-          fill-rule="evenodd"
-          d="M3 9.375C3 8.339 3.84 7.5 4.875 7.5h9.75c1.036 0 1.875.84 1.875 1.875v11.25c0 1.035-.84 1.875-1.875 1.875h-9.75A1.875 1.875 0 013 20.625V9.375zM6 12a.75.75 0 01.75-.75h.008a.75.75 0 01.75.75v.008a.75.75 0 01-.75.75H6.75a.75.75 0 01-.75-.75V12zm2.25 0a.75.75 0 01.75-.75h3.75a.75.75 0 010 1.5H9a.75.75 0 01-.75-.75zM6 15a.75.75 0 01.75-.75h.008a.75.75 0 01.75.75v.008a.75.75 0 01-.75.75H6.75a.75.75 0 01-.75-.75V15zm2.25 0a.75.75 0 01.75-.75h3.75a.75.75 0 010 1.5H9a.75.75 0 01-.75-.75zM6 18a.75.75 0 01.75-.75h.008a.75.75 0 01.75.75v.008a.75.75 0 01-.75.75H6.75a.75.75 0 01-.75-.75V18zm2.25 0a.75.75 0 01.75-.75h3.75a.75.75 0 010 1.5H9a.75.75 0 01-.75-.75z"
-        ></path>
-      </svg>
-      <svg
-        class="check hidden"
         fill="none"
-        stroke="currentColor"
-        stroke-width="1.5"
         viewBox="0 0 24 24"
-        xmlns="http://www.w3.org/2000/svg"
+        stroke-width="1.5"
+        stroke="currentColor"
         aria-hidden="true"
+        class="copy"
       >
         <path
           stroke-linecap="round"
           stroke-linejoin="round"
-          d="M4.5 12.75l6 6 9-13.5"></path>
+          d="M16.5 8.25V6a2.25 2.25 0 00-2.25-2.25H6A2.25 2.25 0 003.75 6v8.25A2.25 2.25 0 006 16.5h2.25m8.25-8.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-7.5A2.25 2.25 0 018.25 18v-1.5m8.25-8.25h-6a2.25 2.25 0 00-2.25 2.25v6"
+        ></path>
+      </svg>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        aria-hidden="true"
+        class="check hidden"
+      >
+        <path
+          fill-rule="evenodd"
+          d="M19.916 4.626a.75.75 0 01.208 1.04l-9 13.5a.75.75 0 01-1.154.114l-6-6a.75.75 0 011.06-1.06l5.353 5.353 8.493-12.739a.75.75 0 011.04-.208z"
+          clip-rule="evenodd"
+        ></path>
       </svg>
     </button>
   </div>
@@ -50,8 +46,8 @@
 
   .btn-container {
     position: absolute;
-    top: 5px;
-    right: 5px;
+    top: 10px;
+    right: 7px;
     display: none;
   }
 
@@ -62,30 +58,20 @@
   }
 
   .copy-to-clipboard {
+    background: none;
+    cursor: pointer;
+    color: rgb(255 255 255 / 0.7);
     height: 30px;
     width: 30px;
-    border: 1px solid #aeb3d5;
-    border-radius: 0.25rem;
     padding: 4px;
-    filter: drop-shadow(0 1px 2px rgb(0 0 0 / 0.1))
-      drop-shadow(0 1px 1px rgb(0 0 0 / 0.06));
-    background: white;
   }
 
   .copy-to-clipboard:hover {
-    border: 1px solid #999;
+    color: rgb(255 255 255 / 1);
   }
 
   .hidden {
     display: none;
-  }
-
-  .copy {
-    fill: #454457;
-  }
-
-  .check {
-    stroke: green;
   }
 
   @media (prefers-color-scheme: dark) {

--- a/docs/src/components/Sandpack.jsx
+++ b/docs/src/components/Sandpack.jsx
@@ -6,6 +6,11 @@ import { useState, useEffect } from 'react';
 
 const light = {
   ...githubLight,
+  colors: {
+    ...githubLight.colors,
+    accent: 'var(--theme-text)',
+    surface1: 'var(--theme-code-bg)',
+  },
   syntax: {
     ...githubLight.syntax,
     definition: '#22863a'
@@ -16,8 +21,23 @@ const light = {
   }
 };
 
+// Make more like GitHub dark to complement the Markdown code blocks.
 const dark = {
   ...sandpackDark,
+  colors: {
+    ...sandpackDark.colors,
+    accent: 'var(--theme-text)',
+    surface1: 'var(--theme-code-bg)',
+  },
+  syntax: {
+    ...sandpackDark.syntax,
+    definition: '#7EE787',
+    property: '#79C0FF',
+    plain: '#79C0FF',
+    static: '#79C0FF',
+    string: '#A5D6FF',
+    keyword: '#FF7B72',
+  },
   font: {
     ...sandpackDark.font,
     mono: 'var(--font-mono)',
@@ -137,10 +157,13 @@ export default function ComponentSandpack({
           hidden: true,
         },
         '/styles.css': {
-          code: `media-controller,
+          code: `body {
+  margin: 0;
+}
+media-controller,
 video {
-width: 100%;
-aspect-ratio: 2.4;
+  width: 100%;
+  aspect-ratio: 2.4;
 }
 ${hiddenCss}`,
           hidden: true,

--- a/docs/src/components/Sandpack.jsx
+++ b/docs/src/components/Sandpack.jsx
@@ -54,6 +54,7 @@ export default function ComponentSandpack({
   html,
   css,
   hiddenCss = '',
+  editorHeight,
   files = {},
   dependencies = {},
   active = Active.HTML,
@@ -124,7 +125,7 @@ export default function ComponentSandpack({
       template="vanilla"
       theme={theme}
       options={{
-        editorHeight: 'auto',
+        editorHeight,
         editorWidthPercentage: 50,
       }}
       customSetup={{

--- a/docs/src/components/Sandpack.jsx
+++ b/docs/src/components/Sandpack.jsx
@@ -54,7 +54,6 @@ export default function ComponentSandpack({
   html,
   css,
   hiddenCss = '',
-  height = 230,
   files = {},
   dependencies = {},
   active = Active.HTML,

--- a/docs/src/components/SandpackContainer.astro
+++ b/docs/src/components/SandpackContainer.astro
@@ -2,8 +2,7 @@
 import Sandpack from "./Sandpack";
 
 let {
-  height = 230,
-  editorHeight = height,
+  editorHeight = 230,
   previewAspectRatio = 16 / 9,
   stacked,
   reversed,
@@ -14,6 +13,11 @@ if (typeof editorHeight === 'number') editorHeight = `${editorHeight}px`;
 ---
 
 <style is:global define:vars={{ previewAspectRatio, editorHeight }}>
+
+  .sp-container {
+    margin-top: 1.25rem;
+    margin-bottom: 1.25rem;
+  }
 
   @media (min-width: 768px) {
     .sp-container {
@@ -27,7 +31,6 @@ if (typeof editorHeight === 'number') editorHeight = `${editorHeight}px`;
     height: 0;
     position: relative;
     overflow: hidden;
-    margin-top: 1rem;
   }
 
   .sp-container.sp-stacked > astro-island {
@@ -35,6 +38,19 @@ if (typeof editorHeight === 'number') editorHeight = `${editorHeight}px`;
     position: absolute;
     width: 100%;
     height: 100%;
+  }
+
+  .sp-resize-handler {
+    position: absolute;
+    background: var(--theme-bg);
+    width: 5px !important;
+    left: calc(50% - 5px);
+    top: 0;
+    bottom: 0;
+  }
+
+  .sp-stacked .sp-resize-handler {
+    display: none;
   }
 
   .sp-pre-placeholder {
@@ -58,6 +74,7 @@ if (typeof editorHeight === 'number') editorHeight = `${editorHeight}px`;
   }
 
   .sp-layout {
+    position: relative;
     display: flex;
     flex-wrap: wrap;
     background-color: var(--theme-bg) !important;
@@ -102,6 +119,7 @@ if (typeof editorHeight === 'number') editorHeight = `${editorHeight}px`;
 <div class={`sp-container${stacked ? ' sp-stacked' : ''}${reversed ? ' sp-reversed' : ''}`}>
   <Sandpack
     client:load
+    editorHeight={editorHeight}
     {...props}
   />
 </div>

--- a/docs/src/components/SandpackContainer.astro
+++ b/docs/src/components/SandpackContainer.astro
@@ -50,11 +50,13 @@ if (typeof previewHeight === 'number') previewHeight = `${previewHeight}px`;
 
   .sp-pre-placeholder {
     margin-top: 0;
+    border-radius: 0;
+    height: var(--editorHeight) !important;
+    background: var(--theme-code-bg) !important;
+    color: var(--theme-code-text) !important;
     font-family: var(--font-mono) !important;
     font-size: 13px !important;
     line-height: 20px !important;
-    background-color: hsla(var(--color-white), 1);
-    color: hsla(var(--color-charcoal), 1);
     -webkit-font-smoothing: antialiased;
   }
 
@@ -69,9 +71,9 @@ if (typeof previewHeight === 'number') previewHeight = `${previewHeight}px`;
   .sp-layout {
     display: flex;
     flex-wrap: var(--flexWrap) !important;
-    background-color: hsla(var(--color-white), 1);
-    border: 1px solid #f3f3f3;
-    border-radius: 4px;
+    background-color: var(--theme-bg) !important;
+    border-radius: 0 !important;
+    border: none !important;
     height: 100% !important;
   }
 
@@ -81,7 +83,17 @@ if (typeof previewHeight === 'number') previewHeight = `${previewHeight}px`;
   }
 
   .sp-preview {
+    --sp-colors-surface1: var(--theme-bg);
+    --sp-colors-surface2: var(--theme-bg);
     height: var(--previewHeight) !important;
+  }
+
+  .sp-preview-container {
+    background: none !important;
+  }
+
+  .sp-preview-iframe {
+    color-scheme: initial !important;
   }
 </style>
 

--- a/docs/src/components/SandpackContainer.astro
+++ b/docs/src/components/SandpackContainer.astro
@@ -4,48 +4,37 @@ import Sandpack from "./Sandpack";
 let {
   height = 230,
   editorHeight = height,
-  previewHeight,
+  previewAspectRatio = 16 / 9,
   stacked,
   reversed,
   ...props
 } = Astro.props as Props;
 
-const minWidth = stacked ? '100%' : 'none';
-const flexWrap = reversed ? 'wrap-reverse' : 'wrap';
-
-if (!previewHeight) {
-  previewHeight = stacked ? height - editorHeight - 1 : editorHeight;
-}
-
-// Account for the 1px border and make it a CSS px string value
-if (typeof height === 'number') height = `${height + 2}px`;
 if (typeof editorHeight === 'number') editorHeight = `${editorHeight}px`;
-if (typeof previewHeight === 'number') previewHeight = `${previewHeight}px`;
 ---
 
-<script>
-  // Allow autoplay and fullscreen in Sandpack previews
-  const observer = new MutationObserver((mutationList) => {
-    const iframe = mutationList[0].target;
-    if (!iframe.allow.includes(' autoplay; fullscreen;')) {
-      iframe.allow += ' autoplay; fullscreen;';
-      iframe.src = iframe.src;
-    }
-  });
-  observer.observe(document, { subtree: true, attributes: true, attributeFilter: ['allow'] });
-</script>
+<style is:global define:vars={{ previewAspectRatio, editorHeight }}>
 
-<style is:global define:vars={{ flexWrap, minWidth, height, editorHeight, previewHeight }}>
-  .sp-container {
-    overflow: hidden;
-    margin-top: 1rem;
-    height: var(--height);
+  @media (min-width: 768px) {
+    .sp-container {
+      height: var(--editorHeight) !important;
+    }
   }
 
-  @media (max-width: 768px) {
-    .sp-container {
-      height: auto !important;
-    }
+  .sp-container.sp-stacked {
+    padding-bottom: calc(1 / var(--previewAspectRatio) * 100% + 50px + var(--editorHeight));
+    width: 100%;
+    height: 0;
+    position: relative;
+    overflow: hidden;
+    margin-top: 1rem;
+  }
+
+  .sp-container.sp-stacked > astro-island {
+    display: block;
+    position: absolute;
+    width: 100%;
+    height: 100%;
   }
 
   .sp-pre-placeholder {
@@ -70,22 +59,35 @@ if (typeof previewHeight === 'number') previewHeight = `${previewHeight}px`;
 
   .sp-layout {
     display: flex;
-    flex-wrap: var(--flexWrap) !important;
+    flex-wrap: wrap;
     background-color: var(--theme-bg) !important;
     border-radius: 0 !important;
     border: none !important;
     height: 100% !important;
   }
 
-  .sp-editor {
-    min-width: var(--minWidth);
-    height: var(--editorHeight) !important;
+  .sp-stacked .sp-layout {
+    flex-direction: column !important;
+  }
+
+  .sp-stacked.sp-reversed .sp-layout {
+    flex-direction: column-reverse !important;
+  }
+
+  .sp-stacked .sp-editor {
+    min-width: 100%;
+    flex: 0 1 var(--editorHeight) !important;
+  }
+
+  .sp-stacked .sp-preview {
+    min-width: 100%;
+    flex: 1 1 auto;
   }
 
   .sp-preview {
     --sp-colors-surface1: var(--theme-bg);
     --sp-colors-surface2: var(--theme-bg);
-    height: var(--previewHeight) !important;
+    height: 100% !important;
   }
 
   .sp-preview-container {
@@ -97,9 +99,21 @@ if (typeof previewHeight === 'number') previewHeight = `${previewHeight}px`;
   }
 </style>
 
-<div class="sp-container">
+<div class={`sp-container${stacked ? ' sp-stacked' : ''}${reversed ? ' sp-reversed' : ''}`}>
   <Sandpack
     client:load
     {...props}
   />
 </div>
+
+<script>
+  // Allow autoplay and fullscreen in Sandpack previews
+  const observer = new MutationObserver((mutationList) => {
+    const iframe = mutationList[0].target;
+    if (!iframe.allow.includes(' autoplay; fullscreen;')) {
+      iframe.allow += ' autoplay; fullscreen;';
+      iframe.src = iframe.src;
+    }
+  });
+  observer.observe(document, { subtree: true, attributes: true, attributeFilter: ['allow'] });
+</script>

--- a/docs/src/layouts/MediaElementLayout.astro
+++ b/docs/src/layouts/MediaElementLayout.astro
@@ -16,7 +16,7 @@ headings.push({ depth: 2, slug: 'installing', text: 'Installing' });
     stacked
     reversed
     editorHeight={300}
-    previewAspectRatio={frontmatter.aspectRatio}
+    previewAspectRatio={frontmatter.previewAspectRatio ?? frontmatter.aspectRatio}
     dependencies={frontmatter.dependencies}
     hiddenCss={`
       media-controller,

--- a/docs/src/layouts/MediaElementLayout.astro
+++ b/docs/src/layouts/MediaElementLayout.astro
@@ -15,8 +15,8 @@ headings.push({ depth: 2, slug: 'installing', text: 'Installing' });
   <SandpackContainer
     stacked
     reversed
-    height={frontmatter.height ?? 850}
     editorHeight={300}
+    previewAspectRatio={frontmatter.aspectRatio}
     dependencies={frontmatter.dependencies}
     hiddenCss={`
       media-controller,

--- a/docs/src/pages/en/components/media-captions-button.mdx
+++ b/docs/src/pages/en/components/media-captions-button.mdx
@@ -16,7 +16,7 @@ The contents and behavior of the `<media-captions-button>` will update automatic
 ## Default usage
 
 <SandpackContainer
-  height={250}
+  editorHeight={250}
   html={`<media-controller defaultsubtitles>
   <video
     playsinline muted crossorigin
@@ -38,7 +38,7 @@ Here's an example of how you can replace the default CC on and CC off icons with
 <b><u>CC</u></b> CC, respectively. Media Controller is also set up to enable captions and subtitles by default.
 
 <SandpackContainer
-  height={310}
+  editorHeight={310}
   html={`<media-controller defaultsubtitles>
   <video
     playsinline muted crossorigin

--- a/docs/src/pages/en/components/media-cast-button.mdx
+++ b/docs/src/pages/en/components/media-cast-button.mdx
@@ -19,7 +19,7 @@ The contents and behavior of the `<media-cast-button>` will update automatically
 ## Default usage
 
 <SandpackContainer
-  height={190}
+  editorHeight={190}
   html={`<media-controller>
   <video
     playsinline muted crossorigin
@@ -38,7 +38,7 @@ This is useful if you'd like to use your own custom Cast button instead of the d
 Here's an example of how you can replace the default icons with the words "Cast" and "Exit".
 
 <SandpackContainer
-  height={250}
+  editorHeight={250}
   html={`<media-controller>
   <video
     playsinline muted crossorigin

--- a/docs/src/pages/en/components/media-fullscreen-button.mdx
+++ b/docs/src/pages/en/components/media-fullscreen-button.mdx
@@ -34,7 +34,7 @@ This is useful if you'd like to use your own custom fullscreen button instead of
 Here's an example of how you can replace the default fullscreen icons with the words "Enter" and "Exit"
 
 <SandpackContainer
-  height={250}
+  editorHeight={250}
   html={`<media-controller defaultsubtitles>
   <video
     playsinline muted crossorigin

--- a/docs/src/pages/en/components/media-live-button.mdx
+++ b/docs/src/pages/en/components/media-live-button.mdx
@@ -18,7 +18,7 @@ The behavior of the button will update automatically based on the state of the m
 
 <SandpackContainer
   includeMuxVideo
-  height={265}
+  editorHeight={265}
   dependencies={{
     '@mux/mux-video': 'latest'
   }}
@@ -45,7 +45,7 @@ Here's an example of how you can replace the default indicator with a custom SVG
 
 <SandpackContainer
   includeMuxVideo
-  height={265}
+  editorHeight={265}
   dependencies={{
     '@mux/mux-video': 'latest'
   }}

--- a/docs/src/pages/en/components/media-loading-indicator.mdx
+++ b/docs/src/pages/en/components/media-loading-indicator.mdx
@@ -45,7 +45,7 @@ This is useful if you'd like to use your own custom loading indicator instead of
 Here is an example with custom SVGs:
 
 <SandpackContainer
-  height={280}
+  editorHeight={280}
   css={`/*
  * Force the loading indicator to be visisble.
  * By default, the indicator is hidden and only

--- a/docs/src/pages/en/components/media-mute-button.mdx
+++ b/docs/src/pages/en/components/media-mute-button.mdx
@@ -18,7 +18,7 @@ The contents and behavior of the `<media-mute-button>` will update automatically
 ## Default usage
 
 <SandpackContainer
-  height={265}
+  editorHeight={265}
   html={`<media-controller defaultsubtitles>
   <video
     playsinline muted crossorigin
@@ -41,7 +41,7 @@ This is useful if you'd like to use your own custom mute button instead of the d
 Here's an example of how you can replace the volume levels with the words that correspond to the level.
 
 <SandpackContainer
-  height={365}
+  editorHeight={365}
   html={`<media-controller defaultsubtitles>
   <video
     playsinline muted crossorigin

--- a/docs/src/pages/en/components/media-pip-button.mdx
+++ b/docs/src/pages/en/components/media-pip-button.mdx
@@ -34,7 +34,7 @@ This is useful if you'd like to use your own custom PiP button instead of the de
 Here's an example of how you can replace the default PiP icons with the words "Enter" and "Exit"
 
 <SandpackContainer
-  height={250}
+  editorHeight={250}
   html={`<media-controller defaultsubtitles>
   <video
     playsinline muted crossorigin

--- a/docs/src/pages/en/components/media-play-button.mdx
+++ b/docs/src/pages/en/components/media-play-button.mdx
@@ -39,7 +39,7 @@ Here's an example of how you can replace the default play and pause icons with
 the literal words "Play" and "Pause":  
 
 <SandpackContainer
-  height={270}
+  editorHeight={270}
   html={`<media-controller>
   <video
     slot="media"

--- a/docs/src/pages/en/components/media-poster-image.mdx
+++ b/docs/src/pages/en/components/media-poster-image.mdx
@@ -17,7 +17,7 @@ You can either use the `<media-poster-image>` component as a static image on its
 ## With `src`
 
 <SandpackContainer
-  height={290}
+  editorHeight={290}
   html={`<media-controller>
   <video
     slot="media"
@@ -35,7 +35,7 @@ You can either use the `<media-poster-image>` component as a static image on its
 ## With `placeholdersrc` and `src`
 
 <SandpackContainer
-  height={290}
+  editorHeight={290}
   html={`<media-controller>
   <video
     slot="media"

--- a/docs/src/pages/en/components/media-seek-backward-button.mdx
+++ b/docs/src/pages/en/components/media-seek-backward-button.mdx
@@ -12,7 +12,7 @@ The `<media-seek-backward-button>` component is used to allow seeking back a con
 ## Default usage
 
 <SandpackContainer
-  height={290}
+  editorHeight={290}
   html={`<media-controller>
   <video
     slot="media"
@@ -33,7 +33,7 @@ The `<media-seek-backward-button>` component is used to allow seeking back a con
 The seeking amount can be configured with the `seekoffset` attribute.
 
 <SandpackContainer
-  height={290}
+  editorHeight={290}
   html={`<media-controller>
   <video
     slot="media"
@@ -58,7 +58,7 @@ The slot for `<media-seek-backward-button>` the slot is named `backward`.
 Here's an example of how you can replace the default icon with the word "Back":
 
 <SandpackContainer
-  height={330}
+  editorHeight={330}
   html={`<media-controller>
   <video
     slot="media"

--- a/docs/src/pages/en/components/media-seek-forward-button.mdx
+++ b/docs/src/pages/en/components/media-seek-forward-button.mdx
@@ -12,7 +12,7 @@ The `<media-seek-forward-button>` component is used to allow seeking forward a c
 ## Default usage
 
 <SandpackContainer
-  height={290}
+  editorHeight={290}
   html={`<media-controller>
   <video
     slot="media"
@@ -33,7 +33,7 @@ The `<media-seek-forward-button>` component is used to allow seeking forward a c
 The seeking amount can be configured with the `seekoffset` attribute.
 
 <SandpackContainer
-  height={290}
+  editorHeight={290}
   html={`<media-controller>
   <video
     slot="media"
@@ -58,7 +58,7 @@ The slot for `<media-seek-forward-button>` the slot is named `forward`.
 Here's an example of how you can replace the default icon with the word "Forward":
 
 <SandpackContainer
-  height={330}
+  editorHeight={330}
   html={`<media-controller>
   <video
     slot="media"

--- a/docs/src/pages/en/components/media-time-display.mdx
+++ b/docs/src/pages/en/components/media-time-display.mdx
@@ -12,7 +12,7 @@ The `<media-time-display>` component is used to show the current or remaining ti
 ## Default usage
 
 <SandpackContainer
-  height={265}
+  editorHeight={265}
   html={`<media-controller>
   <video
     slot="media"
@@ -33,7 +33,7 @@ The `<media-time-display>` component is used to show the current or remaining ti
 Showing the duration can be configured with the `showduration` attribute.
 
 <SandpackContainer
-  height={265}
+  editorHeight={265}
   html={`<media-controller defaultsubtitles>
   <video
     slot="media"
@@ -54,7 +54,7 @@ Showing the duration can be configured with the `showduration` attribute.
 Showing the remaining time by default can be configured with the `remaining` attribute.
 
 <SandpackContainer
-  height={265}
+  editorHeight={265}
   html={`<media-controller defaultsubtitles>
   <video
     slot="media"

--- a/docs/src/pages/en/components/media-time-range.mdx
+++ b/docs/src/pages/en/components/media-time-range.mdx
@@ -18,7 +18,7 @@ a [preview thumbnail](#preview-thumbnails) will be shown.
 ## Default usage
 
 <SandpackContainer
-  height={250}
+  editorHeight={250}
   html={`<media-controller>
   <video
     playsinline muted crossorigin
@@ -39,7 +39,7 @@ Adding a metadata text track labelled "thumbnails" (`<track default label="thumb
 with a valid VTT file as `src` will enable the preview thumbnails on hover functionality.
 
 <SandpackContainer
-  height={330}
+  editorHeight={330}
   html={`<media-controller>
   <video 
     playsinline muted crossorigin
@@ -65,7 +65,7 @@ Add a time display component in the current slot that will slide along
 the timeline as the video progresses.
 
 <SandpackContainer
-  height={270}
+  editorHeight={270}
   html={`<media-controller>
   <video
     playsinline muted crossorigin
@@ -87,7 +87,7 @@ the timeline as the video progresses.
 Set the `preview` slot to an empty element to remove the default preview elements.
 
 <SandpackContainer
-  height={270}
+  editorHeight={270}
   html={`<media-controller>
   <video
     playsinline muted crossorigin
@@ -114,7 +114,7 @@ element which can be tricky to style across browsers but the `<media-time-range>
 comes with targeted CSS variables that make this a breeze.
 
 <SandpackContainer
-  height={270}
+  editorHeight={270}
   html={`<style>
   media-time-range {
     --media-control-background: transparent;

--- a/docs/src/pages/en/components/media-volume-range.mdx
+++ b/docs/src/pages/en/components/media-volume-range.mdx
@@ -14,7 +14,7 @@ The component will be updated automatically based on the volume level and volume
 ## Default usage
 
 <SandpackContainer
-  height={265}
+  editorHeight={265}
   html={`<media-controller defaultsubtitles>
   <video
     playsinline muted crossorigin

--- a/docs/src/pages/en/get-started.mdx
+++ b/docs/src/pages/en/get-started.mdx
@@ -25,6 +25,7 @@ This example demonstrates combining controls, captions, poster image, and a time
 
 <SandpackContainer
   height={710}
+  previewAspectRatio={2.4}
   editorHeight={290}
   stacked
   reversed

--- a/docs/src/pages/en/get-started.mdx
+++ b/docs/src/pages/en/get-started.mdx
@@ -24,7 +24,6 @@ A key focus of Media Chrome is to seperate the UI from media playback. This mean
 This example demonstrates combining controls, captions, poster image, and a timeline with thumbnails on hover. This is a live sandbox so you can edit the code and see it update in real-time. Try adding `<media-volume-range></media-volume-range>` to the control bar.
 
 <SandpackContainer
-  height={710}
   previewAspectRatio={2.4}
   editorHeight={290}
   stacked
@@ -132,7 +131,7 @@ You can add controls to your player by placing them inside of a `<media-control-
 When using controls outside of a `<media-controller>` wrapper element; the control, or the surrounding control bar, needs to specify which media controller it should be associated with. To do this you can set the `mediacontroller` attribute.
 
 <SandpackContainer
-  height={244}
+  editorHeight={244}
   html={`<media-controller id="myController">
   <video slot="media" src="https://stream.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/high.mp4" muted playsinline></video>
 </media-controller>

--- a/docs/src/pages/en/media-elements/hls-video.mdx
+++ b/docs/src/pages/en/media-elements/hls-video.mdx
@@ -3,7 +3,6 @@ title: <hls-video>
 description: Play arbitrary HLS videos with Hls.js
 layout: ../../../layouts/MediaElementLayout.astro
 
-height: 720
 aspectRatio: 2.4
 dependencies: { 'hls-video-element': 'latest' }
 package: hls-video-element

--- a/docs/src/pages/en/media-elements/mux-video.mdx
+++ b/docs/src/pages/en/media-elements/mux-video.mdx
@@ -3,7 +3,6 @@ title: <mux-video>
 description: Play videos hosted by Mux
 layout: ../../../layouts/MediaElementLayout.astro
 
-height: 720
 aspectRatio: 2.4
 dependencies: { '@mux/mux-video': 'latest' }
 package: '@mux/mux-video'

--- a/docs/src/pages/en/media-elements/spotify-audio.mdx
+++ b/docs/src/pages/en/media-elements/spotify-audio.mdx
@@ -3,7 +3,7 @@ title: <spotify-audio>
 description: Play audio hosted by Spotify
 layout: ../../../layouts/MediaElementLayout.astro
 
-height: 400
+previewAspectRatio: 8
 aspectRatio: auto
 html: |
   <media-controller audio>

--- a/docs/src/pages/en/media-elements/videojs-video.mdx
+++ b/docs/src/pages/en/media-elements/videojs-video.mdx
@@ -3,7 +3,6 @@ title: <videojs-video>
 description: Play videos with the Video.js playback engine
 layout: ../../../layouts/MediaElementLayout.astro
 
-height: 720
 aspectRatio: 2.4
 dependencies: { 'videojs-video-element': 'latest' }
 package: videojs-video-element

--- a/docs/src/pages/en/responsive-controls.mdx
+++ b/docs/src/pages/en/responsive-controls.mdx
@@ -23,13 +23,8 @@ Media Chrome helps you to make changes to your video player layout at different 
 <SandpackContainer
   stacked
   reversed
-  height={850}
+  previewAspectRatio={2.4}
   editorHeight={300}
-  hiddenCss={`
-    media-controller {
-      aspect-ratio: 16 / 9;
-    }`
-  }
   active="css"
   html={`<media-controller>
   <video
@@ -116,13 +111,8 @@ It's possible to override the default breakpoint values with your own values if 
 <SandpackContainer
   stacked
   reversed
-  height={850}
-  editorHeight={300}
-  hiddenCss={`
-    media-controller {
-      aspect-ratio: 16 / 9;
-    }`
-  }
+  previewAspectRatio={2.4}
+  editorHeight={220}
   html={`<media-controller breakpoints="sm:288 md:480 lg:768 xl:1056">
   <video
     slot="media"
@@ -139,15 +129,10 @@ Note that even if you only want to override _one_ of the default values that Med
 <SandpackContainer
   stacked
   reversed
-  height={850}
-  editorHeight={300}
-  hiddenCss={`
-    media-controller {
-      aspect-ratio: 16 / 9;
-    }`
-  }
+  previewAspectRatio={2.4}
+  editorHeight={235}
   html={`<!-- Overriding only the 'xl' breakpoint, but still passing all breakpoints -->
-  <media-controller breakpoints="sm:384 md:576 lg:768 xl:1056">
+<media-controller breakpoints="sm:384 md:576 lg:768 xl:1056">
   <video
     slot="media"
     src="https://stream.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/low.mp4"
@@ -198,9 +183,9 @@ Let's make a [simple responsive layout](https://media-chrome-mux.vercel.app/exam
 In addition to the `<media-control-bar>` above, we want to add some center controls.
 ```html
 <div class="center" slot="centered-chrome">
-    <media-seek-backward-button seekoffset="15"></media-seek-backward-button>
-    <media-play-button></media-play-button>
-    <media-seek-forward-button seekoffset="15"></media-seek-forward-button>
+  <media-seek-backward-button seekoffset="15"></media-seek-backward-button>
+  <media-play-button></media-play-button>
+  <media-seek-forward-button seekoffset="15"></media-seek-forward-button>
 </div>
 ```
 

--- a/docs/src/pages/en/responsive-controls.mdx
+++ b/docs/src/pages/en/responsive-controls.mdx
@@ -194,10 +194,10 @@ When the player is medium sized, we can keep the control bar but hide the button
 In a large player size, we can show just the control bar.
 
 The combined HTML for the player should look like this:
+
 <SandpackContainer
   stacked
   reversed
-  height={850}
   editorHeight={300}
   hiddenCss={`
     media-controller {
@@ -341,6 +341,7 @@ but let's add one for the sake of completeness.
 ```
 
 ### The final result
+
 Together, it'll give you a player like this.
 You can resize the page and see how the player responds to the page width.
 Or select a width with the following radio buttons.
@@ -348,7 +349,6 @@ Or select a width with the following radio buttons.
 <SandpackContainer
   stacked
   reversed
-  height={850}
   editorHeight={300}
   hiddenCss={`
     media-controller {

--- a/docs/src/pages/en/styling.mdx
+++ b/docs/src/pages/en/styling.mdx
@@ -125,7 +125,7 @@ To demonstrate this, here's an example with several more components, including a
 <SandpackContainer
   stacked
   active="css"
-  height={900}
+  previewAspectRatio={2.4}
   editorHeight={450}
   css={`media-controller {
   --media-primary-color: mistyrose;
@@ -227,7 +227,7 @@ We've already seen a number of ways to customize the look and feel of things in 
 <SandpackContainer
   stacked
   active="css"
-  height={900}
+  previewAspectRatio={2.4}
   editorHeight={450}
   css={`media-controller {
   --media-primary-color: mistyrose;

--- a/docs/src/pages/en/styling.mdx
+++ b/docs/src/pages/en/styling.mdx
@@ -312,7 +312,7 @@ In order to make responsive design easy, we've built in a concept of "breakpoint
 
 <SandpackContainer
   active="css"
-  height={300}
+  editorHeight={300}
   css={`media-controller {
   --media-primary-color: mistyrose;
   --media-secondary-color: rgb(27 54 93 / 0.85);

--- a/docs/src/styles/index.css
+++ b/docs/src/styles/index.css
@@ -3,13 +3,17 @@
   margin: 0;
 }
 
-iframe {
-  border: 0;
-}
-
 /* Global focus outline reset */
 *:focus:not(:focus-visible) {
   outline: none;
+}
+
+::selection {
+  background: hsla(var(--color-marked), 0.4) !important;
+}
+
+::-moz-selection {
+  background: hsla(var(--color-marked), 0.5) !important;
 }
 
 :root {
@@ -32,6 +36,10 @@ body {
   font-size: clamp(0.9rem, 0.75rem + 0.375vw + var(--user-font-scale), 1rem);
   line-height: 1.5;
   max-width: 100vw;
+}
+
+iframe {
+  border: 0;
 }
 
 nav ul {

--- a/docs/src/styles/index.css
+++ b/docs/src/styles/index.css
@@ -272,7 +272,6 @@ strong {
 /* Supporting Content */
 
 code {
-  --border-radius: 0;
   --padding-block: .125rem;
   --padding-inline: .25rem;
 
@@ -283,7 +282,6 @@ code {
   background-color: var(--theme-code-inline-bg);
   padding: var(--padding-block) var(--padding-inline);
   margin: calc(var(--padding-block) * -1) - .125em;
-  border-radius: var(--border-radius);
   word-break: break-word;
 }
 
@@ -323,6 +321,7 @@ table {
 pre {
   -webkit-font-smoothing: antialiased;
   font-size: .8125em; /* 13px */
+  background-color: hsla(0, 0%, 16%, 1.00) !important;
 }
 
 td,
@@ -369,7 +368,6 @@ blockquote code {
 @media (min-width: 37.75em) {
   pre {
     --padding-inline: 1.25rem;
-    border-radius: 8px;
     margin-left: 0;
     margin-right: 0;
   }
@@ -380,7 +378,6 @@ blockquote {
   padding: 1.25em 1.5rem;
   border-left: 3px solid var(--theme-text-light);
   background-color: var(--theme-bg-offset);
-  border-radius: 0 0.25rem 0.25rem 0;
   line-height: 1.7;
 }
 

--- a/docs/src/styles/theme.css
+++ b/docs/src/styles/theme.css
@@ -87,8 +87,8 @@
   --theme-toggle-bg: hsla(var(--color-gray-95), 1);
   --theme-code-inline-bg: rgb(28 160 253 / .1);
   --theme-code-inline-text: rgb(7 83 137);
-  --theme-code-bg: hsla(217, 19%, 27%, 1);
-  --theme-code-text: hsla(var(--color-gray-95), 1);
+  --theme-code-bg: hsla(60, 9%, 98%, 1.00);
+  --theme-code-text: hsla(var(--color-charcoal), 1);
   --theme-navbar-bg: hsla(var(--color-bg-putty), 1);
   --theme-navbar-height: 5rem;
   --theme-footer-bg: hsla(var(--color-black), 1);
@@ -117,7 +117,7 @@ body {
   --theme-toggle-bg: hsla(var(--color-gray-10), 1);
   --theme-code-inline-bg: rgb(28 160 253 / .1);
   --theme-code-inline-text: rgb(229 244 255);
-  --theme-code-bg: hsla(var(--color-gray-5), 1);
+  --theme-code-bg: hsla(0, 0%, 16%, 1.00);
   --theme-code-text: hsla(var(--color-base-white), 100%, 1);
   --theme-navbar-bg: rgb(56 56 56);
   --theme-footer-bg: rgb(56 56 56);

--- a/docs/src/styles/theme.css
+++ b/docs/src/styles/theme.css
@@ -71,6 +71,7 @@
 :root {
   color-scheme: light;
   --theme-accent-opacity: 0.1;
+  --color-marked: 205, 98%, 55%;
   --theme-accent: hsla(var(--color-green), 1);
   --theme-text-accent: hsla(var(--color-green), 1);
   --theme-text-accent-contrast: hsla(var(--color-base-green), 24%, 1);
@@ -85,7 +86,7 @@
   --theme-bg-offset: hsla(var(--color-gray-95), 1);
   --theme-bg-accent: hsla(var(--color-green), var(--theme-accent-opacity));
   --theme-toggle-bg: hsla(var(--color-gray-95), 1);
-  --theme-code-inline-bg: rgb(28 160 253 / .1);
+  --theme-code-inline-bg: hsla(var(--color-marked), 0.1);
   --theme-code-inline-text: rgb(7 83 137);
   --theme-code-bg: hsla(60, 9%, 98%, 1.00);
   --theme-code-text: hsla(var(--color-charcoal), 1);
@@ -101,6 +102,7 @@ body {
 
 :root.theme-dark {
   color-scheme: dark;
+  --color-marked: 205, 98%, 55%;
   --theme-accent-opacity: 0.15;
   --theme-accent: hsla(var(--color-green), 1);
   --theme-text-accent: hsla(var(--color-green), 1);
@@ -115,7 +117,7 @@ body {
   --theme-bg-offset: hsla(var(--color-gray-5), 1);
   --theme-bg-accent: hsla(var(--color-green), var(--theme-accent-opacity));
   --theme-toggle-bg: hsla(var(--color-gray-10), 1);
-  --theme-code-inline-bg: rgb(28 160 253 / .1);
+  --theme-code-inline-bg: hsla(var(--color-marked), 0.1);
   --theme-code-inline-text: rgb(229 244 255);
   --theme-code-bg: hsla(0, 0%, 16%, 1.00);
   --theme-code-text: hsla(var(--color-base-white), 100%, 1);

--- a/docs/src/styles/toggle.css
+++ b/docs/src/styles/toggle.css
@@ -1,3 +1,8 @@
+/* The integration's default injected base.css file */
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 .switch {
   position: relative;
   display: inline-block;


### PR DESCRIPTION
Test url: https://media-chrome-docs-git-fork-luwes-improve-sandpack-style-mux.vercel.app/en/media-elements/vimeo-video

- makes code highlighting in dark mode uniformer
- moves style closer to Mux docs code blocks, remove border-radius, dimmed background color
- moved to use previewAspectRatio instead of a fixed height
- made copy to clipboard icon nicer