### PR TITLE
fix: -:-- time codes on player load to 0:00

### DIFF
--- a/src/js/utils/time.js
+++ b/src/js/utils/time.js
@@ -80,7 +80,7 @@ export function formatTime(seconds, guide) {
   if (isNaN(seconds) || seconds === Infinity) {
     // '-' is false for all relational operators (e.g. <, >=) so this setting
     // will add the minimum number of fields specified by the guide
-    h = m = s = '-';
+    h = m = s = '0';
   }
 
   // Check if we need to show hours


### PR DESCRIPTION
this was recently introduced with the NaN return value in getNumericAttr I think.

it looks pretty bad sometimes https://media-chrome.mux.dev/examples/vanilla/mobile.html