### PR TITLE
feat: media-icon experiment

### DIFF
--- a/examples/vanilla/control-elements/media-icon.html
+++ b/examples/vanilla/control-elements/media-icon.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width" />
+    <script type="module" src="../../../src/js/icons/default.js"></script>
+    <script type="module" src="../../../src/js/experimental/media-icon.js"></script>
+  </head>
+  <body>
+    <h1>&lt;media-icon&gt;</h1>
+
+    <style>
+      media-icon {
+        font-size: 2rem;
+        color: springgreen;
+      }
+    </style>
+
+    <media-icon name="play"></media-icon>
+    <media-icon name="pause"></media-icon>
+    <media-icon name="fullscreen-enter"></media-icon>
+    <media-icon name="fullscreen-exit"></media-icon>
+  </body>
+</html>

--- a/src/js/experimental/media-icon.js
+++ b/src/js/experimental/media-icon.js
@@ -1,0 +1,72 @@
+import { window, document } from '../utils/server-safe-globals.js';
+import { getIcons } from '../icons/registry.js';
+
+const template = document.createElement('template');
+template.innerHTML = /*html*/`
+  <style>
+    :host {
+      display: inline-block;
+      line-height: 0;
+    }
+  </style>
+`;
+
+class MediaIcon extends window.HTMLElement {
+  static observedAttributes = ['icons', 'name'];
+
+  constructor() {
+    super();
+
+    if (!this.shadowRoot) {
+      // Set up the Shadow DOM if not using Declarative Shadow DOM.
+      this.attachShadow({ mode: 'open' });
+      this.shadowRoot.append(template.content.cloneNode(true));
+    }
+  }
+
+  get icons() {
+    return this.getAttribute('icons') ?? 'default';
+  }
+
+  set icons(val) {
+    this.setAttribute('icons', val);
+  }
+
+  get name() {
+    return this.getAttribute('name');
+  }
+
+  set name(val) {
+    this.setAttribute('name', val);
+  }
+
+  attributeChangedCallback(attrName, oldValue, newValue) {
+    if (oldValue != newValue) {
+      this.renderIcon();
+    }
+  }
+
+  async renderIcon() {
+    const iconSet = getIcons(this.icons);
+    if (iconSet) {
+
+      const html = await iconSet.resolver(this.name);
+      const template = document.createElement('template');
+      template.innerHTML = html;
+
+      const icon = template.content.firstElementChild;
+      if (iconSet.mutator) {
+        await iconSet.mutator(icon);
+      }
+
+      this.shadowRoot.querySelector(':host > :not(style)')?.remove();
+      this.shadowRoot.append(icon);
+    }
+  }
+}
+
+if (!window.customElements.get('media-icon')) {
+  window.customElements.define('media-icon', MediaIcon);
+}
+
+export default MediaIcon;

