### PR TITLE
fix: React createElement function signature

### DIFF
--- a/scripts/react/build.js
+++ b/scripts/react/build.js
@@ -33,8 +33,8 @@ const toReactComponentStr = (config) => {
   const { elementName } = config;
   const ReactComponentName = toPascalCase(elementName);
   return `/** @type { import("react").HTMLElement } */
-const ${ReactComponentName} = React.forwardRef(({ children, ...props }, ref) => {
-  return React.createElement('${elementName}', toNativeProps({ ...props, ref }), children);
+const ${ReactComponentName} = React.forwardRef(({ children = [], ...props }, ref) => {
+  return React.createElement('${elementName}', toNativeProps({ ...props, ref }), ...children);
 });`;
 };
 


### PR DESCRIPTION
not a biggie it seems but children are spread in the React.createElement function signature
https://react.dev/reference/react/createElement