### PR TITLE
feat: Icon slots for buttons with multiple slots

### DIFF
--- a/docs/src/pages/en/components/media-captions-button.mdx
+++ b/docs/src/pages/en/components/media-captions-button.mdx
@@ -9,9 +9,9 @@ import SandpackContainer from "../../../components/SandpackContainer.astro";
 
 The `<media-captions-button>` component is used to toggle captions and subtitles on and off. When turning on captions and subtitles, captions tracks will be preferred over subtitles tracks, but either type will be used.
 
-The contents and behavior of the `<media-captions-button>` will update automatically based on the text track media state.
-- When any captions or subtitles track is shown, the component will switch to display the contents of the `on` slot.
-- When all captions and subtitles track are disabled, the component will switch to display the content of the `off` slot.
+The contents of the `<media-captions-button>` will update based on the text track media state.
+- When *any* captions or subtitles tracks are enabled, the component will display the contents of the `on` slot.
+- When *all* captions and subtitles tracks are disabled, the component will display the contents of the `off` slot.
 
 ## Default usage
 
@@ -34,8 +34,8 @@ The contents and behavior of the `<media-captions-button>` will update automatic
 You can modify the contents of the `<media-captions-button>` component using slots.
 This is useful if you'd like to use your own custom captions button instead of the default one provided by media-chrome.
 
-Here's an example of how you can replace the default CC on and CC off icons with
-<b><u>CC</u></b> CC, respectively. Media Controller is also set up to enable captions and subtitles by default.
+Here's an example of how you can replace the default on and off icons with
+<b><u>CC</u></b> and CC. Media Controller also enables captions and subtitles using the `defaultsubtitles` attribute.
 
 <SandpackContainer
   editorHeight={310}
@@ -49,9 +49,38 @@ Here's an example of how you can replace the default CC on and CC off icons with
   </video>
   <media-captions-button>
     <span slot="on"><b><u>CC</u></b></span>
