### PR TITLE
fix: make poster slot work with fallback

### DIFF
--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -161,7 +161,8 @@ template.innerHTML = /*html*/`
       align-self: stretch;
     }
 
-    :host([${MediaUIAttributes.MEDIA_HAS_PLAYED}]) ::slotted([slot=poster]) {
+    ${/* ::slotted([slot=poster]) doesn't work for slot fallback content so hide parent slot instead */ ''}
+    :host(:not([${Attributes.AUDIO}])[${MediaUIAttributes.MEDIA_HAS_PLAYED}]) slot[name=poster] {
       display: none;
     }
   </style>


### PR DESCRIPTION
with fallback content. preparation for allowing a slotted poster image in Mux player

related https://github.com/muxinc/media-chrome/issues/380