### PR TITLE
fix: revert resize callback delay

### DIFF
--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -322,20 +322,7 @@ class MediaContainer extends globalThis.HTMLElement {
     const mutationObserver = new MutationObserver(mutationCallback);
     mutationObserver.observe(this, { childList: true, subtree: true });
 
-    let pendingResizeCb = false;
-    const deferResizeCallback = (entries) => {
-      // Already have a pending async breakpoint computation, so go ahead and bail
-      if (pendingResizeCb) return;
-      // Just in case it takes too long (which will cause an error to throw),
-      // do the breakpoint computation asynchronously
-      setTimeout(() => {
-        resizeCallback(entries);
-        // Once we've completed, reset the pending cb flag to false
-        pendingResizeCb = false;
-      }, 0);
-      pendingResizeCb = true;
-    };
-    const resizeObserver = new ResizeObserver(deferResizeCallback);
+    const resizeObserver = new ResizeObserver(resizeCallback);
     this.resizeObserver = resizeObserver;
     resizeObserver.observe(this);
 


### PR DESCRIPTION
even this delay of 0s was causing a render jank on player load :(

see here https://elements-demo-nextjs.vercel.app/MuxPlayer?title=%22Landscape+VOD+%28White+Background%29%22&playbackId=%22VcmKA6aqzIzlg3MayLJDnbF55kX00mds028Z65QxvBYaA%22&metadata=%7B%22video_id%22%3A%22videoId1%22%2C%22video_title%22%3A%22Title%3A+Landscape+VOD+%28White+Background%29%22%7D

I think best to revert now and soon do r&d where we can best split up the long running JS tasks that will cause the resize observer loop limit exceeded error.