### PR TITLE
feat: separate slider UI from input range + improve mobile

### DIFF
--- a/examples/vanilla/advanced.html
+++ b/examples/vanilla/advanced.html
@@ -65,7 +65,7 @@
           <media-mute-button></media-mute-button>
           <media-volume-range></media-volume-range>
           <media-time-range></media-time-range>
-          <media-time-display showduration remaining></media-time-display>
+          <media-time-display showduration></media-time-display>
           <media-captions-button></media-captions-button>
           <media-playback-rate-button></media-playback-rate-button>
           <media-pip-button></media-pip-button>

--- a/examples/vanilla/advanced.html
+++ b/examples/vanilla/advanced.html
@@ -65,7 +65,7 @@
           <media-mute-button></media-mute-button>
           <media-volume-range></media-volume-range>
           <media-time-range></media-time-range>
-          <media-time-display showduration></media-time-display>
+          <media-time-display showduration remaining></media-time-display>
           <media-captions-button></media-captions-button>
           <media-playback-rate-button></media-playback-rate-button>
           <media-pip-button></media-pip-button>

--- a/src/js/controller.js
+++ b/src/js/controller.js
@@ -145,7 +145,7 @@ export const MediaUIStates = {
 
       return media.currentTime;
     },
-    mediaEvents: ['timeupdate', 'loadedmetadata'],
+    mediaEvents: ['playing', 'pause', 'timeupdate', 'loadedmetadata'],
   },
   MEDIA_DURATION: {
     get: function (controller) {

--- a/src/js/media-chrome-button.js
+++ b/src/js/media-chrome-button.js
@@ -23,6 +23,7 @@ template.innerHTML = /*html*/`
     transition: background .15s linear;
     pointer-events: auto;
     cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
   }
 
   ${/*

--- a/src/js/media-chrome-range.js
+++ b/src/js/media-chrome-range.js
@@ -6,8 +6,6 @@ const template = document.createElement('template');
 template.innerHTML = /*html*/`
   <style>
     :host {
-      --thumb-height: var(--media-range-thumb-height, 10px);
-      --track-height: var(--media-range-track-height, 4px);
       --_focus-box-shadow: var(--media-focus-box-shadow, inset 0 0 0 2px rgb(27 127 204 / .9));
       --_media-range-padding: var(--media-range-padding, var(--media-control-padding, 10px));
 
@@ -47,30 +45,34 @@ template.innerHTML = /*html*/`
       min-height: min(100%, calc(var(--media-control-height, 24px) + 2 * var(--_media-range-padding)));
     }
 
-    input[type=range] {
-      ${/* Reset */''}
+    #range {
       -webkit-appearance: none; ${/* Hides the slider so that custom slider can be made */''}
+      -webkit-tap-highlight-color: transparent;
       background: transparent; ${/* Otherwise white in Chrome */''}
-
-      ${/* Fill host with the range */''}
-      min-height: 100%;
-      width: var(--media-range-track-width, 100%); ${/* Specific width is required for Firefox. */''}
-
       box-sizing: border-box;
-      padding: 0;
       margin: 0;
+      padding: 0;
+      ${/* The input range acts as a hover and hit zone for input events. */''}
+      width: var(--media-range-track-width, 100%); ${/* Firefox requires specific width. */''}
+      transform: translate(var(--media-range-track-translate-x, 0px), calc(var(--media-range-track-translate-y, 0px)));
+      display: var(--media-time-range-hover-display, block);
+      bottom: var(--media-time-range-hover-bottom, -5px);
+      height: var(--media-time-range-hover-height, max(calc(100% + 5px), 20px));
+      position: absolute;
+      cursor: pointer;
+      z-index: 1; ${/* Apply z-index to overlap buttons below. */''}
     }
 
     ${/* Special styling for WebKit/Blink */''}
     ${/* Make thumb width/height small so it has no effect on range click position. */''}
-    input[type=range]::-webkit-slider-thumb {
+    #range::-webkit-slider-thumb {
       -webkit-appearance: none;
       width: .1px;
       height: .1px;
     }
 
     ${/* The thumb is not positioned relative to the track in Firefox */''}
-    input[type=range]::-moz-range-thumb {
+    #range::-moz-range-thumb {
       background: transparent;
       border: transparent;
       width: .1px;
@@ -80,7 +82,7 @@ template.innerHTML = /*html*/`
     #background,
     #track {
       width: var(--media-range-track-width, 100%);
-      height: var(--track-height);
+      height: var(--media-range-track-height, 4px);
       border-radius: var(--media-range-track-border-radius, 1px);
       transform: translate(var(--media-range-track-translate-x, 0px), calc(var(--media-range-track-translate-y, 0px)));
       position: absolute;
@@ -130,8 +132,8 @@ template.innerHTML = /*html*/`
     }
 
     #thumb {
-      height: var(--thumb-height);
       width: var(--media-range-thumb-width, 10px);
+      height: var(--media-range-thumb-height, 10px);
       margin-left: calc(var(--media-range-thumb-width, 10px) / -2);
       border: var(--media-range-thumb-border, none);
       border-radius: var(--media-range-thumb-border-radius, 10px);
@@ -148,23 +150,6 @@ template.innerHTML = /*html*/`
     :host([disabled]) #thumb {
       background-color: #777;
     }
-
-    #hoverzone {
-      display: var(--media-time-range-hover-display, none);
-      bottom: var(--media-time-range-hover-bottom, -5px);
-      height: var(--media-time-range-hover-height, max(calc(100% + 5px), 20px));
-      position: absolute;
-      width: 100%;
-      ${/* Add z-index so it overlaps the top of the control buttons if they are right under. */''}
-      z-index: 1;
-    }
-
-    #range {
-      height: var(--media-range-track-height, 4px);
-      position: relative;
-      cursor: pointer;
-      z-index: 2;
-    }
   </style>
   <div id="container">
     <div id="background"></div>
