### PR TITLE
Feat/props state propagation

### DIFF
--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -61,6 +61,37 @@ export const MediaStateReceiverAttributes = {
   MEDIA_CONTROLLER: 'mediacontroller',
 };
 
+export const MediaUIProps = {
+  MEDIA_AIRPLAY_UNAVAILABLE: 'mediaAirplayUnavailable',
+  MEDIA_FULLSCREEN_UNAVAILABLE: 'mediaFullscreenUnavailable',
+  MEDIA_PIP_UNAVAILABLE: 'mediaPipUnavailable',
+  MEDIA_CAST_UNAVAILABLE: 'mediaCastUnavailable',
+  MEDIA_PAUSED: 'mediaPaused',
+  MEDIA_HAS_PLAYED: 'mediaHasPlayed',
+  MEDIA_ENDED: 'mediaEnded',
+  MEDIA_MUTED: 'mediaMuted',
+  MEDIA_VOLUME_LEVEL: 'mediaVolumeLevel',
+  MEDIA_VOLUME: 'mediaVolume',
+  MEDIA_VOLUME_UNAVAILABLE: 'mediaVolumeUnavailable',
+  MEDIA_IS_PIP: 'mediaIsPip',
+  MEDIA_IS_CASTING: 'mediaIsCasting',
+  MEDIA_SUBTITLES_LIST: 'mediaSubtitlesList',
+  MEDIA_SUBTITLES_SHOWING: 'mediaSubtitlesShowing',
+  MEDIA_IS_FULLSCREEN: 'mediaIsFullscreen',
+  MEDIA_PLAYBACK_RATE: 'mediaPlaybackRate',
+  MEDIA_CURRENT_TIME: 'mediaCurrentTime',
+  MEDIA_DURATION: 'mediaDuration',
+  MEDIA_SEEKABLE: 'mediaSeekable',
+  MEDIA_PREVIEW_TIME: 'mediaPreviewTime',
+  MEDIA_PREVIEW_IMAGE: 'mediaPreviewImage',
+  MEDIA_PREVIEW_COORDS: 'mediaPreviewCoords',
+  MEDIA_LOADING: 'mediaLoading',
+  MEDIA_BUFFERED: 'mediaBuffered',
+  MEDIA_STREAM_TYPE: 'mediaStreamType',
+  MEDIA_TARGET_LIVE_WINDOW: 'mediaTargetLiveWindow',
+  MEDIA_TIME_IS_LIVE: 'mediaTimeIsLive',
+}
+
 export const MediaUIAttributes = {
   MEDIA_AIRPLAY_UNAVAILABLE: 'mediaairplayunavailable',
   MEDIA_FULLSCREEN_UNAVAILABLE: 'mediafullscreenunavailable',

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -23,39 +23,6 @@ export const MediaUIEvents = {
   UNREGISTER_MEDIA_STATE_RECEIVER: 'unregistermediastatereceiver',
 };
 
-export const MediaStateChangeEvents = {
-  MEDIA_AIRPLAY_UNAVAILABLE: 'mediaairplayunavailablechange',
-  MEDIA_FULLSCREEN_UNAVAILABLE: 'mediafullscreenunavailablechange',
-  MEDIA_PIP_UNAVAILABLE: 'mediapipunavailablechange',
-  MEDIA_CAST_UNAVAILABLE: 'mediacastunavailablechange',
-  MEDIA_PAUSED: 'mediapausedchange',
-  MEDIA_HAS_PLAYED: 'mediahasplayedchange',
-  MEDIA_ENDED: 'mediaendedchange',
-  MEDIA_MUTED: 'mediamutedchange',
-  MEDIA_VOLUME_LEVEL: 'mediavolumelevelchange',
-  MEDIA_VOLUME: 'mediavolumechange',
-  MEDIA_VOLUME_UNAVAILABLE: 'mediavolumeunavailablechange',
-  MEDIA_IS_PIP: 'mediaispipchange',
-  MEDIA_IS_CASTING: 'mediaiscastingchange',
-  MEDIA_SUBTITLES_LIST: 'mediasubtitleslistchange',
-  MEDIA_SUBTITLES_SHOWING: 'mediasubtitlesshowingchange',
-  MEDIA_IS_FULLSCREEN: 'mediaisfullscreenchange',
-  MEDIA_PLAYBACK_RATE: 'mediaplaybackratechange',
-  MEDIA_CURRENT_TIME: 'mediacurrenttimechange',
-  MEDIA_DURATION: 'mediadurationchange',
-  MEDIA_SEEKABLE: 'mediaseekablechange',
-  MEDIA_PREVIEW_TIME: 'mediapreviewtimechange',
-  MEDIA_PREVIEW_IMAGE: 'mediapreviewimagechange',
-  MEDIA_PREVIEW_COORDS: 'mediapreviewcoordschange',
-  MEDIA_LOADING: 'medialoadingchange',
-  MEDIA_BUFFERED: 'mediabufferedchange',
-  MEDIA_STREAM_TYPE: 'mediastreamtypechange',
-  MEDIA_TARGET_LIVE_WINDOW: 'mediatargetlivewindowchange',
-  MEDIA_TIME_IS_LIVE: 'mediatimeislivechange',
-  USER_INACTIVE: 'userinactivechange',
-  BREAKPOINTS_CHANGE: 'breakpointchange',
-};
-
 export const MediaStateReceiverAttributes = {
   MEDIA_CHROME_ATTRIBUTES: 'mediachromeattributes',
   MEDIA_CONTROLLER: 'mediacontroller',
@@ -92,36 +59,31 @@ export const MediaUIProps = {
   MEDIA_TIME_IS_LIVE: 'mediaTimeIsLive',
 };
 
-export const MediaUIAttributes = {
-  MEDIA_AIRPLAY_UNAVAILABLE: 'mediaairplayunavailable',
-  MEDIA_FULLSCREEN_UNAVAILABLE: 'mediafullscreenunavailable',
-  MEDIA_PIP_UNAVAILABLE: 'mediapipunavailable',
-  MEDIA_CAST_UNAVAILABLE: 'mediacastunavailable',
-  MEDIA_PAUSED: 'mediapaused',
-  MEDIA_HAS_PLAYED: 'mediahasplayed',
-  MEDIA_ENDED: 'mediaended',
-  MEDIA_MUTED: 'mediamuted',
-  MEDIA_VOLUME_LEVEL: 'mediavolumelevel',
-  MEDIA_VOLUME: 'mediavolume',
-  MEDIA_VOLUME_UNAVAILABLE: 'mediavolumeunavailable',
-  MEDIA_IS_PIP: 'mediaispip',
-  MEDIA_IS_CASTING: 'mediaiscasting',
-  MEDIA_SUBTITLES_LIST: 'mediasubtitleslist',
-  MEDIA_SUBTITLES_SHOWING: 'mediasubtitlesshowing',
-  MEDIA_IS_FULLSCREEN: 'mediaisfullscreen',
-  MEDIA_PLAYBACK_RATE: 'mediaplaybackrate',
-  MEDIA_CURRENT_TIME: 'mediacurrenttime',
-  MEDIA_DURATION: 'mediaduration',
-  MEDIA_SEEKABLE: 'mediaseekable',
-  MEDIA_PREVIEW_TIME: 'mediapreviewtime',
-  MEDIA_PREVIEW_IMAGE: 'mediapreviewimage',
-  MEDIA_PREVIEW_COORDS: 'mediapreviewcoords',
-  MEDIA_LOADING: 'medialoading',
-  MEDIA_BUFFERED: 'mediabuffered',
-  MEDIA_STREAM_TYPE: 'mediastreamtype',
-  MEDIA_TARGET_LIVE_WINDOW: 'mediatargetlivewindow',
-  MEDIA_TIME_IS_LIVE: 'mediatimeislive',
-};
+const MediaUIPropsEntries = /** @type {[keyof MediaUIProps, string][]} */ (
+  Object.entries(MediaUIProps)
+);
+
+export const MediaUIAttributes =
+  /** @type {{ [k in keyof MediaUIProps]: string }} */ (
+    MediaUIPropsEntries.reduce((dictObj, [key, propName]) => {
+      dictObj[key] = `${propName.toLowerCase()}`;
+      return dictObj;
+    }, /** @type {Partial<{ [k in keyof MediaUIProps]: string }>} */ ({}))
+  );
+
+export const MediaStateChangeEvents =
+  /** @type {{ [k in keyof MediaUIProps | 'USER_INACTIVE' | 'BREAKPOINTS_CHANGE']: string }} */ (
+    MediaUIPropsEntries.reduce(
+      (dictObj, [key, propName]) => {
+        dictObj[key] = `${propName.toLowerCase()}`;
+        return dictObj;
+      },
+      /** @type {Partial<{ [k in keyof MediaUIProps | 'USER_INACTIVE' | 'BREAKPOINTS_CHANGE']: string  }>} */ ({
+        USER_INACTIVE: 'userinactivechange',
+        BREAKPOINTS_CHANGE: 'breakpointchange',
+      })
+    )
+  );
 
 // Maps from state change event type -> attribute name
 export const StateChangeEventToAttributeMap = Object.entries(

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -90,7 +90,7 @@ export const MediaUIProps = {
   MEDIA_STREAM_TYPE: 'mediaStreamType',
   MEDIA_TARGET_LIVE_WINDOW: 'mediaTargetLiveWindow',
   MEDIA_TIME_IS_LIVE: 'mediaTimeIsLive',
-}
+};
 
 export const MediaUIAttributes = {
   MEDIA_AIRPLAY_UNAVAILABLE: 'mediaairplayunavailable',

--- a/src/js/controller.js
+++ b/src/js/controller.js
@@ -451,7 +451,7 @@ export const MediaUIStates = {
   MEDIA_SUBTITLES_LIST: {
     get: function (controller) {
       // TODO: Move to non attr specific values
-      return getSubtitleTracks(controller).map(({ kind, label, language }) => ({ kind, label, language })) || undefined;
+      return getSubtitleTracks(controller).map(({ kind, label, language }) => ({ kind, label, language }));
     },
     mediaEvents: ['loadstart'],
     trackListEvents: ['addtrack', 'removetrack'],
@@ -467,10 +467,7 @@ export const MediaUIStates = {
       ) {
         toggleSubsCaps(controller, true);
       }
-      return (
-        getShowingSubtitleTracks(controller).map(({ kind, label, language }) => ({ kind, label, language })) ||
-        undefined
-      );
+      return getShowingSubtitleTracks(controller).map(({ kind, label, language }) => ({ kind, label, language }));
     },
     mediaEvents: ['loadstart'],
     trackListEvents: ['addtrack', 'removetrack', 'change'],

--- a/src/js/controller.js
+++ b/src/js/controller.js
@@ -1,7 +1,6 @@
 import { window, document } from './utils/server-safe-globals.js';
 import { fullscreenApi } from './utils/fullscreen-api.js';
 import { containsComposedNode } from './utils/element-utils.js';
-import { serializeTimeRanges } from './utils/time.js';
 import {
   hasVolumeSupportAsync,
   fullscreenSupported,
@@ -18,7 +17,6 @@ import {
 } from './constants.js';
 
 import {
-  stringifyTextTrackList,
   getTextTracksList,
   updateTracksModeTo,
   toggleSubsCaps,
@@ -175,7 +173,6 @@ export const MediaUIStates = {
 
       // Account for cases where metadata from slotted media has an "empty" seekable (CJP)
       if (!start && !end) return undefined;
-      // return [Number(start.toFixed(3)), Number(end.toFixed(3))].join(':');
       return [Number(start.toFixed(3)), Number(end.toFixed(3))];
     },
     mediaEvents: ['loadedmetadata', 'emptied', 'progress'],
@@ -188,12 +185,11 @@ export const MediaUIStates = {
   },
   MEDIA_BUFFERED: {
     get: function (controller) {
-      // return serializeTimeRanges(controller.media?.buffered);
       const timeRanges = controller.media?.buffered;
       return Array.from(controller.media?.buffered ?? [])
         .map((_, i) => [
-          Number(timeRanges.start(i)),
-          Number(timeRanges.end(i)),
+          Number(timeRanges.start(i)).toFixed(3),
+          Number(timeRanges.end(i)).toFixed(3),
         ]);
     },
     mediaEvents: ['progress', 'emptied'],
@@ -455,8 +451,6 @@ export const MediaUIStates = {
   MEDIA_SUBTITLES_LIST: {
     get: function (controller) {
       // TODO: Move to non attr specific values
-      console.log('getting mediaSubtitlesList!');
-      // return stringifyTextTrackList(getSubtitleTracks(controller)) || undefined;
       return getSubtitleTracks(controller).map(({ kind, label, language }) => ({ kind, label, language })) || undefined;
     },
     mediaEvents: ['loadstart'],
@@ -474,7 +468,6 @@ export const MediaUIStates = {
         toggleSubsCaps(controller, true);
       }
       return (
-        // stringifyTextTrackList(getShowingSubtitleTracks(controller)) ||
         getShowingSubtitleTracks(controller).map(({ kind, label, language }) => ({ kind, label, language })) ||
         undefined
       );
@@ -733,7 +726,7 @@ export const MediaUIRequestHandlers = {
     );
     controller.propagateMediaState(
       MediaUIAttributes.MEDIA_PREVIEW_COORDS,
-      previewCoordsStr.split(',').join(' ')
+      previewCoordsStr.split(',')
     );
   },
   MEDIA_SHOW_SUBTITLES_REQUEST: (media, e, controller) => {

--- a/src/js/controller.js
+++ b/src/js/controller.js
@@ -175,7 +175,8 @@ export const MediaUIStates = {
 
       // Account for cases where metadata from slotted media has an "empty" seekable (CJP)
       if (!start && !end) return undefined;
-      return [Number(start.toFixed(3)), Number(end.toFixed(3))].join(':');
+      // return [Number(start.toFixed(3)), Number(end.toFixed(3))].join(':');
+      return [Number(start.toFixed(3)), Number(end.toFixed(3))];
     },
     mediaEvents: ['loadedmetadata', 'emptied', 'progress'],
   },
@@ -187,7 +188,13 @@ export const MediaUIStates = {
   },
   MEDIA_BUFFERED: {
     get: function (controller) {
-      return serializeTimeRanges(controller.media?.buffered);
+      // return serializeTimeRanges(controller.media?.buffered);
+      const timeRanges = controller.media?.buffered;
+      return Array.from(controller.media?.buffered ?? [])
+        .map((_, i) => [
+          Number(timeRanges.start(i)),
+          Number(timeRanges.end(i)),
+        ]);
     },
     mediaEvents: ['progress', 'emptied'],
   },
@@ -448,7 +455,9 @@ export const MediaUIStates = {
   MEDIA_SUBTITLES_LIST: {
     get: function (controller) {
       // TODO: Move to non attr specific values
-      return stringifyTextTrackList(getSubtitleTracks(controller)) || undefined;
+      console.log('getting mediaSubtitlesList!');
+      // return stringifyTextTrackList(getSubtitleTracks(controller)) || undefined;
+      return getSubtitleTracks(controller).map(({ kind, label, language }) => ({ kind, label, language })) || undefined;
     },
     mediaEvents: ['loadstart'],
     trackListEvents: ['addtrack', 'removetrack'],
@@ -465,7 +474,8 @@ export const MediaUIStates = {
         toggleSubsCaps(controller, true);
       }
       return (
-        stringifyTextTrackList(getShowingSubtitleTracks(controller)) ||
+        // stringifyTextTrackList(getShowingSubtitleTracks(controller)) ||
+        getShowingSubtitleTracks(controller).map(({ kind, label, language }) => ({ kind, label, language })) ||
         undefined
       );
     },

--- a/src/js/media-captions-button.js
+++ b/src/js/media-captions-button.js
@@ -29,7 +29,7 @@ slotTemplate.innerHTML = /*html*/`
       display: none !important;
     }
   </style>
-  
+
   <slot name="icon">
     <slot name="on">${ccIconOn}</slot>
     <slot name="off">${ccIconOff}</slot>
@@ -58,7 +58,7 @@ const getSubtitlesListAttr = (el, attrName) => {
  */
 const setSubtitlesListAttr = (el, attrName, list) => {
   // null, undefined, and empty arrays are treated as "no value" here
-  if (!list) {
+  if (!list?.length) {
     el.removeAttribute(attrName);
     return;
   }

--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -244,15 +244,16 @@ class MediaController extends MediaContainer {
   }
 
   propagateMediaState(stateName, state) {
-    const previousState = this.getAttribute(stateName);
+    const attrName = stateName.toLowerCase();
+    const previousState = this.getAttribute(attrName);
 
     propagateMediaState(this.mediaStateReceivers, stateName, state);
 
-    if (previousState === this.getAttribute(stateName)) return;
+    if (previousState === this.getAttribute(attrName)) return;
 
     // TODO: I don't think we want these events to bubble? Video element states don't. (heff)
     const evt = new window.CustomEvent(
-      AttributeToStateChangeEventMap[stateName],
+      AttributeToStateChangeEventMap[attrName],
       { composed: true, bubbles: true, detail: state }
     );
     this.dispatchEvent(evt);

--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -20,6 +20,7 @@ import {
   MediaUIProps,
 } from './constants.js';
 import { MediaUIRequestHandlers, MediaUIStates, volumeSupportPromise } from './controller.js';
+import { setBooleanAttr, setNumericAttr, setStringAttr } from './utils/element-utils.js';
 
 const ButtonPressedKeys = ['ArrowLeft', 'ArrowRight', 'Enter', ' ', 'f', 'm', 'k', 'c'];
 const DEFAULT_SEEK_OFFSET = 10;
@@ -532,17 +533,22 @@ const setAttr = async (child, attrName, attrValue) => {
     await delay(0);
   }
 
-  if (attrValue == undefined || (Array.isArray(attrValue) && !attrValue.length)) {
-    return child.removeAttribute(attrName);
+  // NOTE: For "nullish" (null/undefined), can use any setter
+  if (typeof attrValue === 'boolean' || attrValue == null) {
+    return setBooleanAttr(child, attrName, attrValue);
   }
-  if (typeof attrValue === 'boolean') {
-    if (attrValue) return child.setAttribute(attrName, '');
-    return child.removeAttribute(attrName);
+  if (typeof attrValue === 'number') {
+    return setNumericAttr(child, attrName, attrValue)
   }
-  if (Number.isNaN(attrValue)) {
+  if (typeof attrValue === 'string') {
+    return setStringAttr(child, attrName, attrValue);
+  }
+  // Treat empty arrays as "nothing" values
+  if (Array.isArray(attrValue) && !attrValue.length) {
     return child.removeAttribute(attrName);
   }
 
+  // For "special" values with custom serializers or all other values
   const val = CustomAttrSerializer[attrName]?.(attrValue) ?? attrValue;
   return child.setAttribute(attrName, val);
 };

--- a/src/js/media-playback-rate-button.js
+++ b/src/js/media-playback-rate-button.js
@@ -76,10 +76,7 @@ class MediaPlaybackRateButton extends MediaChromeButton {
    * @type {number} The current playback rate
    */
   get mediaPlaybackRate() {
-    return (
-      getNumericAttr(this, MediaUIAttributes.MEDIA_PLAYBACK_RATE) ??
-      DEFAULT_RATE
-    );
+    return getNumericAttr(this, MediaUIAttributes.MEDIA_PLAYBACK_RATE, DEFAULT_RATE);
   }
 
   set mediaPlaybackRate(value) {

--- a/src/js/media-seek-backward-button.js
+++ b/src/js/media-seek-backward-button.js
@@ -61,7 +61,7 @@ class MediaSeekBackwardButton extends MediaChromeButton {
    * @type {number | undefined} Seek amount in seconds
    */
   get seekOffset() {
-    return getNumericAttr(this, Attributes.SEEK_OFFSET) ?? DEFAULT_SEEK_OFFSET;
+    return getNumericAttr(this, Attributes.SEEK_OFFSET, DEFAULT_SEEK_OFFSET);
   }
 
   set seekOffset(value) {
@@ -75,7 +75,7 @@ class MediaSeekBackwardButton extends MediaChromeButton {
    * @type {number | undefined} In seconds
    */
   get mediaCurrentTime() {
-    return getNumericAttr(this, MediaUIAttributes.MEDIA_CURRENT_TIME) ?? DEFAULT_TIME;
+    return getNumericAttr(this, MediaUIAttributes.MEDIA_CURRENT_TIME, DEFAULT_TIME);
   }
 
   set mediaCurrentTime(time) {

--- a/src/js/media-seek-forward-button.js
+++ b/src/js/media-seek-forward-button.js
@@ -61,7 +61,7 @@ class MediaSeekForwardButton extends MediaChromeButton {
    * @type {number | undefined} Seek amount in seconds
    */
   get seekOffset() {
-    return getNumericAttr(this, Attributes.SEEK_OFFSET) ?? DEFAULT_SEEK_OFFSET;
+    return getNumericAttr(this, Attributes.SEEK_OFFSET, DEFAULT_SEEK_OFFSET);
   }
 
   set seekOffset(value) {
@@ -75,7 +75,7 @@ class MediaSeekForwardButton extends MediaChromeButton {
    * @type {number | undefined} In seconds
    */
   get mediaCurrentTime() {
-    return getNumericAttr(this, MediaUIAttributes.MEDIA_CURRENT_TIME) ?? DEFAULT_TIME;
+    return getNumericAttr(this, MediaUIAttributes.MEDIA_CURRENT_TIME, DEFAULT_TIME);
   }
 
   set mediaCurrentTime(time) {

--- a/src/js/media-time-range.js
+++ b/src/js/media-time-range.js
@@ -348,7 +348,7 @@ class MediaTimeRange extends MediaChromeRange {
    * @type {number}
    */
   get mediaPlaybackRate() {
-    return getNumericAttr(this, MediaUIAttributes.MEDIA_PLAYBACK_RATE) ?? 1;
+    return getNumericAttr(this, MediaUIAttributes.MEDIA_PLAYBACK_RATE, 1);
   }
 
   set mediaPlaybackRate(value) {

--- a/src/js/media-time-range.js
+++ b/src/js/media-time-range.js
@@ -351,7 +351,7 @@ class MediaTimeRange extends MediaChromeRange {
     return getNumericAttr(this, MediaUIAttributes.MEDIA_PLAYBACK_RATE) ?? 1;
   }
 
-  set mediaPlaybackrate(value) {
+  set mediaPlaybackRate(value) {
     setNumericAttr(this, MediaUIAttributes.MEDIA_PLAYBACK_RATE, value);
   }
 

--- a/src/js/media-volume-range.js
+++ b/src/js/media-volume-range.js
@@ -81,9 +81,7 @@ class MediaVolumeRange extends MediaChromeRange {
    * @type {number}
    */
   get mediaVolume() {
-    return (
-      getNumericAttr(this, MediaUIAttributes.MEDIA_VOLUME) ?? DEFAULT_VOLUME
-    );
+    return getNumericAttr(this, MediaUIAttributes.MEDIA_VOLUME, DEFAULT_VOLUME);
   }
 
   set mediaVolume(value) {

--- a/src/js/utils/captions.js
+++ b/src/js/utils/captions.js
@@ -96,7 +96,7 @@ export const parseTracks = (trackOrTracks) => {
  * @param {string} [obj.language] - The BCP-47 compliant string representing the language code of the track
  * @returns {string} A string representing a TextTrack with the format: "language[:label]"
  */
-export const formatTextTrackObj = ({ kind, label, language } = {kind: 'subtitles'}) => {
+export const formatTextTrackObj = ({ kind, label, language } = { kind: 'subtitles' }) => {
   if (!label) return language;
   return `${kind === 'captions' ? 'cc': 'sb'}:${language}:${encodeURIComponent(label)}`;
 };

--- a/test/unit/media-controller.spec.js
+++ b/test/unit/media-controller.spec.js
@@ -1,11 +1,17 @@
 import { fixture, assert, aTimeout, waitUntil } from '@open-wc/testing';
 import { constants } from '../../src/js/index.js';
+import { nextFrame } from '@open-wc/testing';
+import { MediaStateReceiverAttributes } from '../../src/js/constants.js';
 
-const { MediaUIEvents, MediaUIAttributes, MediaStateChangeEvents } = constants;
+const {
+  MediaUIEvents,
+  MediaUIAttributes,
+  MediaStateChangeEvents,
+  MediaUIProps,
+} = constants;
 const isSafari = /.*Version\/.*Safari\/.*/.test(navigator.userAgent);
 
 describe('<media-controller>', () => {
-
   it('associates itself to observe for state receivers', async () => {
     const mediaController = await fixture(`
       <media-controller></media-controller>
@@ -34,9 +40,15 @@ describe('<media-controller>', () => {
 
     // Also includes the media-gesture-receiver by default
     assert.equal(mediaController.mediaStateReceivers.length, 3);
-    assert(mediaController.mediaStateReceivers.indexOf(mediaController) >= 0, 'registers itself');
+    assert(
+      mediaController.mediaStateReceivers.indexOf(mediaController) >= 0,
+      'registers itself'
+    );
     const playButton = mediaController.querySelector('media-play-button');
-    assert(mediaController.mediaStateReceivers.indexOf(playButton) >= 0, 'registers play button');
+    assert(
+      mediaController.mediaStateReceivers.indexOf(playButton) >= 0,
+      'registers play button'
+    );
   });
 
   it('registers itself and non-child button state receivers', async () => {
@@ -49,13 +61,22 @@ describe('<media-controller>', () => {
 
     // Also includes the media-gesture-receiver by default
     assert.equal(mediaController.mediaStateReceivers.length, 3);
-    assert(mediaController.mediaStateReceivers.indexOf(mediaController) >= 0, 'registers itself');
-    assert(mediaController.mediaStateReceivers.indexOf(ui) >= 0, 'registers button');
+    assert(
+      mediaController.mediaStateReceivers.indexOf(mediaController) >= 0,
+      'registers itself'
+    );
+    assert(
+      mediaController.mediaStateReceivers.indexOf(ui) >= 0,
+      'registers button'
+    );
 
     ui.remove();
 
     assert.equal(mediaController.mediaStateReceivers.length, 2);
-    assert(!mediaController.mediaStateReceivers.includes(ui), 'unregisters control');
+    assert(
+      !mediaController.mediaStateReceivers.includes(ui),
+      'unregisters control'
+    );
   });
 
   it('registers itself and non-child range state receivers', async () => {
@@ -68,13 +89,22 @@ describe('<media-controller>', () => {
 
     // Also includes media-gesture-receiver, media-preview-thumbnail, media-preview-time-display
     assert.equal(mediaController.mediaStateReceivers.length, 5);
-    assert(mediaController.mediaStateReceivers.indexOf(mediaController) >= 0, 'registers itself');
-    assert(mediaController.mediaStateReceivers.indexOf(ui) >= 0, 'registers range');
+    assert(
+      mediaController.mediaStateReceivers.indexOf(mediaController) >= 0,
+      'registers itself'
+    );
+    assert(
+      mediaController.mediaStateReceivers.indexOf(ui) >= 0,
+      'registers range'
+    );
 
     ui.remove();
 
     assert.equal(mediaController.mediaStateReceivers.length, 2);
-    assert(!mediaController.mediaStateReceivers.includes(ui), 'unregisters control');
+    assert(
+      !mediaController.mediaStateReceivers.includes(ui),
+      'unregisters control'
+    );
   });
 
   it('registers itself and non-child gesture-receiver state receivers', async () => {
@@ -87,13 +117,22 @@ describe('<media-controller>', () => {
 
     // Also includes the media-gesture-receiver by default
     assert.equal(mediaController.mediaStateReceivers.length, 3);
-    assert(mediaController.mediaStateReceivers.indexOf(mediaController) >= 0, 'registers itself');
-    assert(mediaController.mediaStateReceivers.indexOf(ui) >= 0, 'registers gesture-receiver');
+    assert(
+      mediaController.mediaStateReceivers.indexOf(mediaController) >= 0,
+      'registers itself'
+    );
+    assert(
+      mediaController.mediaStateReceivers.indexOf(ui) >= 0,
+      'registers gesture-receiver'
+    );
 
     ui.remove();
 
     assert.equal(mediaController.mediaStateReceivers.length, 2);
-    assert(!mediaController.mediaStateReceivers.includes(ui), 'unregisters control');
+    assert(
+      !mediaController.mediaStateReceivers.includes(ui),
+      'unregisters control'
+    );
   });
 
   it('registers itself and non-child loading-indicator state receivers', async () => {
@@ -106,13 +145,22 @@ describe('<media-controller>', () => {
 
     // Also includes the media-gesture-receiver by default
     assert.equal(mediaController.mediaStateReceivers.length, 3);
-    assert(mediaController.mediaStateReceivers.indexOf(mediaController) >= 0, 'registers itself');
-    assert(mediaController.mediaStateReceivers.indexOf(ui) >= 0, 'registers loading-indicator');
+    assert(
+      mediaController.mediaStateReceivers.indexOf(mediaController) >= 0,
+      'registers itself'
+    );
+    assert(
+      mediaController.mediaStateReceivers.indexOf(ui) >= 0,
+      'registers loading-indicator'
+    );
 
     ui.remove();
 
     assert.equal(mediaController.mediaStateReceivers.length, 2);
-    assert(!mediaController.mediaStateReceivers.includes(ui), 'unregisters control');
+    assert(
+      !mediaController.mediaStateReceivers.includes(ui),
+      'unregisters control'
+    );
   });
 
   it('registers itself and non-child preview-thumbnail state receivers', async () => {
@@ -125,13 +173,22 @@ describe('<media-controller>', () => {
 
     // Also includes the media-gesture-receiver by default
     assert.equal(mediaController.mediaStateReceivers.length, 3);
-    assert(mediaController.mediaStateReceivers.indexOf(mediaController) >= 0, 'registers itself');
-    assert(mediaController.mediaStateReceivers.indexOf(ui) >= 0, 'registers preview-thumbnail');
+    assert(
+      mediaController.mediaStateReceivers.indexOf(mediaController) >= 0,
+      'registers itself'
+    );
+    assert(
+      mediaController.mediaStateReceivers.indexOf(ui) >= 0,
+      'registers preview-thumbnail'
+    );
 
     ui.remove();
 
     assert.equal(mediaController.mediaStateReceivers.length, 2);
-    assert(!mediaController.mediaStateReceivers.includes(ui), 'unregisters control');
+    assert(
+      !mediaController.mediaStateReceivers.includes(ui),
+      'unregisters control'
+    );
   });
 
   it('registers itself and non-child time-display state receivers', async () => {
@@ -144,13 +201,22 @@ describe('<media-controller>', () => {
 
     // Also includes the media-gesture-receiver by default
     assert.equal(mediaController.mediaStateReceivers.length, 3);
-    assert(mediaController.mediaStateReceivers.indexOf(mediaController) >= 0, 'registers itself');
-    assert(mediaController.mediaStateReceivers.indexOf(ui) >= 0, 'registers time-display');
+    assert(
+      mediaController.mediaStateReceivers.indexOf(mediaController) >= 0,
+      'registers itself'
+    );
+    assert(
+      mediaController.mediaStateReceivers.indexOf(ui) >= 0,
+      'registers time-display'
+    );
 
     ui.remove();
 
     assert.equal(mediaController.mediaStateReceivers.length, 2);
-    assert(!mediaController.mediaStateReceivers.includes(ui), 'unregisters control');
+    assert(
+      !mediaController.mediaStateReceivers.includes(ui),
+      'unregisters control'
+    );
   });
 
   it('registers itself and child simple element state receivers', async () => {
@@ -162,9 +228,15 @@ describe('<media-controller>', () => {
 
     // Also includes the media-gesture-receiver by default
     assert.equal(mediaController.mediaStateReceivers.length, 3);
-    assert(mediaController.mediaStateReceivers.indexOf(mediaController) >= 0, 'registers itself');
+    assert(
+      mediaController.mediaStateReceivers.indexOf(mediaController) >= 0,
+      'registers itself'
+    );
     const div = mediaController.querySelector('div');
-    assert(mediaController.mediaStateReceivers.indexOf(div) >= 0, 'registers div');
+    assert(
+      mediaController.mediaStateReceivers.indexOf(div) >= 0,
+      'registers div'
+    );
   });
 });
 
@@ -193,10 +265,26 @@ describe('receiving state / dispatching (bubbling) events', () => {
   it('receives state as attributes from the media', async () => {
     assert(mediaController.hasAttribute(MediaUIAttributes.MEDIA_PAUSED));
     assert(mediaController.hasAttribute(MediaUIAttributes.MEDIA_MUTED));
-    assert.equal(mediaController.getAttribute(MediaUIAttributes.MEDIA_CURRENT_TIME), '0', MediaUIAttributes.MEDIA_CURRENT_TIME);
-    assert.equal(mediaController.getAttribute(MediaUIAttributes.MEDIA_PLAYBACK_RATE), '1', MediaUIAttributes.MEDIA_PLAYBACK_RATE);
-    assert.equal(mediaController.getAttribute(MediaUIAttributes.MEDIA_VOLUME), '1', MediaUIAttributes.MEDIA_VOLUME);
-    assert.equal(mediaController.getAttribute(MediaUIAttributes.MEDIA_VOLUME_LEVEL), 'off', MediaUIAttributes.MEDIA_VOLUME_LEVEL);
+    assert.equal(
+      mediaController.getAttribute(MediaUIAttributes.MEDIA_CURRENT_TIME),
+      '0',
+      MediaUIAttributes.MEDIA_CURRENT_TIME
+    );
+    assert.equal(
+      mediaController.getAttribute(MediaUIAttributes.MEDIA_PLAYBACK_RATE),
+      '1',
+      MediaUIAttributes.MEDIA_PLAYBACK_RATE
+    );
+    assert.equal(
+      mediaController.getAttribute(MediaUIAttributes.MEDIA_VOLUME),
+      '1',
+      MediaUIAttributes.MEDIA_VOLUME
+    );
+    assert.equal(
+      mediaController.getAttribute(MediaUIAttributes.MEDIA_VOLUME_LEVEL),
+      'off',
+      MediaUIAttributes.MEDIA_VOLUME_LEVEL
+    );
 
     await video.play();
 
@@ -207,57 +295,87 @@ describe('receiving state / dispatching (bubbling) events', () => {
   it('can play/pause', async () => {
     assert(mediaController.hasAttribute(MediaUIAttributes.MEDIA_PAUSED));
 
-    div.dispatchEvent(new Event(MediaUIEvents.MEDIA_PLAY_REQUEST, { bubbles: true }));
+    div.dispatchEvent(
+      new Event(MediaUIEvents.MEDIA_PLAY_REQUEST, { bubbles: true })
+    );
     await aTimeout(10);
 
     assert(!video.paused, 'video.paused is false');
-    assert(!mediaController.hasAttribute(MediaUIAttributes.MEDIA_PAUSED), 'has no mediapaused');
+    assert(
+      !mediaController.hasAttribute(MediaUIAttributes.MEDIA_PAUSED),
+      'has no mediapaused'
+    );
 
-    div.dispatchEvent(new Event(MediaUIEvents.MEDIA_PAUSE_REQUEST, { bubbles: true }));
+    div.dispatchEvent(
+      new Event(MediaUIEvents.MEDIA_PAUSE_REQUEST, { bubbles: true })
+    );
     await aTimeout(10);
 
     assert(video.paused, 'video.paused is true');
-    assert(mediaController.hasAttribute(MediaUIAttributes.MEDIA_PAUSED), 'has mediapaused');
+    assert(
+      mediaController.hasAttribute(MediaUIAttributes.MEDIA_PAUSED),
+      'has mediapaused'
+    );
   });
 
   it('can unmute/mute', async () => {
     assert(mediaController.hasAttribute(MediaUIAttributes.MEDIA_MUTED));
 
-    div.dispatchEvent(new Event(MediaUIEvents.MEDIA_UNMUTE_REQUEST, { bubbles: true }));
+    div.dispatchEvent(
+      new Event(MediaUIEvents.MEDIA_UNMUTE_REQUEST, { bubbles: true })
+    );
     await aTimeout(10);
 
     assert(!video.muted, 'video.muted is false');
-    assert(!mediaController.hasAttribute(MediaUIAttributes.MEDIA_MUTED), 'has no mediamuted');
+    assert(
+      !mediaController.hasAttribute(MediaUIAttributes.MEDIA_MUTED),
+      'has no mediamuted'
+    );
 
-    div.dispatchEvent(new Event(MediaUIEvents.MEDIA_MUTE_REQUEST, { bubbles: true }));
+    div.dispatchEvent(
+      new Event(MediaUIEvents.MEDIA_MUTE_REQUEST, { bubbles: true })
+    );
     await aTimeout(10);
 
     assert(video.muted, 'video.muted is true');
-    assert(mediaController.hasAttribute(MediaUIAttributes.MEDIA_MUTED), 'has mediamuted');
+    assert(
+      mediaController.hasAttribute(MediaUIAttributes.MEDIA_MUTED),
+      'has mediamuted'
+    );
   });
 
   it('can seek', async () => {
     await video.play();
 
-    div.dispatchEvent(new CustomEvent(MediaUIEvents.MEDIA_SEEK_REQUEST, {
-      detail: 2,
-      bubbles: true
-    }));
+    div.dispatchEvent(
+      new CustomEvent(MediaUIEvents.MEDIA_SEEK_REQUEST, {
+        detail: 2,
+        bubbles: true,
+      })
+    );
 
-    await waitUntil(() => mediaController.getAttribute(MediaUIAttributes.MEDIA_CURRENT_TIME) >= 2);
+    await waitUntil(
+      () =>
+        mediaController.getAttribute(MediaUIAttributes.MEDIA_CURRENT_TIME) >= 2
+    );
     assert(true, 'mediacurrenttime is 2');
   });
 
   (isSafari ? it.skip : it)('can change volume', async () => {
-    div.dispatchEvent(new CustomEvent(MediaUIEvents.MEDIA_VOLUME_REQUEST, {
-      detail: 0.73,
-      bubbles: true
-    }));
+    div.dispatchEvent(
+      new CustomEvent(MediaUIEvents.MEDIA_VOLUME_REQUEST, {
+        detail: 0.73,
+        bubbles: true,
+      })
+    );
 
-    await waitUntil(() => mediaController.getAttribute(MediaUIAttributes.MEDIA_VOLUME) == 0.73, 10000);
+    await waitUntil(
+      () =>
+        mediaController.getAttribute(MediaUIAttributes.MEDIA_VOLUME) == 0.73,
+      10000
+    );
     assert(true, 'mediavolume is 0.73');
   });
-
 });
 
 describe('state propagation behaviors', () => {
@@ -274,14 +392,136 @@ describe('state propagation behaviors', () => {
     mediaController = undefined;
   });
 
-  Object.entries(MediaUIAttributes).forEach(([key, attrName]) => {
+  Object.entries(MediaUIProps).forEach(([key, propName]) => {
     const eventType = MediaStateChangeEvents[key];
 
-    it(`should dispatch event ${eventType} when ${attrName} changes`, async (done) => {
-      const nextState = mediaController.hasAttribute(attrName) ? undefined : true;
+    it(`should dispatch event ${eventType} when ${propName} changes`, (done) => {
+      const nextState = !mediaController.hasAttribute(propName.toLowerCase());
       assert.exists(eventType);
       mediaController.addEventListener(eventType, () => done());
-      mediaController.propagateMediaState(attrName, nextState);
+      mediaController.propagateMediaState(propName, nextState);
+    });
+
+    it(`should not dispatch event ${eventType} when ${propName} does not change`, (done) => {
+      const nextState = !mediaController.hasAttribute(propName.toLowerCase());
+      assert.exists(eventType);
+      mediaController.propagateMediaState(propName, nextState);
+      mediaController.addEventListener(eventType, () =>
+        done('Event should not fire!')
+      );
+      mediaController.propagateMediaState(propName, nextState);
+      nextFrame().then(done);
+    });
+  });
+
+  describe('media state receivers', () => {
+    class MediaStateReceiverWC extends HTMLElement {
+      static observedAttributes = Object.values(MediaUIAttributes);
+    }
+
+    const MEDIA_STATE_RECEIVER_WC_NAME = 'media-state-receiver';
+    window.customElements.define(
+      MEDIA_STATE_RECEIVER_WC_NAME,
+      MediaStateReceiverWC
+    );
+
+    let mediaStateReceiverObj;
+    let div;
+    let wc;
+    const INITIAL_VALUE = '@@placeholder@@';
+
+    beforeEach(async () => {
+      mediaStateReceiverObj = Object.values(MediaUIProps).reduce(
+        (obj, propName) => {
+          obj[propName] = INITIAL_VALUE;
+          return obj;
+        },
+        {}
+      );
+
+      div = await fixture('<div></div>');
+      div.setAttribute(
+        MediaStateReceiverAttributes.MEDIA_CHROME_ATTRIBUTES,
+        Object.values(MediaUIAttributes).join(' ')
+      );
+
+      wc = await fixture(`<${MEDIA_STATE_RECEIVER_WC_NAME}></${MEDIA_STATE_RECEIVER_WC_NAME}>`);
+    });
+
+    afterEach(() => {
+      mediaStateReceiverObj = undefined;
+      div = undefined;
+      wc = undefined;
+    });
+
+    Object.entries(MediaUIProps).forEach(([key, propName]) => {
+      it(`should propagate ${propName} to a media state receiver with a corresponding property when its value changes`, () => {
+        mediaController.registerMediaStateReceiver(mediaStateReceiverObj);
+        const nextState = !mediaController.hasAttribute(propName.toLowerCase());
+        mediaController.propagateMediaState(propName, nextState);
+        assert.notEqual(mediaStateReceiverObj[propName], INITIAL_VALUE);
+        assert.equal(mediaStateReceiverObj[propName], nextState);
+      });
+
+      it(`should not propagate ${propName} to a media state receiver if it has no corresponding property when its value changes`, () => {
+        delete mediaStateReceiverObj[propName];
+        mediaController.registerMediaStateReceiver(mediaStateReceiverObj);
+        const nextState = !mediaController.hasAttribute(propName.toLowerCase());
+        mediaController.propagateMediaState(propName, nextState);
+        assert.notEqual(mediaStateReceiverObj[propName], nextState);
+        assert(!(propName in mediaStateReceiverObj));
+      });
+
+      const attrName = MediaUIAttributes[key];
+
+      it(`should propagate ${propName} via attrs to a media state receiver if ${attrName} is listed in ${MediaStateReceiverAttributes.MEDIA_CHROME_ATTRIBUTES}`, () => {
+        mediaController.registerMediaStateReceiver(div);
+        const nextState = !mediaController.hasAttribute(propName.toLowerCase());
+        mediaController.propagateMediaState(propName, nextState);
+        assert.equal(div.hasAttribute(attrName), nextState);
+      });
+
+      it(`should not propagate ${propName} via attrs to a media state receiver if ${attrName} is not listed in ${MediaStateReceiverAttributes.MEDIA_CHROME_ATTRIBUTES}`, () => {
+        div.setAttribute(
+          MediaStateReceiverAttributes.MEDIA_CHROME_ATTRIBUTES,
+          Object.values(MediaUIAttributes)
+            .filter((name) => name !== attrName)
+            .join(' ')
+        );
+        mediaController.registerMediaStateReceiver(div);
+        // NOTE: Given the generic values here, we need to update state twice to ensure a toggle between true & false
+        // (which is represented by removing an attribute from a media state receiver)
+        const nextState = !mediaController.hasAttribute(propName.toLowerCase());
+        mediaController.propagateMediaState(propName, nextState);
+        assert(!div.hasAttribute(attrName));
+        mediaController.propagateMediaState(propName, !nextState);
+        assert(!div.hasAttribute(attrName));
+      });
+
+      it(`should propagate ${propName} via props to a media state receiver if prop exists, even if a corresponding ${attrName} attr is listed in ${MediaStateReceiverAttributes.MEDIA_CHROME_ATTRIBUTES}`, () => {
+        div[propName] = INITIAL_VALUE;
+        mediaController.registerMediaStateReceiver(div);
+        const nextState = !mediaController.hasAttribute(propName.toLowerCase());
+        mediaController.propagateMediaState(propName, nextState);
+        assert(!div.hasAttribute(attrName));
+        assert.equal(div[propName], nextState);
+      });
+
+      it(`should propagate ${propName} via attrs to a web component media state receiver if ${attrName} is an observed attr`, () => {
+        mediaController.registerMediaStateReceiver(wc);
+        const nextState = !mediaController.hasAttribute(propName.toLowerCase());
+        mediaController.propagateMediaState(propName, nextState);
+        assert.equal(wc.hasAttribute(attrName), nextState);
+      });
+
+      it(`should propagate ${propName} via props to a web component media state receiver if prop exists, even if ${attrName} is an observed attr`, () => {
+        wc[propName] = INITIAL_VALUE;
+        mediaController.registerMediaStateReceiver(wc);
+        const nextState = !mediaController.hasAttribute(propName.toLowerCase());
+        mediaController.propagateMediaState(propName, nextState);
+        assert(!div.hasAttribute(attrName));
+        assert.equal(wc[propName], nextState);
+      });
     });
   });
 });


### PR DESCRIPTION
This PR:
1. Adds support for propagating state via `props` if/when available
2. Detecting whether or not a descendant is a "media state receiver" based on the presence of corresponding properties
3. Prefers using media state props over attrs (detected via `observedAttributes` or `mediachromeattributes`) when both are present
4. Adds tests for these defined behaviors/relationships
5. A couple of bug fixes discovered while implementing