### PR TITLE
docs: fix component docs links on Styling Reference page

### DIFF
--- a/docs/src/pages/docs/en/reference/styling.astro
+++ b/docs/src/pages/docs/en/reference/styling.astro
@@ -82,7 +82,7 @@ function backticksToMdnLinks(str) {
         .map(cls => (
           <li>
             <code>{cls.tagName}</code>
-            {hasLink(cls.tagName) && (<>(<a href={`./components/${cls.tagName}`}>docs</a>)</>)}
+            {hasLink(cls.tagName) && (<>(<a href={`../components/${cls.tagName}`}>docs</a>)</>)}
           </li>
         ))
       }


### PR DESCRIPTION
Fixes #701 by correcting the component relative path.

[Direct preview link to relevant page](https://media-chrome-docs-git-fork-derikolsson-docs-fix-styl-86641d-mux.vercel.app/docs/en/reference/styling)