### PR TITLE
Listbox fixes

### DIFF
--- a/examples/vanilla/control-elements/media-chrome-listbox.html
+++ b/examples/vanilla/control-elements/media-chrome-listbox.html
@@ -11,6 +11,10 @@
         cursor: not-allowed;
       }
 
+      media-chrome-listbox {
+        --media-option-selected-background: rgb(255 255 255 / .5);
+      }
+
       .examples {
         margin-top: 20px;
       }

--- a/examples/vanilla/control-elements/media-playback-rate-listbox.html
+++ b/examples/vanilla/control-elements/media-playback-rate-listbox.html
@@ -6,6 +6,11 @@
   <script type="module" src="../../../dist/index.js"></script>
   <script type="module" src="../../../../dist/experimental/media-playback-rate-listbox.js"></script>
   <style>
+    /* Hide custom elements that are not defined yet */
+    :not(:defined) {
+      display: none;
+    }
+
     /** add styles to prevent CLS (Cumulative Layout Shift) */
     media-controller:not([audio]) {
       display: block;         /* expands the container if preload=none */
@@ -61,7 +66,6 @@
           margin-top: -.14em;
           vertical-align: middle;
           border-radius: 50%;
-          visibility: visible;
         }
 
         [aria-selected="true"] .select-icon::after {
@@ -71,10 +75,6 @@
           height: 4px;
           border-radius: 8px;
           background: currentcolor;
-        }
-
-        [slot="select-indicator"] {
-          display: none;
         }
       </style>
     </span>

--- a/examples/vanilla/control-elements/media-playback-rate-selectmenu.html
+++ b/examples/vanilla/control-elements/media-playback-rate-selectmenu.html
@@ -6,6 +6,11 @@
   <script type="module" src="../../../dist/index.js"></script>
   <script type="module" src="../../../../dist/experimental/media-playback-rate-selectmenu.js"></script>
   <style>
+    /* Hide custom elements that are not defined yet */
+    :not(:defined) {
+      display: none;
+    }
+
     /** add styles to prevent CLS (Cumulative Layout Shift) */
     media-controller:not([audio]) {
       display: block;         /* expands the container if preload=none */
@@ -56,7 +61,6 @@
                 margin-top: -.14em;
                 vertical-align: middle;
                 border-radius: 50%;
-                visibility: visible;
               }
 
               [aria-selected="true"] .select-icon::after {
@@ -66,10 +70,6 @@
                 height: 4px;
                 border-radius: 8px;
                 background: currentcolor;
-              }
-
-              [slot="select-indicator"] {
-                display: none;
               }
             </style>
           </span>

--- a/examples/vanilla/control-elements/media-rendition-selectmenu.html
+++ b/examples/vanilla/control-elements/media-rendition-selectmenu.html
@@ -20,6 +20,18 @@
       display: none;
     }
 
+    :not(:defined) .rendition-title {
+      display: none;
+    }
+
+    .rendition-title {
+      background: rgb(20 20 30 / .8);
+      border-bottom: 1px solid rgb(255 255 255 / .38);
+      border-radius: 2px 2px 0 0;
+      text-align: center;
+      padding-block: .4em;
+    }
+
     video {
       width: 100%;      /* prevents video to expand beyond its container */
     }
@@ -47,7 +59,12 @@
       <media-time-display showduration></media-time-display>
       <media-time-range></media-time-range>
       <media-mute-button></media-mute-button>
-      <media-rendition-selectmenu></media-rendition-selectmenu>
+      <media-rendition-selectmenu>
+        <div slot="listbox">
+          <div class="rendition-title">Quality</div>
+          <media-rendition-listbox></media-rendition-listbox>
+        </div>
+      </media-rendition-selectmenu>
       <media-pip-button></media-pip-button>
       <media-fullscreen-button></media-fullscreen-button>
     </media-control-bar>