-    <span slot="off">CC</span>
+    <span slot="off" style="font-weight: 400;">CC</span>
   </media-captions-button>
 </media-controller>`}
+/>
+
+Alternatively, if you would like to use a single element you could use the `icon` slot instead. This is useful for creating an animated icon that transitions between states. Here's a basic example that uses CSS to control how it looks.
+
+<SandpackContainer
+  height={325}
+  active="css"
+  html={`<media-controller>
+  <video slot="media" playsinline muted crossorigin src="https://stream.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/low.mp4">
+    <track label="English" kind="captions" srclang="en" src='https://media-chrome.mux.dev/examples/vanilla/vtt/en-cc.vtt' />
+  </video>
+  <media-control-bar>
+    <media-captions-button>
+      <span class="my-icon" slot="icon">CC</span>
+    </media-captions-button>
+  </media-control-bar>
+</media-controller>`}
+css={`.my-icon {
+  transition: all .5s;
+  font-weight: 400;
+  border-radius: 5px;
+}
+
+media-captions-button[aria-checked=true] .my-icon {
+  font-weight: 700;
+  text-decoration: underline;
+  color: red;
+}
+`}
 />
 
 ## Styling with attributes

--- a/docs/src/pages/en/components/media-cast-button.mdx
+++ b/docs/src/pages/en/components/media-cast-button.mdx
@@ -71,6 +71,7 @@ css={`.my-icon {
   border-radius: 4px;
   outline: 2px solid #fff;
   padding: 0 6px;
+  transition: all .4s;
 }
 
 media-cast-button[mediaiscasting] .cast-icon {

--- a/docs/src/pages/en/components/media-cast-button.mdx
+++ b/docs/src/pages/en/components/media-cast-button.mdx
@@ -10,11 +10,11 @@ import SandpackContainer from "../../../components/SandpackContainer.astro";
 The `<media-cast-button>` component is used to bring up the Cast menu and select playback on a Chromecast-enabled device and to stop casting once started.
 
 
-The contents and behavior of the `<media-cast-button>` will update automatically based on the availability of casting support and current casting state.
+The contents of the `<media-cast-button>` will update based on the availability of casting support and current casting state.
 - When the media is not currently casting, the `enter` slot will be shown.
 - When the media is currently casting, the `exit` slot will be shown.
 
-> NOTE: Casting support isn't available in all browsers
+> NOTE: Casting support isn't available in all browsers. Interacting with these examples may not do anything when support isn't available.
 
 ## Default usage
 
@@ -32,8 +32,7 @@ The contents and behavior of the `<media-cast-button>` will update automatically
 
 ## Customize icons
 
-You can modify the contents of the `<media-cast-button>` component using slots.
-This is useful if you'd like to use your own custom Cast button instead of the default one provided by media-chrome.
+You can modify the contents of the `<media-cast-button>` component using slots. This is useful if you'd like to use your own custom icons instead of the default ones provided by media-chrome.
 
 Here's an example of how you can replace the default icons with the words "Cast" and "Exit".
 
@@ -50,6 +49,35 @@ Here's an example of how you can replace the default icons with the words "Cast"
     <span slot="exit">Exit</span>
   </media-cast-button>
 </media-controller>`}
+/>
+
+Alternatively, if you would like to represent both states using a single element you could use the `icon` slot instead. This is useful for creating an animated icon that transitions between states. Here's a basic example that uses CSS to change an element based on the casting state.
+
+<SandpackContainer
+  height={365}
+  active="css"
+  html={`<media-controller>
+  <video
+    slot="media"
+    src="https://stream.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/low.mp4"
+    playsinline
+    muted
+  ></video>
+  <media-cast-button>
+    <span class="my-icon" slot="icon">[ ]</span>
+  </media-cast-button>
+</media-controller>`}
+css={`.my-icon {
+  border-radius: 4px;
+  outline: 2px solid #fff;
+  padding: 0 6px;
+}
+
+media-cast-button[mediaiscasting] .cast-icon {
+  outline: 2px solid green;
+  color: green;
+}
+`}
 />
 
 ## Styling with attributes

--- a/docs/src/pages/en/components/media-fullscreen-button.mdx
+++ b/docs/src/pages/en/components/media-fullscreen-button.mdx
@@ -9,7 +9,7 @@ import SandpackContainer from "../../../components/SandpackContainer.astro";
 
 The `<media-fullscreen-button>` component is used to toggle fullscreen viewing.
 
-The contents and behavior of the `<media-fullscreen-button>` will update automatically based on the fullscreen state and availability.
+The contents of the `<media-fullscreen-button>` will update based on the fullscreen state and availability.
 - When the media is not fullscreen, the component will switch to display the contents of the `enter` slot.
 - When the media is fullscreen, the component will switch to display the contents of the `exit` slot.
 
@@ -28,8 +28,7 @@ The contents and behavior of the `<media-fullscreen-button>` will update automat
 
 ## Customize icons
 
-You can modify the contents of the `<media-fullscreen-button>` component using slots.
-This is useful if you'd like to use your own custom fullscreen button instead of the default one provided by media-chrome.
+You can modify the contents of the `<media-fullscreen-button>` component using slots. This is useful if you'd like to use your own custom fullscreen icon instead of the default one provided by media-chrome.
 
 Here's an example of how you can replace the default fullscreen icons with the words "Enter" and "Exit"
 
@@ -46,6 +45,37 @@ Here's an example of how you can replace the default fullscreen icons with the w
     <span slot="exit">Exit</span>
   </media-fullscreen-button>
 </media-controller>`}
+/>
+
+Alternatively, if you would like to represent both states using a single element you could use the `icon` slot instead. This is useful for creating an animated icon that transitions between states. Here's a basic example that uses CSS to change an element based on the fullscreen state.
+
+<SandpackContainer
+  height={365}
+  active="css"
+  html={`<media-controller>
+  <video
+    slot="media"
+    src="https://stream.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/low.mp4"
+    playsinline
+    muted
+  ></video>
+  <media-fullscreen-button>
+    <span class="my-icon" slot="icon">
+      <span>Enter</span>
+      <span>Exit</span>
+    </span>
+  </media-fullscreen-button>
+</media-controller>`}
+css={`.my-icon {
+  font-size: 16px;
+  font-weight: 700;
+}
+
+media-fullscreen-button:not([mediaisfullscreen]) .my-icon span:last-child,
+media-fullscreen-button[mediaisfullscreen] .my-icon span:first-child {
+  display: none;
+}
+`}
 />
 
 ## Styling with attributes

--- a/docs/src/pages/en/components/media-fullscreen-button.mdx
+++ b/docs/src/pages/en/components/media-fullscreen-button.mdx
@@ -69,11 +69,16 @@ Alternatively, if you would like to represent both states using a single element
 css={`.my-icon {
   font-size: 16px;
   font-weight: 700;
+  transition: color .4s;
 }
 
 media-fullscreen-button:not([mediaisfullscreen]) .my-icon span:last-child,
 media-fullscreen-button[mediaisfullscreen] .my-icon span:first-child {
   display: none;
+}
+
+media-fullscreen-button[mediaisfullscreen] .my-icon {
+  color: coral;
 }
 `}
 />