@@ -173,7 +158,6 @@ template.innerHTML = /*html*/`
       <div id="progress"></div>
       <div id="thumb"></div>
     </div>
-    <div id="hoverzone"></div>
     <input id="range" type="range" min="0" max="1" step="any" value="0">
   </div>
 `;
@@ -335,7 +319,7 @@ class MediaChromeRange extends globalThis.HTMLElement {
   }
 
   updateBar() {
-    const rangePercent = this.range.value * 100;
+    const rangePercent = this.range.valueAsNumber * 100;
 
     const progressRule = getOrInsertCSSRule(this.shadowRoot, '#progress');
     const thumbRule = getOrInsertCSSRule(this.shadowRoot, '#thumb');

--- a/src/js/media-chrome-range.js
+++ b/src/js/media-chrome-range.js
@@ -44,7 +44,7 @@ template.innerHTML = /*html*/`
       position: relative;
       width: 100%;
       height: 100%;
-      min-height: calc(var(--media-control-height, 24px) + 2 * var(--_media-range-padding));
+      min-height: min(100%, calc(var(--media-control-height, 24px) + 2 * var(--_media-range-padding)));
     }
 
     input[type=range] {

--- a/src/js/media-chrome-range.js
+++ b/src/js/media-chrome-range.js
@@ -377,6 +377,8 @@ class MediaChromeRange extends globalThis.HTMLElement {
     this.removeEventListener('input', this);
     this.removeEventListener('pointerdown', this);
     this.removeEventListener('pointerenter', this);
+    globalThis.window?.removeEventListener('pointerup', this);
+    globalThis.window?.removeEventListener('pointermove', this);
   }
 
   handleEvent(evt) {

--- a/src/js/media-chrome-range.js
+++ b/src/js/media-chrome-range.js
@@ -11,19 +11,18 @@ template.innerHTML = /*html*/`
       --_focus-box-shadow: var(--media-focus-box-shadow, inset 0 0 0 2px rgb(27 127 204 / .9));
       --_media-range-padding: var(--media-range-padding, var(--media-control-padding, 10px));
 
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
       vertical-align: middle;
       box-sizing: border-box;
-      display: inline-block;
       position: relative;
+      width: 100px;
       background: var(--media-control-background, var(--media-secondary-color, rgb(20 20 30 / .7)));
       transition: background .15s linear;
-      width: 100px;
-      height: calc(var(--media-control-height, 24px) + 2 * var(--_media-range-padding));
       padding-left: var(--media-range-padding-left, var(--_media-range-padding));
       padding-right: var(--media-range-padding-right, var(--_media-range-padding));
       pointer-events: auto;
-      ${/* needed for vertical align issue 1px off */''}
-      font-size: 0;
       box-shadow: var(--_focus-visible-box-shadow, none);
     }
 
