### PR TITLE
fix: select keyboard focus

### DIFF
--- a/examples/vanilla/control-elements/media-playback-rate-listbox.html
+++ b/examples/vanilla/control-elements/media-playback-rate-listbox.html
@@ -72,6 +72,10 @@
           border-radius: 8px;
           background: currentcolor;
         }
+
+        [slot="select-indicator"] {
+          display: none;
+        }
       </style>
     </span>
   </media-playback-rate-listbox>

--- a/src/js/experimental/media-chrome-selectmenu.js
+++ b/src/js/experimental/media-chrome-selectmenu.js
@@ -21,7 +21,7 @@ template.innerHTML = /*html*/`
     max-height: 300px;
     overflow: hidden auto;
     transition: var(--media-selectmenu-transition-in,
-      visibility .15s ease-out, transform .15s ease-out, opacity .15s ease-out);
+      visibility 0s, transform .15s ease-out, opacity .15s ease-out);
     transform: var(--media-listbox-transform-in, translateY(0) scale(1));
     visibility: visible;
     opacity: 1;


### PR DESCRIPTION
when opening the select list keyboard focus wouldn't jump from button to list.
removing the fade in duration of visibility fixed this.