--- a/docs/src/pages/en/components/media-pip-button.mdx
+++ b/docs/src/pages/en/components/media-pip-button.mdx
@@ -9,9 +9,11 @@ import SandpackContainer from "../../../components/SandpackContainer.astro";
 
 The `<media-pip-button>` component is used to toggle the picture-in-picture mode of the video.
 
-The contents and behavior of the `<media-pip-button>` will update automatically based on the PiP state and availability.
-- When the media is not in PiP mode, the component will switch to display the contents of the `enter` slot.
-- When the media is PiP mode, the component will switch to display the contents of the `exit` slot.
+The contents of `<media-pip-button>` will update based on the PiP state and availability.
+- When the media is not in PiP mode, the component will display the contents of the `enter` slot.
+- When the media is PiP mode, the component will display the contents of the `exit` slot.
+
+> NOTE: picture-in-picture support isn't available in all browsers. Interacting with these examples may not do anything when support isn't available.
 
 ## Default usage
 
@@ -28,8 +30,7 @@ The contents and behavior of the `<media-pip-button>` will update automatically 
 
 ## Customize icons
 
-You can modify the contents of the `<media-pip-button>` component using slots.
-This is useful if you'd like to use your own custom PiP button instead of the default one provided by media-chrome.
+You can modify the contents of the `<media-pip-button>` component using slots. This is useful if you'd like to use your own custom PiP icon instead of the default one provided by media-chrome.
 
 Here's an example of how you can replace the default PiP icons with the words "Enter" and "Exit"
 
@@ -46,6 +47,37 @@ Here's an example of how you can replace the default PiP icons with the words "E
     <span slot="exit">Exit</span>
   </media-pip-button>
 </media-controller>`}
+/>
+
+Alternatively, if you would like to represent both states using a single element you could use the `icon` slot instead. This is useful for creating an animated icon that transitions between states. Here's a basic example that uses CSS to change an element based on the picture-in-picture state.
+
+<SandpackContainer
+  height={365}
+  active="css"
+  html={`<media-controller>
+  <video
+    slot="media"
+    src="https://stream.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/low.mp4"
+    playsinline
+    muted
+  ></video>
+  <media-pip-button>
+    <span class="my-icon" slot="icon">
+      <span>Enter</span>
+      <span>Exit</span>
+    </span>
+  </media-pip-button>
+</media-controller>`}
+css={`.my-icon {
+  font-size: 16px;
+  font-weight: 700;
+}
+
+media-pip-button:not([mediaispip]) .my-icon span:last-child,
+media-pip-button[mediaispip] .my-icon span:first-child {
+  display: none;
+}
+`}
 />
 
 ## Styling with attributes

--- a/docs/src/pages/en/components/media-pip-button.mdx
+++ b/docs/src/pages/en/components/media-pip-button.mdx
@@ -71,11 +71,16 @@ Alternatively, if you would like to represent both states using a single element
 css={`.my-icon {
   font-size: 16px;
   font-weight: 700;
+  transition: color .4s;
 }
 
 media-pip-button:not([mediaispip]) .my-icon span:last-child,
 media-pip-button[mediaispip] .my-icon span:first-child {
   display: none;
+}
+
+media-pip-button[mediaispip] .my-icon {
+  color: coral;
 }
 `}
 />

--- a/docs/src/pages/en/components/media-play-button.mdx
+++ b/docs/src/pages/en/components/media-play-button.mdx
@@ -7,13 +7,11 @@ source: https://github.com/muxinc/media-chrome/tree/main/src/js/media-play-butto
 
 import SandpackContainer from "../../../components/SandpackContainer.astro";
 
-The `<media-play-button>` component is used to toggle your media playback state.  
-In simpler terms, it is used to both play and pause your media content.
+The `<media-play-button>` component is used to toggle playback of the media content.
 
-The contents and behavior of the `<media-play-button>` will update automatically 
-once your media playback state changes.
-  - When your media begins to play, the component will switch to show the contents of its `pause` slot.
-  - When your media is paused, the component will display the contents of its `play` slot.
+The contents of the `<media-play-button>` will update when the media playback state changes.
+- When the media is playing, the component will display the contents of its `pause` slot.
+- When the media is paused, the component will display the contents of its `play` slot.
 
 ## Default usage
 
@@ -31,12 +29,9 @@ once your media playback state changes.
 
 ## Customize icons
 
-You can modify the contents of the `<media-play-button>` component using slots. 
-This is useful if you'd like to use your own custom play button instead of 
-the default one provided by media-chrome.
+You can modify the contents of the `<media-play-button>` component using slots. This is useful if you'd like to use your own custom icons instead of the default ones provided by media-chrome.
 
-Here's an example of how you can replace the default play and pause icons with 
-the literal words "Play" and "Pause":  
+Here's an example of how you can replace the default play and pause icons with the literal words "Play" and "Pause":  
 
 <SandpackContainer
   editorHeight={270}
@@ -54,6 +49,40 @@ the literal words "Play" and "Pause":
 </media-controller>`}
 />
 