@@ -40,8 +39,12 @@ template.innerHTML = /*html*/`
     }
 
     #container {
+      display: flex;
+      align-items: center;
       position: relative;
+      width: 100%;
       height: 100%;
+      min-height: calc(var(--media-control-height, 24px) + 2 * var(--_media-range-padding));
     }
 
     input[type=range] {
@@ -79,9 +82,8 @@ template.innerHTML = /*html*/`
       width: var(--media-range-track-width, 100%);
       height: var(--track-height);
       border-radius: var(--media-range-track-border-radius, 1px);
-      transform: translate(var(--media-range-track-translate-x, 0px), calc(var(--media-range-track-translate-y, 0px) - 50%));
+      transform: translate(var(--media-range-track-translate-x, 0px), calc(var(--media-range-track-translate-y, 0px)));
       position: absolute;
-      top: 50%;
       pointer-events: none;
     }
 
@@ -249,7 +251,7 @@ class MediaChromeRange extends globalThis.HTMLElement {
     }
 
     const { style } = getOrInsertCSSRule(this.shadowRoot, ':host');
-    style.setProperty('display', `var(--media-control-display, var(--${this.localName}-display, inline-block))`);
+    style.setProperty('display', `var(--media-control-display, var(--${this.localName}-display, inline-flex))`);
 
     this.container = this.shadowRoot.querySelector('#container');
     this.track = this.shadowRoot.querySelector('#track');

--- a/src/js/media-chrome-range.js
+++ b/src/js/media-chrome-range.js
@@ -9,19 +9,18 @@ template.innerHTML = /*html*/`
       --_focus-box-shadow: var(--media-focus-box-shadow, inset 0 0 0 2px rgb(27 127 204 / .9));
       --_media-range-padding: var(--media-range-padding, var(--media-control-padding, 10px));
 
+      box-shadow: var(--_focus-visible-box-shadow, none);
+      background: var(--media-control-background, var(--media-secondary-color, rgb(20 20 30 / .7)));
+      height: calc(var(--media-control-height, 24px) + 2 * var(--_media-range-padding));
       display: inline-flex;
       align-items: center;
-      justify-content: center;
+      ${/* Don't horizontal align w/ justify-content! #container can go negative on the x-axis w/ small width. */''}
       vertical-align: middle;
       box-sizing: border-box;
       position: relative;
       width: 100px;
-      background: var(--media-control-background, var(--media-secondary-color, rgb(20 20 30 / .7)));
       transition: background .15s linear;
-      padding-left: var(--media-range-padding-left, var(--_media-range-padding));
-      padding-right: var(--media-range-padding-right, var(--_media-range-padding));
       pointer-events: auto;
-      box-shadow: var(--_focus-visible-box-shadow, none);
     }
 
     ${/* Reset before `outline` on track could be set by a CSS var */''}
@@ -37,36 +36,42 @@ template.innerHTML = /*html*/`
     }
 
     #container {
+      ${/* Not using the CSS `padding` prop makes it easier for slide open volume ranges so the width can be zero. */''}
+      width: calc(
+        var(--media-range-track-width, 100%)
+        - var(--media-range-padding-left, var(--_media-range-padding))
+        - var(--media-range-padding-right, var(--_media-range-padding)));
+      transform: translate(
+        calc(var(--media-range-track-translate-x, 0px) + var(--media-range-padding-left, var(--_media-range-padding))),
+        var(--media-range-track-translate-y, 0px));
+      height: 100%;
       display: flex;
       align-items: center;
       position: relative;
