### PR TITLE
chore: Define the type of `_inactiveTimeout` so it is not inferred as `NodeJS.Timeout`

### DIFF
--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -486,6 +486,7 @@ class MediaContainer extends globalThis.HTMLElement {
       // Setting autohide to -1 turns off autohide
       if (this.autohide < 0) return;
 
+      /** @type {ReturnType<typeof setTimeout>} */
       this._inactiveTimeout = setTimeout(() => {
         setInactive();
       }, this.autohide * 1000);


### PR DESCRIPTION
`_inactiveTimeout` was incorrectly typed to `NodeJS.Timeout` which made my linter unhappy.

Either `number` or `ReturnType<typeof setTimeout>` would work but the latter feels more explicit.