+Alternatively, if you would like to represent both states using a single element you could use the `icon` slot instead. This is useful for creating an animated icon that transitions between states. Here's a basic example that uses CSS to change an element based on the play state.
+
+<SandpackContainer
+  height={365}
+  active="css"
+  html={`<media-controller>
+  <video
+    slot="media"
+    src="https://stream.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/low.mp4"
+    playsinline
+    muted
+  ></video>
+  <media-play-button>
+    <span class="my-icon" slot="icon">
+      <span>Play</span>
+      <span>Pause</span>
+    </span>
+  </media-play-button>
+</media-controller>`}
+css={`.my-icon {
+  font-weight: bold;
+  transition: color .4s;
+}
+
+media-play-button:not([mediapaused]) .my-icon span:first-child,
+media-play-button[mediapaused] .my-icon span:last-child {
+  display: none;
+}
+
+media-play-button:not([mediapaused]) .my-icon {
+  color: purple;
+}
+`}
+/>
 
 ## Styling with attributes
 

--- a/docs/src/pages/en/components/media-play-button.mdx
+++ b/docs/src/pages/en/components/media-play-button.mdx
@@ -79,7 +79,7 @@ media-play-button[mediapaused] .my-icon span:last-child {
 }
 
 media-play-button:not([mediapaused]) .my-icon {
-  color: purple;
+  color: coral;
 }
 `}
 />

--- a/examples/vanilla/animated-icons.html
+++ b/examples/vanilla/animated-icons.html
@@ -67,6 +67,16 @@
         outline: 2px solid green;
         color: green;
       }
+
+      .fullscreen-icon {
+        font-size: 16px;
+        font-weight: 700;
+      }
+
+      media-fullscreen-button:not([mediaisfullscreen]) .fullscreen-icon span:last-child,
+      media-fullscreen-button[mediaisfullscreen] .fullscreen-icon span:first-child {
+        display: none;
+      }
     </style>
   </head>
   <body>
@@ -116,7 +126,12 @@
             <span class="cast-icon" slot="icon">[ ]</span>
           </media-cast-button>
           <media-pip-button></media-pip-button>
-          <media-fullscreen-button></media-fullscreen-button>
+          <media-fullscreen-button>
+            <span class="fullscreen-icon" slot="icon">
+              <span>+</span>
+              <span>-</span>
+            </span>
+          </media-fullscreen-button>
         </media-control-bar>
       </media-controller>
       <div class="examples">

--- a/examples/vanilla/animated-icons.html
+++ b/examples/vanilla/animated-icons.html
@@ -19,7 +19,6 @@
         margin-top: 20px;
       }
 
-      /* Mute icon simple animation */
       .mute-icon {
         display: inline-block;
         
@@ -57,6 +56,17 @@
         text-decoration: underline;
         color: red;
       }
+
+      .cast-icon {
+        border-radius: 4px;
+        outline: 2px solid #fff;
+        padding: 0 6px;
+      }
+
+      media-cast-button[mediaiscasting] .cast-icon {
+        outline: 2px solid green;
+        color: green;
+      }
     </style>
   </head>
   <body>
@@ -74,8 +84,6 @@
         </video>
         <media-control-bar>
           <media-play-button></media-play-button>
-          <media-seek-backward-button></media-seek-backward-button>
-          <media-seek-forward-button></media-seek-forward-button>
           <media-mute-button>
             <svg viewBox="0 0 18 14" slot="icon" class="mute-icon">
               <g class="unmuted">
@@ -104,6 +112,9 @@
           <media-captions-button>
             <span class="captions-icon" slot="icon">CC</span>
           </media-captions-button>
+          <media-cast-button>
+            <span class="cast-icon" slot="icon">[ ]</span>
+          </media-cast-button>
           <media-pip-button></media-pip-button>
           <media-fullscreen-button></media-fullscreen-button>
         </media-control-bar>

--- a/examples/vanilla/animated-icons.html
+++ b/examples/vanilla/animated-icons.html
@@ -88,6 +88,19 @@
       media-pip-button[mediaispip] .pip-icon {
         background: maroon;
       }
+
+      .play-icon {
+        font-weight: bold;
+      }
+
+      media-play-button:not([mediapaused]) .play-icon span:first-child,
+      media-play-button[mediapaused] .play-icon span:last-child {
+        display: none;
+      }
+
+      media-play-button:not([mediapaused]) .my-icon {
+        color: purple;
+      }
     </style>
   </head>
   <body>
@@ -104,7 +117,12 @@
           <track label="English" kind="captions" srclang="en" src='https://media-chrome.mux.dev/examples/vanilla/vtt/en-cc.vtt' />
         </video>
         <media-control-bar>
-          <media-play-button></media-play-button>
+          <media-play-button>
+            <span class="play-icon" slot="icon">
+              <span>play</span>
+              <span>pause</span>
+            </span>
+          </media-play-button>
           <media-mute-button>
             <svg viewBox="0 0 18 14" slot="icon" class="mute-icon">
               <g class="unmuted">

--- a/examples/vanilla/animated-icons.html
+++ b/examples/vanilla/animated-icons.html
@@ -15,13 +15,6 @@
         width: 100%;
       }
 
-      media-airplay-button[mediaairplayunavailable],
-      media-fullscreen-button[mediafullscreenunavailable],
-      media-volume-range[mediavolumeunavailable],
-      media-pip-button[mediapipunavailable] {
-        display: none;
-      }
-
       .examples {
         margin-top: 20px;
       }
@@ -52,19 +45,33 @@
       media-mute-button[mediavolumelevel='off'] .muted {
         opacity: 1;
       }
+
+      .captions-icon {
+        transition: all .5s;
+        font-weight: 400;
+        border-radius: 5px;
+      }
+
+      media-captions-button[aria-checked=true] .captions-icon {
+        font-weight: 700;
+        text-decoration: underline;
+        color: red;
+      }
     </style>
   </head>
   <body>
     <main>
       <h1>Media Chrome Animated Icons Usage Example</h1>
-      <media-controller>
+      <media-controller defaultsubtitles>
         <video
           slot="media"
           src="https://stream.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/high.mp4"
           muted
           crossorigin
           playsinline
-        ></video>
+        >
+          <track label="English" kind="captions" srclang="en" src='https://media-chrome.mux.dev/examples/vanilla/vtt/en-cc.vtt' />
+        </video>
         <media-control-bar>
           <media-play-button></media-play-button>
           <media-seek-backward-button></media-seek-backward-button>
@@ -94,11 +101,11 @@
           <media-volume-range></media-volume-range>
           <media-time-range></media-time-range>
           <media-time-display showduration remaining></media-time-display>
-          <media-captions-button></media-captions-button>
-          <media-playback-rate-button></media-playback-rate-button>
+          <media-captions-button>
+            <span class="captions-icon" slot="icon">CC</span>
+          </media-captions-button>
           <media-pip-button></media-pip-button>
           <media-fullscreen-button></media-fullscreen-button>
-          <media-airplay-button></media-airplay-button>
         </media-control-bar>
       </media-controller>
       <div class="examples">

--- a/examples/vanilla/animated-icons.html
+++ b/examples/vanilla/animated-icons.html
@@ -61,6 +61,7 @@
         border-radius: 4px;
         outline: 2px solid #fff;
         padding: 0 6px;
+        transition: all .4s;
       }
 
       media-cast-button[mediaiscasting] .cast-icon {
@@ -71,11 +72,16 @@
       .fullscreen-icon {
         font-size: 16px;
         font-weight: 700;
+        transition: color .4s;
       }
 
       media-fullscreen-button:not([mediaisfullscreen]) .fullscreen-icon span:last-child,
       media-fullscreen-button[mediaisfullscreen] .fullscreen-icon span:first-child {
         display: none;
+      }
+
+      media-fullscreen-button[mediaisfullscreen] .fullscreen-icon {
+        color: coral;
       }
 
       .pip-icon {
@@ -98,7 +104,7 @@
         display: none;
       }
 
-      media-play-button:not([mediapaused]) .my-icon {
+      media-play-button:not([mediapaused]) .play-icon {
         color: purple;
       }
     </style>

--- a/examples/vanilla/animated-icons.html
+++ b/examples/vanilla/animated-icons.html
@@ -77,6 +77,17 @@
       media-fullscreen-button[mediaisfullscreen] .fullscreen-icon span:first-child {
         display: none;
       }
+
+      .pip-icon {
+        background: darkcyan;
+        border-radius: 50%;
+        width: 24px;
+        transition: all .5s;
+      }
+
+      media-pip-button[mediaispip] .pip-icon {
+        background: maroon;
+      }
     </style>
   </head>
   <body>
@@ -125,7 +136,9 @@
           <media-cast-button>
             <span class="cast-icon" slot="icon">[ ]</span>
           </media-cast-button>
-          <media-pip-button></media-pip-button>
+          <media-pip-button>
+            <span class="pip-icon" slot="icon">PiP</span>
+          </media-pip-button>
           <media-fullscreen-button>
             <span class="fullscreen-icon" slot="icon">
               <span>+</span>

--- a/src/js/media-captions-button.js
+++ b/src/js/media-captions-button.js
@@ -20,20 +20,20 @@ const ccIconOff = `<svg aria-hidden="true" viewBox="0 0 26 24">
 const slotTemplate = document.createElement('template');
 slotTemplate.innerHTML = /*html*/ `
   <style>
-  :host([aria-checked="true"]) slot:not([name=on]) > *,
-  :host([aria-checked="true"]) ::slotted(:not([slot=on])) {
-    display: none !important;
-  }
+    :host([aria-checked="true"]) slot[name=off] {
+      display: none !important;
+    }
 
-  ${/* Double negative, but safer if display doesn't equal 'block' */ ''}
-  :host(:not([aria-checked="true"])) slot:not([name=off]) > *,
-  :host(:not([aria-checked="true"])) ::slotted(:not([slot=off])) {
-    display: none !important;
-  }
+    ${/* Double negative, but safer if display doesn't equal 'block' */ ''}
+    :host(:not([aria-checked="true"])) slot[name=on] {
+      display: none !important;
+    }
   </style>
-
-  <slot name="on">${ccIconOn}</slot>
-  <slot name="off">${ccIconOff}</slot>
+  
+  <slot name="icon">
+    <slot name="on">${ccIconOn}</slot>
+    <slot name="off">${ccIconOff}</slot>
+  </slot>
 `;
 
 const updateAriaChecked = (el) => {
@@ -74,6 +74,7 @@ const setSubtitlesListAttr = (el, attrName, list) => {
 /**
  * @slot on - An element that will be shown while closed captions or subtitles are on.
  * @slot off - An element that will be shown while closed captions or subtitles are off.
+ * @slot icon - An element for representing on and off states in a single icon
  *
  * @attr {string} mediasubtitleslist - (read-only) A list of all subtitles and captions.
  * @attr {string} mediasubtitlesshowing - (read-only) A list of the showing subtitles and captions.

--- a/src/js/media-cast-button.js
+++ b/src/js/media-cast-button.js
@@ -41,7 +41,7 @@ const updateAriaLabel = (el) => {
 /**
  * @slot enter - An element shown when the media is not in casting mode and pressing the button will open the Cast menu.
  * @slot exit - An element shown when the media is in casting mode and pressing the button will trigger exiting casting mode.
- * @slot icon - An element for representing enter and exist states in a single icon
+ * @slot icon - An element for representing enter and exit states in a single icon
  *
  * @attr {(unavailable|unsupported)} mediacastunavailable - (read-only) Set if casting is unavailable.
  * @attr {boolean} mediaiscasting - (read-only) Present if the media is casting.

--- a/src/js/media-cast-button.js
+++ b/src/js/media-cast-button.js
@@ -16,24 +16,20 @@ const exitIcon = `<svg aria-hidden="true" viewBox="0 0 24 24"><g><path class="ca
 const slotTemplate = document.createElement('template');
 slotTemplate.innerHTML = /*html*/ `
   <style>
-  :host([${MediaUIAttributes.MEDIA_IS_CASTING}]) slot:not([name=exit]) > *,
-  :host([${MediaUIAttributes.MEDIA_IS_CASTING}]) ::slotted(:not([slot=exit])) {
+  :host([${MediaUIAttributes.MEDIA_IS_CASTING}]) slot:not([name=exit]):not([name=icon]) {
     display: none !important;
   }
 
   ${/* Double negative, but safer if display doesn't equal 'block' */ ''}
-  :host(:not([${
-    MediaUIAttributes.MEDIA_IS_CASTING
-  }])) slot:not([name=enter]) > *,
-  :host(:not([${
-    MediaUIAttributes.MEDIA_IS_CASTING
-  }])) ::slotted(:not([slot=enter])) {
+  :host(:not([${MediaUIAttributes.MEDIA_IS_CASTING}])) slot:not([name=enter]):not([name=icon]) {
     display: none !important;
   }
   </style>
 
-  <slot name="enter">${enterIcon}</slot>
-  <slot name="exit">${exitIcon}</slot>
+  <slot name="icon">
+    <slot name="enter">${enterIcon}</slot>
+    <slot name="exit">${exitIcon}</slot>
+  </slot>
 `;
 
 const updateAriaLabel = (el) => {
@@ -45,6 +41,7 @@ const updateAriaLabel = (el) => {
 /**
  * @slot enter - An element shown when the media is not in casting mode and pressing the button will open the Cast menu.
  * @slot exit - An element shown when the media is in casting mode and pressing the button will trigger exiting casting mode.
+ * @slot icon - An element for representing enter and exist states in a single icon
  *
  * @attr {(unavailable|unsupported)} mediacastunavailable - (read-only) Set if casting is unavailable.
  * @attr {boolean} mediaiscasting - (read-only) Present if the media is casting.

--- a/src/js/media-fullscreen-button.js
+++ b/src/js/media-fullscreen-button.js
@@ -28,26 +28,20 @@ const exitFullscreenIcon = `<svg aria-hidden="true" viewBox="0 0 26 24">
 const slotTemplate = document.createElement('template');
 slotTemplate.innerHTML = /*html*/ `
   <style>
-  :host([${MediaUIAttributes.MEDIA_IS_FULLSCREEN}]) slot:not([name=exit]) > *,
-  :host([${
-    MediaUIAttributes.MEDIA_IS_FULLSCREEN
-  }]) ::slotted(:not([slot=exit])) {
+  :host([${MediaUIAttributes.MEDIA_IS_FULLSCREEN}]) slot:not([name=exit]):not([name=icon]) {
     display: none !important;
   }
 
   ${/* Double negative, but safer if display doesn't equal 'block' */ ''}
-  :host(:not([${
-    MediaUIAttributes.MEDIA_IS_FULLSCREEN
-  }])) slot:not([name=enter]) > *,
-  :host(:not([${
-    MediaUIAttributes.MEDIA_IS_FULLSCREEN
-  }])) ::slotted(:not([slot=enter])) {
+  :host(:not([${MediaUIAttributes.MEDIA_IS_FULLSCREEN}])) slot:not([name=enter]):not([name=icon]) {
     display: none !important;
   }
   </style>
 
-  <slot name="enter">${enterFullscreenIcon}</slot>
-  <slot name="exit">${exitFullscreenIcon}</slot>
+  <slot name="icon">
+    <slot name="enter">${enterFullscreenIcon}</slot>
+    <slot name="exit">${exitFullscreenIcon}</slot>
+  </slot>
 `;
 
 const updateAriaLabel = (el) => {
@@ -60,6 +54,7 @@ const updateAriaLabel = (el) => {
 /**
  * @slot enter - An element shown when the media is not in fullscreen and pressing the button will trigger entering fullscreen.
  * @slot exit - An element shown when the media is in fullscreen and pressing the button will trigger exiting fullscreen.
+ * @slot icon - An element for representing enter and exist states in a single icon
  *
  * @attr {(unavailable|unsupported)} mediafullscreenunavailable - (read-only) Set if fullscreen is unavailable.
  * @attr {boolean} mediaisfullscreen - (read-only) Present if the media is fullscreen.

--- a/src/js/media-fullscreen-button.js
+++ b/src/js/media-fullscreen-button.js
@@ -54,7 +54,7 @@ const updateAriaLabel = (el) => {
 /**
  * @slot enter - An element shown when the media is not in fullscreen and pressing the button will trigger entering fullscreen.
  * @slot exit - An element shown when the media is in fullscreen and pressing the button will trigger exiting fullscreen.
- * @slot icon - An element for representing enter and exist states in a single icon
+ * @slot icon - An element for representing enter and exit states in a single icon
  *
  * @attr {(unavailable|unsupported)} mediafullscreenunavailable - (read-only) Set if fullscreen is unavailable.
  * @attr {boolean} mediaisfullscreen - (read-only) Present if the media is fullscreen.

--- a/src/js/media-pip-button.js
+++ b/src/js/media-pip-button.js
@@ -40,7 +40,7 @@ const updateAriaLabel = (el) => {
 /**
  * @slot enter - An element shown when the media is not in PIP mode and pressing the button will trigger entering PIP mode.
  * @slot exit - An element shown when the media is in PIP and pressing the button will trigger exiting PIP mode.
- * @slot icon - An element for representing enter and exist states in a single icon
+ * @slot icon - An element for representing enter and exit states in a single icon
  *
  * @attr {(unavailable|unsupported)} mediapipunavailable - (read-only) Set if picture-in-picture is unavailable.
  * @attr {boolean} mediaispip - (read-only) Present if the media is playing in picture-in-picture.

--- a/src/js/media-pip-button.js
+++ b/src/js/media-pip-button.js
@@ -16,22 +16,20 @@ const pipIcon = `<svg aria-hidden="true" viewBox="0 0 28 24">
 const slotTemplate = document.createElement('template');
 slotTemplate.innerHTML = /*html*/ `
   <style>
-  :host([${MediaUIAttributes.MEDIA_IS_PIP}]) slot:not([name=exit]) > *, 
-  :host([${MediaUIAttributes.MEDIA_IS_PIP}]) ::slotted(:not([slot=exit])) {
+  :host([${MediaUIAttributes.MEDIA_IS_PIP}]) slot:not([name=exit]):not([name=icon]) {
     display: none !important;
   }
 
   ${/* Double negative, but safer if display doesn't equal 'block' */ ''}
-  :host(:not([${MediaUIAttributes.MEDIA_IS_PIP}])) slot:not([name=enter]) > *, 
-  :host(:not([${
-    MediaUIAttributes.MEDIA_IS_PIP
-  }])) ::slotted(:not([slot=enter])) {
+  :host(:not([${MediaUIAttributes.MEDIA_IS_PIP}])) slot:not([name=enter]):not([name=icon]) {
     display: none !important;
   }
   </style>
 
-  <slot name="enter">${pipIcon}</slot>
-  <slot name="exit">${pipIcon}</slot>
+  <slot name="icon">
+    <slot name="enter">${pipIcon}</slot>
+    <slot name="exit">${pipIcon}</slot>
+  </slot>
 `;
 
 const updateAriaLabel = (el) => {
@@ -42,6 +40,7 @@ const updateAriaLabel = (el) => {
 /**
  * @slot enter - An element shown when the media is not in PIP mode and pressing the button will trigger entering PIP mode.
  * @slot exit - An element shown when the media is in PIP and pressing the button will trigger exiting PIP mode.
+ * @slot icon - An element for representing enter and exist states in a single icon
  *
  * @attr {(unavailable|unsupported)} mediapipunavailable - (read-only) Set if picture-in-picture is unavailable.
  * @attr {boolean} mediaispip - (read-only) Present if the media is playing in picture-in-picture.

--- a/src/js/media-play-button.js
+++ b/src/js/media-play-button.js
@@ -15,19 +15,19 @@ const pauseIcon = `<svg aria-hidden="true" viewBox="0 0 24 24">
 const slotTemplate = document.createElement('template');
 slotTemplate.innerHTML = /*html*/ `
   <style>
-  :host([${MediaUIAttributes.MEDIA_PAUSED}]) slot[name=pause] > *, 
-  :host([${MediaUIAttributes.MEDIA_PAUSED}]) ::slotted([slot=pause]) {
+  :host([${MediaUIAttributes.MEDIA_PAUSED}]) slot[name=pause] {
     display: none !important;
   }
 
-  :host(:not([${MediaUIAttributes.MEDIA_PAUSED}])) slot[name=play] > *, 
-  :host(:not([${MediaUIAttributes.MEDIA_PAUSED}])) ::slotted([slot=play]) {
+  :host(:not([${MediaUIAttributes.MEDIA_PAUSED}])) slot[name=play] {
     display: none !important;
   }
   </style>
 
-  <slot name="play">${playIcon}</slot>
-  <slot name="pause">${pauseIcon}</slot>
+  <slot name="icon">
+    <slot name="play">${playIcon}</slot>
+    <slot name="pause">${pauseIcon}</slot>
+  </slot>
 `;
 
 const updateAriaLabel = (el) => {
@@ -38,6 +38,7 @@ const updateAriaLabel = (el) => {
 /**
  * @slot play - An element shown when the media is paused and pressing the button will start media playback.
  * @slot pause - An element shown when the media is playing and pressing the button will pause media playback.
+ * @slot icon - An element for representing play and pause states in a single icon
  *
  * @attr {boolean} mediapaused - (read-only) Present if the media is paused.
  *


### PR DESCRIPTION
Adds an optional `icon` slot to buttons with multiple available slots e.g. Captions, Cast, Fullscreen, PiP and Play.

Updates docs with basic examples of usage. There's also a new `animated-icons.html` in the examples folder but this also currently has very basic examples to allow us to check the slots work as expected. We can expand this in the future with fancier animated demos.