-      width: 100%;
-      height: 100%;
-      min-height: min(100%, calc(var(--media-control-height, 24px) + 2 * var(--_media-range-padding)));
+      min-width: 40px;
     }
 
     #range {
-      -webkit-appearance: none; ${/* Hides the slider so that custom slider can be made */''}
-      -webkit-tap-highlight-color: transparent;
-      background: transparent; ${/* Otherwise white in Chrome */''}
-      box-sizing: border-box;
-      margin: 0;
-      padding: 0;
       ${/* The input range acts as a hover and hit zone for input events. */''}
-      width: var(--media-range-track-width, 100%); ${/* Firefox requires specific width. */''}
-      transform: translate(var(--media-range-track-translate-x, 0px), calc(var(--media-range-track-translate-y, 0px)));
       display: var(--media-time-range-hover-display, block);
       bottom: var(--media-time-range-hover-bottom, -5px);
       height: var(--media-time-range-hover-height, max(calc(100% + 5px), 20px));
+      width: 100%;
       position: absolute;
       cursor: pointer;
       z-index: 1; ${/* Apply z-index to overlap buttons below. */''}
+
+      -webkit-appearance: none; ${/* Hides the slider so that custom slider can be made */''}
+      -webkit-tap-highlight-color: transparent;
+      background: transparent; ${/* Otherwise white in Chrome */''}
+      margin: 0;
     }
 
     ${/* Special styling for WebKit/Blink */''}
     ${/* Make thumb width/height small so it has no effect on range click position. */''}
     #range::-webkit-slider-thumb {
       -webkit-appearance: none;
+      background: transparent;
       width: .1px;
       height: .1px;
     }
@@ -81,10 +86,9 @@ template.innerHTML = /*html*/`
 
     #background,
     #track {
-      width: var(--media-range-track-width, 100%);
+      width: 100%;
       height: var(--media-range-track-height, 4px);
       border-radius: var(--media-range-track-border-radius, 1px);
-      transform: translate(var(--media-range-track-translate-x, 0px), calc(var(--media-range-track-translate-y, 0px)));
       position: absolute;
       pointer-events: none;
     }
@@ -92,7 +96,6 @@ template.innerHTML = /*html*/`
     #background {
       background: var(--media-range-track-background, rgb(255 255 255 / .2));
       backdrop-filter: var(--media-range-track-background-backdrop-filter);
-      min-width: 40px;
     }
 
     #track {
@@ -104,7 +107,6 @@ template.innerHTML = /*html*/`
       display: flex;
       flex-direction: column;
       justify-content: center;
-      min-width: 40px;
     }
 
     #progress {

--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -542,10 +542,6 @@ class MediaContainer extends globalThis.HTMLElement {
     });
 
     this.addEventListener('pointermove', (e) => {
-      // pointermove doesn't happen with touch on taps on iOS, but does on android,
-      // so, only run pointermove for mouse
-      if (e.pointerType !== 'mouse') return;
-
       setActive();
       // Stay visible if hovered over control bar
       clearTimeout(this._inactiveTimeout);

--- a/src/js/media-control-bar.js
+++ b/src/js/media-control-bar.js
@@ -20,7 +20,7 @@ template.innerHTML = /*html*/`
 
     ::slotted(media-time-range),
     ::slotted(media-volume-range) {
-      height: auto;
+      min-height: 100%;
     }
 
     ::slotted(media-time-range),

--- a/src/js/media-control-bar.js
+++ b/src/js/media-control-bar.js
@@ -18,7 +18,11 @@ template.innerHTML = /*html*/`
       --media-loading-indicator-icon-height: 44px;
     }
 
-    media-time-range,
+    ::slotted(media-time-range),
+    ::slotted(media-volume-range) {
+      height: auto;
+    }
+
     ::slotted(media-time-range),
     ::slotted(media-clip-selector) {
       flex-grow: 1;

--- a/src/js/media-control-bar.js
+++ b/src/js/media-control-bar.js
@@ -4,7 +4,6 @@
   Auto position contorls in a line and set some base colors
 */
 import { MediaStateReceiverAttributes } from './constants.js';
-import { getOrInsertCSSRule } from './utils/element-utils.js';
 import { globalThis, document } from './utils/server-safe-globals.js';
 
 const template = document.createElement('template');
@@ -23,14 +22,6 @@ template.innerHTML = /*html*/`
     ::slotted(media-time-range),
     ::slotted(media-clip-selector) {
       flex-grow: 1;
-    }
-
-    media-time-range,
-    ::slotted(media-time-range),
-    ::slotted(media-clip-selector),
-    media-volume-range,
-    ::slotted(media-volume-range) {
-      height: var(--_range-auto-size, calc(var(--media-control-height, 24px) + 2 * var(--_media-range-padding)));
     }
   </style>
 
