### PR TITLE
fix: media-chrome/dist/react import

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,11 @@
       "require": "./dist/cjs/react/index.js",
       "default": "./dist/react/index.js"
     },
+    "./dist/react": {
+      "import": "./dist/react/index.js",
+      "require": "./dist/cjs/react/index.js",
+      "default": "./dist/react/index.js"
+    },
     "./dist/cjs/*": "./dist/cjs/*",
     "./dist/react/*": {
       "import": "./dist/react/*",


### PR DESCRIPTION
related #680

allows to use `media-chrome/dist/react` as import 

this issue came up after adding support for CJS in https://github.com/muxinc/media-chrome/pull/650

Typescript types seem to still be broken for the new import path `media-chrome/react`
https://github.com/muxinc/media-chrome/pull/672