--- a/examples/vanilla/control-elements/media-rendition-selectmenu.html
+++ b/examples/vanilla/control-elements/media-rendition-selectmenu.html
@@ -7,6 +7,11 @@
   <script type="module" src="../../../dist/index.js"></script>
   <script type="module" src="../../../../dist/experimental/media-rendition-selectmenu.js"></script>
   <style>
+    /* Hide custom elements that are not defined yet */
+    :not(:defined) {
+      display: none;
+    }
+
     /** add styles to prevent CLS (Cumulative Layout Shift) */
     media-controller:not([audio]) {
       display: block;         /* expands the container if preload=none */
@@ -14,26 +19,14 @@
       aspect-ratio: 16 / 9;   /* set container aspect ratio if preload=none */
     }
 
+    video {
+      width: 100%;      /* prevents video to expand beyond its container */
+    }
+
     media-rendition-selectmenu[mediarenditionunavailable],
     media-fullscreen-button[mediafullscreenunavailable],
     media-pip-button[mediapipunavailable] {
       display: none;
-    }
-
-    :not(:defined) .rendition-title {
-      display: none;
-    }
-
-    .rendition-title {
-      background: rgb(20 20 30 / .8);
-      border-bottom: 1px solid rgb(255 255 255 / .38);
-      border-radius: 2px 2px 0 0;
-      text-align: center;
-      padding-block: .4em;
-    }
-
-    video {
-      width: 100%;      /* prevents video to expand beyond its container */
     }
 
     .examples {
@@ -60,10 +53,9 @@
       <media-time-range></media-time-range>
       <media-mute-button></media-mute-button>
       <media-rendition-selectmenu>
-        <div slot="listbox">
-          <div class="rendition-title">Quality</div>
-          <media-rendition-listbox></media-rendition-listbox>
-        </div>
+        <media-rendition-listbox slot="listbox">
+          <div slot="header">Quality</div>
+        </media-rendition-listbox>
       </media-rendition-selectmenu>
       <media-pip-button></media-pip-button>
       <media-fullscreen-button></media-fullscreen-button>

--- a/src/js/experimental/media-captions-listbox.js
+++ b/src/js/experimental/media-captions-listbox.js
@@ -1,11 +1,11 @@
-import { MediaChromeListbox, createOption } from './media-chrome-listbox.js';
+import { MediaChromeListbox, createOption, createIndicator } from './media-chrome-listbox.js';
 import './media-chrome-option.js';
 import { globalThis, document } from '../utils/server-safe-globals.js';
 import { MediaUIAttributes, MediaUIEvents } from '../constants.js';
 import { parseTextTracksStr, stringifyTextTrackList, formatTextTrackObj, toggleSubsCaps } from '../utils/captions.js';
 
 const ccIcon = /*html*/`
-<svg aria-hidden="true" viewBox="0 0 26 24">
+<svg aria-hidden="true" viewBox="0 0 26 24" part="captions-indicator indicator">
   <path d="M22.83 5.68a2.58 2.58 0 0 0-2.3-2.5c-3.62-.24-11.44-.24-15.06 0a2.58 2.58 0 0 0-2.3 2.5c-.23 4.21-.23 8.43 0 12.64a2.58 2.58 0 0 0 2.3 2.5c3.62.24 11.44.24 15.06 0a2.58 2.58 0 0 0 2.3-2.5c.23-4.21.23-8.43 0-12.64Zm-11.39 9.45a3.07 3.07 0 0 1-1.91.57 3.06 3.06 0 0 1-2.34-1 3.75 3.75 0 0 1-.92-2.67 3.92 3.92 0 0 1 .92-2.77 3.18 3.18 0 0 1 2.43-1 2.94 2.94 0 0 1 2.13.78c.364.359.62.813.74 1.31l-1.43.35a1.49 1.49 0 0 0-1.51-1.17 1.61 1.61 0 0 0-1.29.58 2.79 2.79 0 0 0-.5 1.89 3 3 0 0 0 .49 1.93 1.61 1.61 0 0 0 1.27.58 1.48 1.48 0 0 0 1-.37 2.1 2.1 0 0 0 .59-1.14l1.4.44a3.23 3.23 0 0 1-1.07 1.69Zm7.22 0a3.07 3.07 0 0 1-1.91.57 3.06 3.06 0 0 1-2.34-1 3.75 3.75 0 0 1-.92-2.67 3.88 3.88 0 0 1 .93-2.77 3.14 3.14 0 0 1 2.42-1 3 3 0 0 1 2.16.82 2.8 2.8 0 0 1 .73 1.31l-1.43.35a1.49 1.49 0 0 0-1.51-1.21 1.61 1.61 0 0 0-1.29.58A2.79 2.79 0 0 0 15 12a3 3 0 0 0 .49 1.93 1.61 1.61 0 0 0 1.27.58 1.44 1.44 0 0 0 1-.37 2.1 2.1 0 0 0 .6-1.15l1.4.44a3.17 3.17 0 0 1-1.1 1.7Z"/>
 </svg>`;
 
@@ -30,17 +30,10 @@ class MediaCaptionsListbox extends MediaChromeListbox {
     ];
   }
 