--- a/src/js/icons/default.js
+++ b/src/js/icons/default.js
@@ -1,0 +1,122 @@
+import { registerIcons } from './registry.js';
+
+export const play = /*html*/`
+  <svg viewBox="0 0 24 24">
+    <path d="m6 21 15-9L6 3v18Z"/>
+  </svg>`;
+
+export const pause = /*html*/`
+  <svg viewBox="0 0 24 24">
+    <path d="M6 20h4V4H6v16Zm8-16v16h4V4h-4Z"/>
+  </svg>`;
+
+export const seekBackward = /*html*/`
+  <svg viewBox="0 0 20 24">
+    <defs><style>.text{font-size:8px;font-family:Arial-BoldMT, Arial;font-weight:700;}</style></defs><text class="text value" transform="translate(2.18 19.87)">30</text><path d="M10 6V3L4.37 7 10 10.94V8a5.54 5.54 0 0 1 1.9 10.48v2.12A7.5 7.5 0 0 0 10 6Z"/>
+  </svg>`;
+
+export const seekForward = /*html*/`
+  <svg viewBox="0 0 20 24">
+    <defs><style>.text{font-size:8px;font-family:Arial-BoldMT, Arial;font-weight:700;}</style></defs><text class="text value" transform="translate(8.9 19.87)">30</text><path d="M10 6V3l5.61 4L10 10.94V8a5.54 5.54 0 0 0-1.9 10.48v2.12A7.5 7.5 0 0 1 10 6Z"/>
+  </svg>`;
+
+export const volumeOff = /*html*/`
+  <svg viewBox="0 0 24 24">
+    <path d="M16.5 12A4.5 4.5 0 0 0 14 8v2.18l2.45 2.45a4.22 4.22 0 0 0 .05-.63Zm2.5 0a6.84 6.84 0 0 1-.54 2.64L20 16.15A8.8 8.8 0 0 0 21 12a9 9 0 0 0-7-8.77v2.06A7 7 0 0 1 19 12ZM4.27 3 3 4.27 7.73 9H3v6h4l5 5v-6.73l4.25 4.25A6.92 6.92 0 0 1 14 18.7v2.06A9 9 0 0 0 17.69 19l2 2.05L21 19.73l-9-9L4.27 3ZM12 4 9.91 6.09 12 8.18V4Z"/>
+  </svg>`;
+
+export const volumeLow = /*html*/`
+  <svg viewBox="0 0 24 24">
+    <path d="M3 9v6h4l5 5V4L7 9H3Zm13.5 3A4.5 4.5 0 0 0 14 8v8a4.47 4.47 0 0 0 2.5-4Z"/>
+  </svg>`;
+
+export const volumeMedium = /*html*/`
+  <svg viewBox="0 0 24 24">
+    <path d="M3 9v6h4l5 5V4L7 9H3Zm13.5 3A4.5 4.5 0 0 0 14 8v8a4.47 4.47 0 0 0 2.5-4Z"/>
+  </svg>`;
+
+export const volumeHigh = /*html*/`
+  <svg viewBox="0 0 24 24">
+    <path d="M3 9v6h4l5 5V4L7 9H3Zm13.5 3A4.5 4.5 0 0 0 14 8v8a4.47 4.47 0 0 0 2.5-4ZM14 3.23v2.06a7 7 0 0 1 0 13.42v2.06a9 9 0 0 0 0-17.54Z"/>
+  </svg>`;
+
+export const captionsOn = /*html*/`
+  <svg viewBox="0 0 26 24">
+    <path d="M22.83 5.68a2.58 2.58 0 0 0-2.3-2.5c-3.62-.24-11.44-.24-15.06 0a2.58 2.58 0 0 0-2.3 2.5c-.23 4.21-.23 8.43 0 12.64a2.58 2.58 0 0 0 2.3 2.5c3.62.24 11.44.24 15.06 0a2.58 2.58 0 0 0 2.3-2.5c.23-4.21.23-8.43 0-12.64Zm-11.39 9.45a3.07 3.07 0 0 1-1.91.57 3.06 3.06 0 0 1-2.34-1 3.75 3.75 0 0 1-.92-2.67 3.92 3.92 0 0 1 .92-2.77 3.18 3.18 0 0 1 2.43-1 2.94 2.94 0 0 1 2.13.78c.364.359.62.813.74 1.31l-1.43.35a1.49 1.49 0 0 0-1.51-1.17 1.61 1.61 0 0 0-1.29.58 2.79 2.79 0 0 0-.5 1.89 3 3 0 0 0 .49 1.93 1.61 1.61 0 0 0 1.27.58 1.48 1.48 0 0 0 1-.37 2.1 2.1 0 0 0 .59-1.14l1.4.44a3.23 3.23 0 0 1-1.07 1.69Zm7.22 0a3.07 3.07 0 0 1-1.91.57 3.06 3.06 0 0 1-2.34-1 3.75 3.75 0 0 1-.92-2.67 3.88 3.88 0 0 1 .93-2.77 3.14 3.14 0 0 1 2.42-1 3 3 0 0 1 2.16.82 2.8 2.8 0 0 1 .73 1.31l-1.43.35a1.49 1.49 0 0 0-1.51-1.21 1.61 1.61 0 0 0-1.29.58A2.79 2.79 0 0 0 15 12a3 3 0 0 0 .49 1.93 1.61 1.61 0 0 0 1.27.58 1.44 1.44 0 0 0 1-.37 2.1 2.1 0 0 0 .6-1.15l1.4.44a3.17 3.17 0 0 1-1.1 1.7Z"/>
+  </svg>`;
+
+export const captionsOff = /*html*/`
+  <svg viewBox="0 0 26 24">
+    <path d="M17.73 14.09a1.4 1.4 0 0 1-1 .37 1.579 1.579 0 0 1-1.27-.58A3 3 0 0 1 15 12a2.8 2.8 0 0 1 .5-1.85 1.63 1.63 0 0 1 1.29-.57 1.47 1.47 0 0 1 1.51 1.2l1.43-.34A2.89 2.89 0 0 0 19 9.07a3 3 0 0 0-2.14-.78 3.14 3.14 0 0 0-2.42 1 3.91 3.91 0 0 0-.93 2.78 3.74 3.74 0 0 0 .92 2.66 3.07 3.07 0 0 0 2.34 1 3.07 3.07 0 0 0 1.91-.57 3.17 3.17 0 0 0 1.07-1.74l-1.4-.45c-.083.43-.3.822-.62 1.12Zm-7.22 0a1.43 1.43 0 0 1-1 .37 1.58 1.58 0 0 1-1.27-.58A3 3 0 0 1 7.76 12a2.8 2.8 0 0 1 .5-1.85 1.63 1.63 0 0 1 1.29-.57 1.47 1.47 0 0 1 1.51 1.2l1.43-.34a2.81 2.81 0 0 0-.74-1.32 2.94 2.94 0 0 0-2.13-.78 3.18 3.18 0 0 0-2.43 1 4 4 0 0 0-.92 2.78 3.74 3.74 0 0 0 .92 2.66 3.07 3.07 0 0 0 2.34 1 3.07 3.07 0 0 0 1.91-.57 3.23 3.23 0 0 0 1.07-1.74l-1.4-.45a2.06 2.06 0 0 1-.6 1.07Zm12.32-8.41a2.59 2.59 0 0 0-2.3-2.51C18.72 3.05 15.86 3 13 3c-2.86 0-5.72.05-7.53.17a2.59 2.59 0 0 0-2.3 2.51c-.23 4.207-.23 8.423 0 12.63a2.57 2.57 0 0 0 2.3 2.5c1.81.13 4.67.19 7.53.19 2.86 0 5.72-.06 7.53-.19a2.57 2.57 0 0 0 2.3-2.5c.23-4.207.23-8.423 0-12.63Zm-1.49 12.53a1.11 1.11 0 0 1-.91 1.11c-1.67.11-4.45.18-7.43.18-2.98 0-5.76-.07-7.43-.18a1.11 1.11 0 0 1-.91-1.11c-.21-4.14-.21-8.29 0-12.43a1.11 1.11 0 0 1 .91-1.11C7.24 4.56 10 4.49 13 4.49s5.76.07 7.43.18a1.11 1.11 0 0 1 .91 1.11c.21 4.14.21 8.29 0 12.43Z"/>
+  </svg>`;
+
+export const pipEnter = /*html*/`
+  <svg viewBox="0 0 28 24">
+    <path d="M24 3H4a1 1 0 0 0-1 1v16a1 1 0 0 0 1 1h20a1 1 0 0 0 1-1V4a1 1 0 0 0-1-1Zm-1 16H5V5h18v14Zm-3-8h-7v5h7v-5Z"/>
+  </svg>`;
+
+export const pipExit = /*html*/`
+  <svg viewBox="0 0 28 24">
+    <path d="M24 3H4a1 1 0 0 0-1 1v16a1 1 0 0 0 1 1h20a1 1 0 0 0 1-1V4a1 1 0 0 0-1-1Zm-1 16H5V5h18v14Zm-3-8h-7v5h7v-5Z"/>
+  </svg>`;
+
+export const airplay = /*html*/`
+  <svg viewBox="0 0 26 24">
+    <path d="M22.13 3H3.87a.87.87 0 0 0-.87.87v13.26a.87.87 0 0 0 .87.87h3.4L9 16H5V5h16v11h-4l1.72 2h3.4a.87.87 0 0 0 .87-.87V3.87a.87.87 0 0 0-.86-.87Zm-8.75 11.44a.5.5 0 0 0-.76 0l-4.91 5.73a.5.5 0 0 0 .38.83h9.82a.501.501 0 0 0 .38-.83l-4.91-5.73Z"/>
+  </svg>`;
+
+export const castEnter = /*html*/`
+  <svg viewBox="0 0 24 24">
+    <g><path class="cast_caf_icon_arch0" d="M1,18 L1,21 L4,21 C4,19.3 2.66,18 1,18 L1,18 Z"/><path class="cast_caf_icon_arch1" d="M1,14 L1,16 C3.76,16 6,18.2 6,21 L8,21 C8,17.13 4.87,14 1,14 L1,14 Z"/><path class="cast_caf_icon_arch2" d="M1,10 L1,12 C5.97,12 10,16.0 10,21 L12,21 C12,14.92 7.07,10 1,10 L1,10 Z"/><path class="cast_caf_icon_box" d="M21,3 L3,3 C1.9,3 1,3.9 1,5 L1,8 L3,8 L3,5 L21,5 L21,19 L14,19 L14,21 L21,21 C22.1,21 23,20.1 23,19 L23,5 C23,3.9 22.1,3 21,3 L21,3 Z"/></g>
+  </svg>`;
+
+export const castExit = /*html*/`
+  <svg viewBox="0 0 24 24">
+    <g><path class="cast_caf_icon_arch0" d="M1,18 L1,21 L4,21 C4,19.3 2.66,18 1,18 L1,18 Z"/><path class="cast_caf_icon_arch1" d="M1,14 L1,16 C3.76,16 6,18.2 6,21 L8,21 C8,17.13 4.87,14 1,14 L1,14 Z"/><path class="cast_caf_icon_arch2" d="M1,10 L1,12 C5.97,12 10,16.0 10,21 L12,21 C12,14.92 7.07,10 1,10 L1,10 Z"/><path class="cast_caf_icon_box" d="M21,3 L3,3 C1.9,3 1,3.9 1,5 L1,8 L3,8 L3,5 L21,5 L21,19 L14,19 L14,21 L21,21 C22.1,21 23,20.1 23,19 L23,5 C23,3.9 22.1,3 21,3 L21,3 Z"/><path class="cast_caf_icon_boxfill" d="M5,7 L5,8.63 C8,8.6 13.37,14 13.37,17 L19,17 L19,7 Z"/></g>
+  </svg>`;
+
+export const fullscreenEnter = /*html*/`
+  <svg viewBox="0 0 26 24">
+    <path d="M16 3v2.5h3.5V9H22V3h-6ZM4 9h2.5V5.5H10V3H4v6Zm15.5 9.5H16V21h6v-6h-2.5v3.5ZM6.5 15H4v6h6v-2.5H6.5V15Z"/>
+  </svg>`;
+
+export const fullscreenExit = /*html*/`
+  <svg viewBox="0 0 26 24">
+    <path d="M18.5 6.5V3H16v6h6V6.5h-3.5ZM16 21h2.5v-3.5H22V15h-6v6ZM4 17.5h3.5V21H10v-6H4v2.5Zm3.5-11H4V9h6V3H7.5v3.5Z"/>
+  </svg>`;
+
+
+const icons = {
+  play,
+  pause,
+  seekBackward,
+  seekForward,
+  volumeOff,
+  volumeLow,
+  volumeMedium,
+  volumeHigh,
+  captionsOn,
+  captionsOff,
+  pipEnter,
+  pipExit,
+  airplay,
+  castEnter,
+  castExit,
+  fullscreenEnter,
+  fullscreenExit,
+};
+
+registerIcons('default', {
+  resolver: (name) => {
+    return icons[camelCase(name)];
+  },
+  mutator: svg => {
+    svg.setAttribute('aria-hidden', 'true');
+    svg.setAttribute('height', '1em');
+    svg.setAttribute('fill', 'currentColor');
+  }
+});
+
+function camelCase(name) {
+  return name.replace(/[-_]([a-z])/g, ($0, $1) => $1.toUpperCase());
+}

--- a/src/js/icons/registry.js
+++ b/src/js/icons/registry.js
@@ -1,0 +1,10 @@
+
+const iconSets = {};
+
+export function registerIcons(name, options) {
+  iconSets[name] = options;
+}
+
+export function getIcons(name) {
+  return iconSets[name];
+}


### PR DESCRIPTION
Related discussion https://github.com/muxinc/media-chrome/discussions/470

test url: https://media-chrome-git-fork-luwes-media-icon-mux.vercel.app/examples/vanilla/control-elements/media-icon.html

a quick experiment on how there could be icon packs as a module import and consumable with a new `<media-icon>` custom element. 

the resolver callback lets you request the single icon however you want. 

I've implemented the default icon set as a JSON map but it could also be an url request for each icon or a querySelector in a template element holding each SVG element.

it does add some complexity, I'm not fully convinced it's worth it. 
maybe it's best left to the theme developer.