### PR TITLE
fix: time range preview and value inconsistency

### DIFF
--- a/src/js/media-chrome-range.js
+++ b/src/js/media-chrome-range.js
@@ -233,7 +233,7 @@ template.innerHTML = /*html*/`
  * @cssproperty --media-range-track-pointer-border-right - `border-right` of range track pointer.
  */
 class MediaChromeRange extends window.HTMLElement {
-  #thumbWidth;
+  thumbWidth;
   #mediaController;
 
   static get observedAttributes() {
@@ -261,7 +261,7 @@ class MediaChromeRange extends window.HTMLElement {
     this.range = this.shadowRoot.querySelector('#range');
     this.range.addEventListener('input', this.updateBar.bind(this));
 
-    this.#thumbWidth = parseInt(getComputedStyle(this).getPropertyValue('--media-range-thumb-width') || '10', 10);
+    this.thumbWidth = parseInt(getComputedStyle(this).getPropertyValue('--media-range-thumb-width') || '10', 10);
   }
 
   #onFocusIn = () => {
@@ -385,7 +385,7 @@ class MediaChromeRange extends window.HTMLElement {
     // Ideally the thumb center would go all the way to min and max values
     // but input[type=range] doesn't play like that.
     if (!!relativeValue && relativeValue < relativeMax) {
-      const thumbOffset = this.#thumbWidth * (0.5 - rangePercent / 100);
+      const thumbOffset = this.thumbWidth * (0.5 - rangePercent / 100);
       thumbPercent = (thumbOffset / range.offsetWidth) * 100;
     }
 

--- a/src/js/media-time-range.js
+++ b/src/js/media-time-range.js
@@ -535,7 +535,7 @@ class MediaTimeRange extends MediaChromeRange {
 
     // Get mouse position percent
     const rangeRect = this.range.getBoundingClientRect();
-    let mouseRatio = (evt.clientX - rangeRect.left) / rangeRect.width;
+    let mouseRatio = (evt.clientX - rangeRect.left - this.thumbWidth / 2) / (rangeRect.width - this.thumbWidth);
     // Lock between 0 and 1
     mouseRatio = Math.max(0, Math.min(1, mouseRatio));
 


### PR DESCRIPTION
Fixes https://github.com/muxinc/media-chrome/issues/656

As it turned out, input[type=range] makes half the width of thumb a "dead zone" where the value is either max or min. If we account for that when calculating preview values, we get the "right" result in preview. On a video of 3 minutes, the difference is < 0.01s between preview and input value.