### PR TITLE
fix: Playback rate sorting for double digits

### DIFF
--- a/src/js/media-playback-rate-button.js
+++ b/src/js/media-playback-rate-button.js
@@ -84,7 +84,8 @@ class MediaPlaybackRateButton extends MediaChromeButton {
   }
 
   handleClick() {
-    const availableRates = Array.from(this.rates.values(), str => +str).sort();
+    const availableRates = Array.from(this.rates.values(), str => +str).sort((a, b) => a - b);
+
     const detail =
       availableRates.find((r) => r > this.mediaPlaybackRate) ??
       availableRates[0] ??


### PR DESCRIPTION
A playback rate of `10` was being sorted wrong. Thanks `sort()`!