### PR TITLE
feat: Add preview chapter state support (WIP).

### DIFF
--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -77,6 +77,7 @@ export const MediaUIAttributes = {
   MEDIA_PREVIEW_TIME: 'mediapreviewtime',
   MEDIA_PREVIEW_IMAGE: 'mediapreviewimage',
   MEDIA_PREVIEW_COORDS: 'mediapreviewcoords',
+  MEDIA_PREVIEW_CHAPTER: 'mediapreviewchapter',
   MEDIA_LOADING: 'medialoading',
   MEDIA_BUFFERED: 'mediabuffered',
   MEDIA_STREAM_TYPE: 'mediastreamtype',

--- a/src/js/controller.js
+++ b/src/js/controller.js
@@ -685,8 +685,12 @@ export const MediaUIRequestHandlers = {
       kind: TextTrackKinds.METADATA,
       label: 'thumbnails',
     });
+
+    const [chaptersTrack] = getTextTracksList(media, {
+      kind: TextTrackKinds.CHAPTERS,
+    });
     // No thumbnails track (yet) or no cues available in thumbnails track, so bail early.
-    if (!(track && track.cues)) return;
+    // if (!(track && track.cues)) return;
 
     // if time is null, then we're done previewing and want to remove the attributes
     if (time === null) {
@@ -698,25 +702,40 @@ export const MediaUIRequestHandlers = {
         MediaUIAttributes.MEDIA_PREVIEW_COORDS,
         undefined
       );
+      controller.propagateMediaState(
+        MediaUIAttributes.MEDIA_PREVIEW_CHAPTER,
+        undefined
+      );
       return;
     }
 
     const cue = Array.prototype.find.call(
-      track.cues,
+      track?.cues ?? [],
       (c) => c.startTime >= time
     );
 
+    const chapterCue = Array.prototype.find.call(
+      chaptersTrack.cues,
+      (c) => c.startTime <= time && c.endTime > time
+    );
+
+    console.log('chapterCue', chapterCue?.text);
+    controller.propagateMediaState(
+      MediaUIAttributes.MEDIA_PREVIEW_CHAPTER,
+      chapterCue?.text
+    );
+
     // No corresponding cue, so bail early
-    if (!cue) return;
+    // if (!cue) return;
 
     // Since this isn't really "global state", we may want to consider moving this "down" to the component level,
     // probably pulled out into its own module/set of functions (CJP)
-    const base = !/'^(?:[a-z]+:)?\/\//i.test(cue.text)
+    const base = !/'^(?:[a-z]+:)?\/\//i.test(cue?.text ?? '')
       ? // @ts-ignore
         media.querySelector('track[label="thumbnails"]')?.src
       : undefined;
-    const url = new URL(cue.text, base);
-    const previewCoordsStr = new URLSearchParams(url.hash).get('#xywh');
+    const url = new URL(cue?.text ?? './', base);
+    const previewCoordsStr = new URLSearchParams(url.hash).get('#xywh') ?? '';
     controller.propagateMediaState(
       MediaUIAttributes.MEDIA_PREVIEW_IMAGE,
       url.href

--- a/src/js/media-chapter-display.js
+++ b/src/js/media-chapter-display.js
@@ -1,0 +1,85 @@
+import MediaTextDisplay from './media-text-display.js';
+import { window } from './utils/server-safe-globals.js';
+import { MediaUIAttributes } from './constants.js';
+// import { nouns } from './labels/labels.js';
+
+export const Attributes = {
+};
+
+const updateAriaValueText = (el) => {
+  el.setAttribute('aria-valuetext', 'Something');
+};
+
+class MediaChapterDisplay extends MediaTextDisplay {
+  #slot;
+
+  static get observedAttributes() {
+    return [
+      ...super.observedAttributes,
+      MediaUIAttributes.MEDIA_PREVIEW_CHAPTER
+    ];
+  }
+
+  constructor() {
+    super();
+
+    this.#slot = this.shadowRoot.querySelector('slot');
+  }
+
+  connectedCallback() {
+    if (!this.hasAttribute('disabled')) {
+      this.enable();
+    }
+
+    // this.setAttribute('role', 'progressbar');
+    // this.setAttribute('aria-label', nouns.PLAYBACK_TIME());
+
+    super.connectedCallback();
+  }
+
+  disconnectedCallback() {
+    this.disable();
+    super.disconnectedCallback();
+  }
+
+  attributeChangedCallback(attrName, oldValue, newValue) {
+    if (
+      [
+        MediaUIAttributes.MEDIA_PREVIEW_CHAPTER,
+      ].includes(attrName)
+    ) {
+      this.update();
+    } else if (attrName === 'disabled' && newValue !== oldValue) {
+      if (newValue == null) {
+        this.enable();
+      } else {
+        this.disable();
+      }
+    }
+
+    super.attributeChangedCallback(attrName, oldValue, newValue);
+  }
+
+  enable() {
+    this.tabIndex = 0;
+  }
+
+  disable() {
+    this.tabIndex = -1;
+  }
+
+  update() {
+    const label = this.getAttribute(MediaUIAttributes.MEDIA_PREVIEW_CHAPTER);
+    updateAriaValueText(this);
+    // Only update if it changed, timeupdate events are called a few times per second.
+    if (label !== this.#slot.innerHTML) {
+      this.#slot.innerHTML = label;
+    }
+  }
+}
+
+if (!window.customElements.get('media-chapter-display')) {
+  window.customElements.define('media-chapter-display', MediaChapterDisplay);
+}
+
+export default MediaChapterDisplay;

--- a/src/js/media-time-range.js
+++ b/src/js/media-time-range.js
@@ -1,4 +1,7 @@
 import { MediaChromeRange } from './media-chrome-range.js';
+import './media-preview-thumbnail.js';
+import './media-preview-time-display.js';
+import './media-chapter-display.js';
 import { window, document } from './utils/server-safe-globals.js';
 import { MediaUIEvents, MediaUIAttributes } from './constants.js';
 import { nouns } from './labels/labels.js';
@@ -120,10 +123,23 @@ template.innerHTML = /*html*/`
     :host([${MediaUIAttributes.MEDIA_PREVIEW_TIME}]:hover) {
       --media-time-range-hover-display: block;
     }
+
+    media-chapter-display {
+      display: none;
+      padding: 0;transition-delay: var(--media-preview-transition-delay-in, .25s);
+      min-width: 100%;
+      border-radius: var(--media-preview-time-border-radius,
+        0 0 var(--media-preview-border-radius) var(--media-preview-border-radius));
+    }
+
+    media-chapter-display[${MediaUIAttributes.MEDIA_PREVIEW_CHAPTER}] {
+      display: initial;
+    }
   </style>
   <div id="preview-rail">
     <slot name="preview" part="box preview-box">
       <media-preview-thumbnail></media-preview-thumbnail>
+      <media-chapter-display></media-chapter-display>
       <media-preview-time-display></media-preview-time-display>
     </slot>
   </div>


### PR DESCRIPTION
Adding for reference and making available branch for baseline of future efforts. Callouts:
* Need to complete ARIA impl for media-chapter-display (may want to rename media-preview-chapter-display)
* There are some assumptions on the preview time around thumbnails. We should be able to find and propagate chapter data, thumbnail data, both, or neither, depending on what's available.
* There is not yet any chapter marker support for the timeline presentation in media-time-range. We may want to hold off on this until we support state propagation via props instead of attrs.