### PR TITLE
Add typesVersions in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,12 @@
   },
   "main": "dist/index.js",
   "type": "module",
+  "typesVersions": {
+    "*": {
+      "react": ["dist/react/index.d.ts"],
+      "*": ["dist/index.d.ts"]
+    }
+  },
   "exports": {
     ".": {
       "import": "./dist/index.js",


### PR DESCRIPTION
fix #680 

Thanks for adding exports declarations for EMS and CJS!  I was testing [the v1.x version of this package in the sanity-plugin-mux-input plugin](https://github.com/sanity-io/sanity-plugin-mux-input/pull/285) and TypeScript was having problems with `import { ... } from 'media-chrome/react'` which stemmed from problems with type resolution.

The solution I came across was adding in these `typesVersions` declarations which routes type resolution for react vs non-react imports to the expected files under `dist` to match what's declared under the `exports` field.