-  /** @type {Element} */
-  #captionsIndicator;
-  /** @type {Element} */
-  #selectIndicator;
   #prevState;
 
   constructor() {
     super({ slotTemplate });
-
-    this.#selectIndicator = this.getSlottedIndicator('select');
-    this.#captionsIndicator = this.getSlottedIndicator('captions');
   }
 
   attributeChangedCallback(attrName, oldValue, newValue) {
@@ -103,7 +96,7 @@ class MediaCaptionsListbox extends MediaChromeListbox {
     const isOff = !this.value;
 
     const option = createOption(this.formatOptionText('Off'), 'off', isOff);
-    option.prepend(this.#selectIndicator.cloneNode(true));
+    option.prepend(createIndicator(this, 'select-indicator'));
     container.append(option);
 
     const subtitlesList = this.mediaSubtitlesList;
@@ -116,12 +109,12 @@ class MediaCaptionsListbox extends MediaChromeListbox {
         formatTextTrackObj(subs),
         this.value == formatTextTrackObj(subs),
       );
-      option.prepend(this.#selectIndicator.cloneNode(true));
+      option.prepend(createIndicator(this, 'select-indicator'));
 
       // add CC icon for captions
       const type = subs.kind ?? 'subs';
       if (type === 'captions') {
-        option.append(this.#captionsIndicator.cloneNode(true));
+        option.append(createIndicator(this, 'captions-indicator'));
       }
 
       container.append(option);

--- a/src/js/experimental/media-captions-listbox.js
+++ b/src/js/experimental/media-captions-listbox.js
@@ -11,10 +11,12 @@ const ccIcon = /*html*/`
 
 const slotTemplate = document.createElement('template');
 slotTemplate.innerHTML = /*html*/`
-  <slot hidden name="captions-indicator">${ccIcon}</slot>
+  <slot name="captions-indicator" hidden>${ccIcon}</slot>
 `;
 
 /**
+ * @slot captions-indicator - An icon element indicating an option with closed captions.
+ *
  * @attr {string} mediasubtitleslist - (read-only) A list of all subtitles and captions.
  * @attr {boolean} mediasubtitlesshowing - (read-only) A list of the showing subtitles and captions.
  */

--- a/src/js/experimental/media-chrome-listbox.js
+++ b/src/js/experimental/media-chrome-listbox.js
@@ -36,6 +36,12 @@ template.innerHTML = /*html*/`
     padding: .5em 0;
   }
 
+  ::slotted([slot=header]) {
+    padding: 0 1.4em .4em;
+    margin-bottom: .5em;
+    border-bottom: 1px solid rgb(255 255 255 / .25);
+  }
+
   media-chrome-option {
     padding-inline: .7em 1.4em;
   }
@@ -58,8 +64,11 @@ template.innerHTML = /*html*/`
     visibility: visible;
   }
 </style>
+<slot name="header"></slot>
 <slot id="container"></slot>
-<slot hidden name="select-indicator">${checkIcon}</slot>
+<slot name="select-indicator" hidden>
+  ${checkIcon}
+</slot>
 `;
 
 /**

--- a/src/js/experimental/media-chrome-listbox.js
+++ b/src/js/experimental/media-chrome-listbox.js
@@ -30,6 +30,7 @@ template.innerHTML = /*html*/`
       var(--media-font-family, helvetica neue, segoe ui, roboto, arial, sans-serif));
     color: var(--media-text-color, var(--media-primary-color, rgb(238 238 238)));
     background: var(--media-listbox-background, var(--media-control-background, var(--media-secondary-color, rgb(20 20 30 / .8))));
+    border-radius: var(--media-listbox-border-radius);
     display: inline-flex;
     gap: .5em;
     margin: 0;
@@ -74,6 +75,7 @@ template.innerHTML = /*html*/`
  *
  * @cssproperty --media-control-background - `background` of control.
  * @cssproperty --media-listbox-background - `background` of listbox.
+ * @cssproperty --media-listbox-border-radius - `border-radius` of listbox.
  *
  * @cssproperty --media-font - `font` shorthand property.
  * @cssproperty --media-font-weight - `font-weight` property.

--- a/src/js/experimental/media-chrome-listbox.js
+++ b/src/js/experimental/media-chrome-listbox.js
@@ -32,8 +32,7 @@ template.innerHTML = /*html*/`
     background: var(--media-listbox-background, var(--media-control-background, var(--media-secondary-color, rgb(20 20 30 / .8))));
     border-radius: var(--media-listbox-border-radius);
     display: inline-block;
-    margin: 0;
-    padding: .5em 0;
+    padding-block: .5em;
   }
 
   ::slotted([slot=header]) {
@@ -66,13 +65,15 @@ template.innerHTML = /*html*/`
 </style>
 <slot name="header"></slot>
 <slot id="container"></slot>
-<slot name="select-indicator" hidden>
-  ${checkIcon}
-</slot>
+<slot name="select-indicator" hidden>${checkIcon}</slot>
 `;
 
 /**
  * @extends {HTMLElement}
+ *
+ * @slot - Default slotted elements.
+ * @slot header - An element shown at the top of the listbox.
+ * @slot select-indicator - An icon element indicating a selected option.
  *
  * @attr {boolean} disabled - The Boolean disabled attribute makes the element not mutable or focusable.
  * @attr {string} mediacontroller - The element `id` of the media controller to connect to (if not nested within).

--- a/src/js/experimental/media-chrome-listbox.js
+++ b/src/js/experimental/media-chrome-listbox.js
@@ -31,8 +31,7 @@ template.innerHTML = /*html*/`
     color: var(--media-text-color, var(--media-primary-color, rgb(238 238 238)));
     background: var(--media-listbox-background, var(--media-control-background, var(--media-secondary-color, rgb(20 20 30 / .8))));
     border-radius: var(--media-listbox-border-radius);
-    display: inline-flex;
-    gap: .5em;
+    display: inline-block;
     margin: 0;
     padding: .5em 0;
   }
@@ -59,7 +58,7 @@ template.innerHTML = /*html*/`
     visibility: visible;
   }
 </style>
-<div id="container"></div>
+<slot id="container"></slot>
 <slot hidden name="select-indicator">${checkIcon}</slot>
 `;
 
@@ -120,6 +119,16 @@ class MediaChromeListbox extends globalThis.HTMLElement {
     }
 
     this.container = this.shadowRoot.querySelector('#container');
+
+    this.container.addEventListener('slotchange', (event) => {
+      // @ts-ignore
+      for (let node of event.target.assignedNodes({ flatten: true })) {
+        // Remove all whitespace text nodes so the unnamed slot shows its fallback content.
+        if (node.nodeType === 3 && node.textContent.trim() === '') {
+          node.remove();
+        }
+      }
+    });
   }
 
   formatOptionText(text, data) {
@@ -138,6 +147,8 @@ class MediaChromeListbox extends globalThis.HTMLElement {
     if (!indicator)
       indicator = this.shadowRoot.querySelector(`[name="${name}-indicator"] > svg`);
 
+    // @ts-ignore
+    indicator = indicator.cloneNode(true);
     indicator.removeAttribute('slot');
     indicator.part.add('indicator');
     indicator.classList.add(`${name}-indicator`);

--- a/src/js/experimental/media-chrome-option.js
+++ b/src/js/experimental/media-chrome-option.js
@@ -149,15 +149,15 @@ class MediaChromeOption extends globalThis.HTMLElement {
     const options = this.#ownerElement?.options;
     if (!options) return;
 
-    const hasActiveOption = options.some(option => option.getAttribute('tabindex') === '0');
-    // If the user set an element as active, we should use that rather than assume a default.
-    if (hasActiveOption) return;
-
-    // Default to the aria-selected element if there isn't an active element already.
-    let selectedOption = options.find(option => option.getAttribute('aria-selected') === 'true');
+    // Default to the last aria-selected element if there isn't an active element already.
+    let selectedOption = options.filter(option => option.getAttribute('aria-selected') === 'true').pop();
 
     // If there isn't an active element or a selected element, default to the first element.
     if (!selectedOption) selectedOption = options[0];
+
+    if (this.#ownerElement.getAttribute('aria-multiselectable') !== 'true') {
+      options.forEach(option => option.setAttribute('aria-selected', 'false'));
+    }
 
     selectedOption?.setAttribute('tabindex', '0');
     selectedOption?.setAttribute('aria-selected', 'true');

--- a/src/js/experimental/media-chrome-option.js
+++ b/src/js/experimental/media-chrome-option.js
@@ -156,7 +156,10 @@ class MediaChromeOption extends globalThis.HTMLElement {
     if (!selectedOption) selectedOption = options[0];
 
     if (this.#ownerElement.getAttribute('aria-multiselectable') !== 'true') {
-      options.forEach(option => option.setAttribute('aria-selected', 'false'));
+      options.forEach(option => {
+        option.setAttribute('tabindex', '-1');
+        option.setAttribute('aria-selected', 'false')
+      });
     }
 
     selectedOption?.setAttribute('tabindex', '0');

--- a/src/js/experimental/media-chrome-selectmenu.js
+++ b/src/js/experimental/media-chrome-selectmenu.js
@@ -8,6 +8,12 @@ const template = document.createElement('template');
 template.innerHTML = /*html*/`
   <style>
   :host {
+    font: var(--media-font,
+      var(--media-font-weight, normal)
+      var(--media-font-size, 15px) /
+      var(--media-text-content-height, var(--media-control-height, 24px))
+      var(--media-font-family, helvetica neue, segoe ui, roboto, arial, sans-serif));
+    color: var(--media-text-color, var(--media-primary-color, rgb(238 238 238)));
     display: inline-flex;
     position: relative;
     flex-shrink: .5;

--- a/src/js/experimental/media-playback-rate-listbox.js
+++ b/src/js/experimental/media-playback-rate-listbox.js
@@ -1,4 +1,4 @@
-import { MediaChromeListbox, createOption } from './media-chrome-listbox.js';
+import { MediaChromeListbox, createOption, createIndicator } from './media-chrome-listbox.js';
 import './media-chrome-option.js';
 import { DEFAULT_RATES, DEFAULT_RATE } from '../media-playback-rate-button.js';
 import { MediaUIAttributes, MediaUIEvents } from '../constants.js';
@@ -24,14 +24,11 @@ class MediaPlaybackRateListbox extends MediaChromeListbox {
     ];
   }
 
-  /** @type {Element} */
-  #selectIndicator;
   #rates = new AttributeTokenList(this, Attributes.RATES, { defaultValue: DEFAULT_RATES });
 
   constructor() {
     super();
 
-    this.#selectIndicator = this.getSlottedIndicator('select');
     this.#render();
   }
 
@@ -98,7 +95,7 @@ class MediaPlaybackRateListbox extends MediaChromeListbox {
         rate,
         this.mediaPlaybackRate == rate
       );
-      option.prepend(this.#selectIndicator.cloneNode(true));
+      option.prepend(createIndicator(this, 'select-indicator'));
       container.append(option);
     }
   }

--- a/src/js/experimental/media-rendition-listbox.js
+++ b/src/js/experimental/media-rendition-listbox.js
@@ -1,4 +1,4 @@
-import { MediaChromeListbox, createOption } from './media-chrome-listbox.js';
+import { MediaChromeListbox, createOption, createIndicator } from './media-chrome-listbox.js';
 import './media-chrome-option.js';
 import { globalThis } from '../utils/server-safe-globals.js';
 import { getStringAttr, setStringAttr } from '../utils/element-utils.js';
@@ -18,16 +18,8 @@ class MediaRenditionListbox extends MediaChromeListbox {
     ];
   }
 
-  /** @type {Element} */
-  #selectIndicator;
   #renditionList = [];
   #prevState;
-
-  constructor() {
-    super();
-
-    this.#selectIndicator = this.getSlottedIndicator('select');
-  }
 
   attributeChangedCallback(attrName, oldValue, newValue) {
     super.attributeChangedCallback(attrName, oldValue, newValue);
@@ -98,13 +90,13 @@ class MediaRenditionListbox extends MediaChromeListbox {
         `${rendition.id}`,
         rendition.selected && !isAuto
       );
-      option.prepend(this.#selectIndicator.cloneNode(true));
+      option.prepend(createIndicator(this, 'select-indicator'));
 
       container.append(option);
     }
 
     const option = createOption(this.formatOptionText('Auto'), 'auto', isAuto);
-    option.prepend(this.#selectIndicator.cloneNode(true));
+    option.prepend(createIndicator(this, 'select-indicator'));
     container.append(option);
   }
 

--- a/src/js/experimental/media-rendition-listbox.js
+++ b/src/js/experimental/media-rendition-listbox.js
@@ -85,10 +85,6 @@ class MediaRenditionListbox extends MediaChromeListbox {
 
     let isAuto = !this.mediaRenditionSelected;
 
-    const option = createOption(this.formatOptionText('Auto'), 'auto', isAuto);
-    option.prepend(this.#selectIndicator.cloneNode(true));
-    container.append(option);
-
     for (const rendition of renditionList) {
 
       const text = this.formatOptionText(
@@ -100,12 +96,16 @@ class MediaRenditionListbox extends MediaChromeListbox {
       const option = createOption(
         text,
         `${rendition.id}`,
-        rendition.enabled && !isAuto
+        rendition.selected && !isAuto
       );
       option.prepend(this.#selectIndicator.cloneNode(true));
 
       container.append(option);
     }
+
+    const option = createOption(this.formatOptionText('Auto'), 'auto', isAuto);
+    option.prepend(this.#selectIndicator.cloneNode(true));
+    container.append(option);
   }
 
   #onChange() {


### PR DESCRIPTION
- adds a header slot to listbox + example
  https://media-chrome-git-fork-luwes-listbox-fixes-mux.vercel.app/examples/vanilla/control-elements/media-rendition-selectmenu.html
- adds a border-radius CSS var for listbox
- adds default font and color styles to the selectlist
- moves the `Auto` option to the bottom
- fixes an issue using the media-chrome-listbox as standalone 
  https://media-chrome-git-fork-luwes-listbox-fixes-mux.vercel.app/examples/vanilla/control-elements/media-chrome-listbox.html