### PR TITLE
fix: media-chrome-option outline fix and new css vars

### DIFF
--- a/src/js/experimental/media-chrome-option.js
+++ b/src/js/experimental/media-chrome-option.js
@@ -1,7 +1,7 @@
 import { globalThis, document } from '../utils/server-safe-globals.js';
 
 const template = document.createElement('template');
-template.innerHTML = /*html*/`
+template.innerHTML = /*html*/ `
 <style>
   :host {
     cursor: pointer;
@@ -13,17 +13,21 @@ template.innerHTML = /*html*/`
     min-height: 1.2em;
     padding: .4em .5em;
     transition: var(--media-option-transition);
+    outline: var(--media-option-outline, 0);
+    outline-offset: var(--media-option-outline-offset, -1px);
   }
 
   :host(:focus-visible) {
     box-shadow: inset 0 0 0 2px rgb(27 127 204 / .9);
-    outline: 0;
+    outline: var(--media-option-hover-outline, 0);
+    outline-offset: var(--media-option-hover-outline-offset, -1px);
   }
 
   :host(:hover) {
     cursor: pointer;
     background: var(--media-option-hover-background, rgb(82 82 122 / .8));
     outline: var(--media-option-hover-outline);
+    outline-offset: var(--media-option-hover-outline-offset, -1px);
   }
 
   :host([aria-selected="true"]) {
@@ -51,8 +55,11 @@ export const Attributes = {
  *
  * @cssproperty --media-option-transition - `transition` of option.
  * @cssproperty --media-option-selected-background - `background` of selected option.
+ * @cssproperty --media-option-outline - `outline` option.
+ * @cssproperty --media-option-outline-offset - `outline-offset` of option.
  * @cssproperty --media-option-hover-background - `background` of hovered option.
  * @cssproperty --media-option-hover-outline - `outline` of hovered option.
+ * @cssproperty --media-option-hover-outline-offset - `outline-offset` of hovered option.
  */
 class MediaChromeOption extends globalThis.HTMLElement {
   static get observedAttributes() {

--- a/src/js/experimental/media-chrome-option.js
+++ b/src/js/experimental/media-chrome-option.js
@@ -18,7 +18,7 @@ template.innerHTML = /*html*/ `
   }
 
   :host(:focus-visible) {
-    box-shadow: inset 0 0 0 2px rgb(27 127 204 / .9);
+    box-shadow: var(--media-option-focus-shadow, inset 0 0 0 2px rgb(27 127 204 / .9));
     outline: var(--media-option-hover-outline, 0);
     outline-offset: var(--media-option-hover-outline-offset, -1px);
   }
@@ -60,6 +60,7 @@ export const Attributes = {
  * @cssproperty --media-option-hover-background - `background` of hovered option.
  * @cssproperty --media-option-hover-outline - `outline` of hovered option.
  * @cssproperty --media-option-hover-outline-offset - `outline-offset` of hovered option.
+ * @cssproperty --media-option-focus-shadow - `box-shadow` of the :focus-visible state
  */
 class MediaChromeOption extends globalThis.HTMLElement {
   static get observedAttributes() {

--- a/src/js/experimental/media-chrome-option.js
+++ b/src/js/experimental/media-chrome-option.js
@@ -20,14 +20,14 @@ template.innerHTML = /*html*/ `
   :host(:focus-visible) {
     box-shadow: var(--media-option-focus-shadow, inset 0 0 0 2px rgb(27 127 204 / .9));
     outline: var(--media-option-hover-outline, 0);
-    outline-offset: var(--media-option-hover-outline-offset, -1px);
+    outline-offset: var(--media-option-hover-outline-offset,  var(--media-option-outline-offset, -1px));
   }
 
   :host(:hover) {
     cursor: pointer;
     background: var(--media-option-hover-background, rgb(82 82 122 / .8));
     outline: var(--media-option-hover-outline);
-    outline-offset: var(--media-option-hover-outline-offset, -1px);
+    outline-offset: var(--media-option-hover-outline-offset,  var(--media-option-outline-offset, -1px));
   }
 
   :host([aria-selected="true"]) {


### PR DESCRIPTION
Adds new CSS vars for controlling hover and non hover outlines. This fixes an issue where outlines are being cut off on the left and right side of the options.

Hover outline styles are also applied to the `:focus-visible` state for consistency.

There's also a new `--media-option-focus-shadow` var which is helpful for disabling the shadow on `:focus-visible` for simply allowing the option to look the same on hover and focus relying only on the outline vars.