### PR TITLE
fix: Handle visualization in media-time-range for cases where media h…

### DIFF
--- a/src/js/media-chrome-range.js
+++ b/src/js/media-chrome-range.js
@@ -360,21 +360,31 @@ class MediaChromeRange extends window.HTMLElement {
     style.setProperty('--media-range-track-progress-internal', gradientStr);
   }
 
+  getRelativeValues() {
+    const { range } = this;
+    return {
+      relativeValue: range.value - range.min,
+      relativeMax: range.max - range.min,
+    };
+  }
+
   /*
     Build the color gradient for the range bar.
     Creating an array so progress-bar can insert the buffered bar.
   */
   getBarColors() {
     const range = this.range;
-    const relativeValue = range.value - range.min;
-    const relativeMax = range.max - range.min;
+    const {
+      relativeValue,
+      relativeMax,
+    } = this.getRelativeValues();
     const rangePercent = (relativeValue / relativeMax) * 100;
 
     let thumbPercent = 0;
     // If the range thumb is at min or max don't correct the time range.
     // Ideally the thumb center would go all the way to min and max values
     // but input[type=range] doesn't play like that.
-    if (range.value > range.min && range.value < range.max) {
+    if (!!relativeValue && relativeValue < relativeMax) {
       const thumbOffset = this.#thumbWidth * (0.5 - rangePercent / 100);
       thumbPercent = (thumbOffset / range.offsetWidth) * 100;
     }


### PR DESCRIPTION
…as ended.

This ensures that if media playback has ended, it should "look like it" in `media-time-range`, corresponding to things like the buffered ranges, the thumb position, and the track bar gradient for what has played. Discrepancies here can happen as a result of mismatches/precision issues between advertised `seekable` end vs. `duration` vs. `currentTime`. This solution will simply "bump the visual indicators to the end" whenever the media has ended.

To keep this extensible/generic, I added a new method to `media-chrome-range`, `getRelativeValues()`, which abstracts and allows for overriding of computed relative ranges. This is then used in `media-time-range` to conditionally yield a different `relativeValue` when `mediaEnded`.

To test, I used a Mux Video playback id with some known discrepancies here, modifying our `mux-video.html` vanilla example, and tested with `--media-range-thumb-height: 0;` vs no override set to confirm visualization both with and without the thumb.