@@ -62,14 +53,6 @@ class MediaControlBar extends globalThis.HTMLElement {
       this.attachShadow({ mode: 'open' });
       this.shadowRoot.appendChild(template.content.cloneNode(true));
     }
-
-    this.shadowRoot.querySelector('slot').addEventListener('slotchange', ({ target }) => {
-      const onlyRanges = target.assignedElements({flatten: true})
-        .every(el => ['media-time-range', 'media-volume-range'].includes(el.nodeName.toLowerCase()));
-      const { style } = getOrInsertCSSRule(this.shadowRoot, ':host');
-      const autoSizeHeight = onlyRanges ? 'unset' : 'initial';
-      style.setProperty('--_range-auto-size', autoSizeHeight);
-    });
   }
 
   attributeChangedCallback(attrName, oldValue, newValue) {

--- a/src/js/media-time-display.js
+++ b/src/js/media-time-display.js
@@ -97,14 +97,12 @@ class MediaTimeDisplay extends MediaTextDisplay {
     this.#slot = this.shadowRoot.querySelector('slot');
     this.#slot.innerHTML = `${formatTimesLabel(this)}`;
 
-    const { style } = getOrInsertCSSRule(this.shadowRoot, ':host:not([notoggle])');
-    style.setProperty('cursor', 'pointer');
-
-    const { style: hoverStyle } = getOrInsertCSSRule(
+    const { style } = getOrInsertCSSRule(
       this.shadowRoot,
       ':host(:hover:not([notoggle]))'
     );
-    hoverStyle.setProperty(
+    style.setProperty('cursor', 'pointer');
+    style.setProperty(
       'background',
       'var(--media-control-hover-background, rgba(50 50 70 / .7))'
     );

--- a/src/js/media-time-range.js
+++ b/src/js/media-time-range.js
@@ -144,7 +144,8 @@ template.innerHTML = /*html*/`
 
 const calcRangeValueFromTime = (el, time = el.mediaCurrentTime) => {
   if (Number.isNaN(el.mediaSeekableEnd)) return 0;
-  return (time - el.mediaSeekableStart) / (el.mediaSeekableEnd - el.mediaSeekableStart);
+  const value = (time - el.mediaSeekableStart) / (el.mediaSeekableEnd - el.mediaSeekableStart);
+  return Math.max(0, Math.min(value, 1));
 }
 
 const calcTimeFromRangeValue = (el, value = el.range.value) => {
@@ -482,10 +483,8 @@ class MediaTimeRange extends MediaChromeRange {
       relativeBufferedEnd = 1;
     }
 
-    const buffPercent = Math.max(0, Math.min(relativeBufferedEnd, 1)) * 100;
-
     const { style } = getOrInsertCSSRule(this.shadowRoot, '#buffered');
-    style.setProperty('width', `${buffPercent}%`);
+    style.setProperty('width', `${relativeBufferedEnd * 100}%`);
   }
 
   updateCurrentBox() {

--- a/src/js/media-volume-range.js
+++ b/src/js/media-volume-range.js
@@ -52,24 +52,24 @@ class MediaVolumeRange extends MediaChromeRange {
   }
 
   connectedCallback() {
-    this.range.setAttribute('aria-label', nouns.VOLUME());
     super.connectedCallback();
+    this.range.setAttribute('aria-label', nouns.VOLUME());
   }
 
   attributeChangedCallback(attrName, oldValue, newValue) {
+    super.attributeChangedCallback(attrName, oldValue, newValue);
+
     if (
       attrName === MediaUIAttributes.MEDIA_VOLUME ||
       attrName === MediaUIAttributes.MEDIA_MUTED
     ) {
-      const newVolume = toVolume(this);
-      this.range.value = newVolume;
+      this.range.valueAsNumber = toVolume(this);
       this.range.setAttribute(
         'aria-valuetext',
         formatAsPercentString(this.range)
       );
       this.updateBar();
     }
-    super.attributeChangedCallback(attrName, oldValue, newValue);
   }
 
   /**

--- a/src/js/media-volume-range.js
+++ b/src/js/media-volume-range.js
@@ -11,16 +11,14 @@ import {
   setStringAttr,
 } from './utils/element-utils.js';
 
-const DEFAULT_MAX_VOLUME = 100;
 const DEFAULT_VOLUME = 1;
 
 const toVolume = (el) => {
   if (el.mediaMuted) return 0;
-  return Math.round(el.mediaVolume * el.range.max);
+  return el.mediaVolume;
 };
 
-const formatAsPercentString = ({ value, max }) =>
-  `${Math.round((value / max) * 100)}%`;
+const formatAsPercentString = ({ value }) => `${value}%`;
 
 /**
  * @attr {string} mediavolume - (read-only) Set to the media volume.
@@ -42,11 +40,8 @@ class MediaVolumeRange extends MediaChromeRange {
   constructor() {
     super();
 
-    this.range.max = DEFAULT_MAX_VOLUME;
-
     this.range.addEventListener('input', () => {
-      const newVolume = this.range.value / this.range.max;
-      const detail = newVolume;
+      const detail = this.range.value;
       const evt = new globalThis.CustomEvent(MediaUIEvents.MEDIA_VOLUME_REQUEST, {
         composed: true,
         bubbles: true,

--- a/src/js/media-volume-range.js
+++ b/src/js/media-volume-range.js
@@ -18,7 +18,7 @@ const toVolume = (el) => {
   return el.mediaVolume;
 };
 
-const formatAsPercentString = ({ value }) => `${value}%`;
+const formatAsPercentString = ({ value }) => `${Math.round(value * 100)}%`;
 
 /**
  * @attr {string} mediavolume - (read-only) Set to the media volume.

--- a/src/js/themes/youtube.js
+++ b/src/js/themes/youtube.js
@@ -71,8 +71,6 @@ template.innerHTML = /*html*/`
   }
 
   media-volume-range {
-    padding-left: 0px;
-
     --media-range-track-background: rgba(255,255,255,.2);
   }
 
@@ -81,13 +79,8 @@ template.innerHTML = /*html*/`
   }
 
   media-mute-button + media-volume-range {
-    width: 0px;
+    width: 0;
     overflow: hidden;
-    padding-right: 0px;
-    --media-range-track-translate-x: 7px;
-
-    /* Set the internal width so it reveals, not grows */
-    --media-range-track-width: 50px;
     transition: width 0.2s ease-in;
   }
 

--- a/src/js/themes/youtube.js
+++ b/src/js/themes/youtube.js
@@ -84,9 +84,10 @@ template.innerHTML = /*html*/`
     width: 0px;
     overflow: hidden;
     padding-right: 0px;
+    --media-range-track-translate-x: 7px;
 
     /* Set the internal width so it reveals, not grows */
-    --media-range-track-width: 60px;
+    --media-range-track-width: 50px;
     transition: width 0.2s ease-in;
   }
 

--- a/src/js/utils/element-utils.js
+++ b/src/js/utils/element-utils.js
@@ -39,6 +39,24 @@ export function getActiveElement(root = document) {
 }
 
 /**
+ * Checks if the element is visible includes opacity: 0 and visibility: hidden.
+ * @param  {HTMLElement} el
+ * @return {Boolean}
+ */
+export function isElementVisible(el) {
+  // Supported by Chrome and Firefox https://caniuse.com/mdn-api_element_checkvisibility
+  // https://drafts.csswg.org/cssom-view-1/#dom-element-checkvisibility
+  // @ts-ignore
+  if (el.checkVisibility) {
+    // @ts-ignore
+    return el.checkVisibility({ checkOpacity: true, checkVisibilityCSS: true });
+  }
+  // Check if the element or its parent is hidden.
+  // This doesn't go up the tree further than the parent because getComputedStyle is expensive.
+  return getComputedStyle(el).opacity != '0' && getComputedStyle(el.parentElement).opacity != '0';
+}
+
+/**
  * Get or insert a CSS rule with a selector in an element containing <style> tags.
  * @param  {Element|ShadowRoot} styleParent
  * @param  {string} selectorText

--- a/src/js/utils/range-animation.js
+++ b/src/js/utils/range-animation.js
@@ -1,0 +1,79 @@
+/**
+ * Smoothly animate a range input accounting for hiccups and diverging playback.
+ */
+export class RangeAnimation {
+  #range;
+  #startTime;
+  #previousTime;
+  #deltaTime;
+  #frameCount;
+  #updateTimestamp;
+  #updateStartValue;
+  #lastRangeIncrease;
+  #id = 0;
+
+  constructor(range, callback, fps) {
+    this.#range = range;
+    this.callback = callback;
+    this.fps = fps;
+  }
+
+  start() {
+    if (this.#id !== 0) return;
+
+    this.#previousTime = performance.now();
+    this.#startTime = this.#previousTime;
+    this.#frameCount = 0;
+    this.#animate();
+  }
+
+  stop() {
+    if (this.#id === 0) return;
+
+    cancelAnimationFrame(this.#id);
+    this.#id = 0;
+  }
+
+  update({ start, duration, playbackRate }) {
+    // 1. Always allow increases.
+    // 2. Allow a relatively large decrease (user action or Safari jumping back :s).
+    const increase = start - this.#range.valueAsNumber;
+    if (increase > 0 || increase < -.03) {
+      this.callback(start);
+    }
+
+    this.#updateStartValue = start;
+    this.#updateTimestamp = performance.now();
+    this.duration = duration;
+    this.playbackRate = playbackRate;
+  }
+
+  #animate = (now = performance.now()) => {
+    this.#id = requestAnimationFrame(this.#animate);
+    this.#deltaTime = performance.now() - this.#previousTime;
+    const fpsInterval = 1000 / this.fps;
+
+    if (this.#deltaTime > fpsInterval) {
+      // Get ready for next frame by setting previousTime=now, but also adjust for your
+      // specified fpsInterval not being a multiple of RAF's interval (16.7ms)
+      this.#previousTime = now - (this.#deltaTime % fpsInterval);
+
+      const fps = 1000 / ((now - this.#startTime) / ++this.#frameCount);
+      const delta = (now - this.#updateTimestamp) / 1000 / this.duration;
+      let value = this.#updateStartValue + delta * this.playbackRate;
+      const increase = value - this.#range.valueAsNumber;
+
+      // If the increase is negative, the animation was faster than the playhead.
+      // Can happen on video startup. Slow down the animation to match the playhead.
+      if (increase > 0) {
+        // A perfect increase at this frame rate should be this much.
+        this.#lastRangeIncrease = this.playbackRate / this.duration / fps;
+      } else {
+        this.#lastRangeIncrease = .995 * this.#lastRangeIncrease;
+        value = this.#range.valueAsNumber + this.#lastRangeIncrease;
+      }
+
+      this.callback(value);
+    }
+  }
+}


### PR DESCRIPTION
related discussion: https://github.com/muxinc/media-chrome/discussions/421

- [x] fix jitteriness of progress bar on video startup (especially noticeable in Safari)
- [x] fix not hiding controls while dragging on mobile #751
- [x] add touch move handler for mobile enabling dragging #662

--- 

this change removes the variable `min` and `max` values from the range and sets them to a fixed `0` and `1`.
it simplifies the code as you can see in this PR.

this change doesn't use the UI from input[type=range] anymore but the range is still used as state object, event listener.
this will allow new features and more flexibility, some examples:

- less have to worry about browser inconsistencies in styling the range
- a gradient as background color of the progress bar
- using transitions on the progress bar width and left positioning of the thumb
- it does away with the annoying calculating issue where you have to incorporate the thumb width of the range