### PR TITLE
fix: Make computation for breakpoints in ResizeObserver async.

### DIFF
--- a/src/js/utils/server-safe-globals.js
+++ b/src/js/utils/server-safe-globals.js
@@ -21,7 +21,8 @@ const windowShim = {
   },
   CustomEvent: function CustomEvent() {},
   getComputedStyle: function () {},
-  requestAnimationFrame: function(cb) {
+  // eslint-disable-next-line no-unused-vars
+  requestAnimationFrame: function(_cb) {
     return 1;
   }
 };

--- a/src/js/utils/server-safe-globals.js
+++ b/src/js/utils/server-safe-globals.js
@@ -21,6 +21,9 @@ const windowShim = {
   },
   CustomEvent: function CustomEvent() {},
   getComputedStyle: function () {},
+  requestAnimationFrame: function(cb) {
+    return 1;
+  }
 };
 
 const documentShim = {
@@ -54,7 +57,8 @@ export const isServer =
   * document?,
   * chrome?,
   * DocumentFragment?,
-  * ResizeObserver?
+  * ResizeObserver?,
+  * requestAnimationFrame,
   * } }
   * */
 export const Window = isServer ? windowShim : window;


### PR DESCRIPTION
Ensures we do not end up with loop limit exceeded RTEs when breakpoints computations take too long.