### PR TITLE
feat: add audio track selectmenu

### DIFF
--- a/examples/vanilla/control-elements/media-audio-track-listbox.html
+++ b/examples/vanilla/control-elements/media-audio-track-listbox.html
@@ -30,9 +30,11 @@
     <mux-video
       id="video"
       slot="media"
-      src="https://playertest.longtailvideo.com/adaptive/elephants_dream_v4/index.m3u8"
+      src="https://stream.mux.com/Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008.m3u8"
+      poster="https://image.mux.com/Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008/thumbnail.webp?time=13"
       stream-type="on-demand"
       preload="metadata"
+      playsinline
       crossorigin
     ></mux-video>
     <media-control-bar>

--- a/examples/vanilla/control-elements/media-audio-track-listbox.html
+++ b/examples/vanilla/control-elements/media-audio-track-listbox.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta name="viewport" content="width=device-width">
+  <title>Media Chrome Audio Track Listbox</title>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@mux/mux-video@canary/+esm"></script>
+  <script type="module" src="../../../dist/index.js"></script>
+  <script type="module" src="../../../../dist/experimental/media-audio-track-listbox.js"></script>
+  <style>
+    /** add styles to prevent CLS (Cumulative Layout Shift) */
+    media-controller:not([audio]) {
+      display: block;         /* expands the container if preload=none */
+      max-width: 540px;       /* allows the container to shrink if small */
+      aspect-ratio: 16 / 9;   /* set container aspect ratio if preload=none */
+    }
+
+    video {
+      width: 100%;      /* prevents video to expand beyond its container */
+    }
+
+    .examples {
+      margin-top: 20px;
+    }
+  </style>
+</head>
+<body>
+  <h1>Audio Track Listbox</h1>
+
+  <media-controller id="mc">
+    <mux-video
+      id="video"
+      slot="media"
+      src="https://playertest.longtailvideo.com/adaptive/elephants_dream_v4/index.m3u8"
+      stream-type="on-demand"
+      preload="metadata"
+      crossorigin
+    ></mux-video>
+    <media-control-bar>
+      <media-play-button></media-play-button>
+      <media-time-display showduration></media-time-display>
+      <media-time-range></media-time-range>
+      <media-mute-button></media-mute-button>
+      <media-pip-button></media-pip-button>
+      <media-fullscreen-button></media-fullscreen-button>
+    </media-control-bar>
+  </media-controller>
+  <br>
+
+  <media-audio-track-listbox mediacontroller="mc"></media-audio-track-listbox>
+
+  <div class="examples">
+    <a href="../">View more examples</a>
+  </div>
+</body>
+</html>

--- a/examples/vanilla/control-elements/media-audio-track-selectmenu.html
+++ b/examples/vanilla/control-elements/media-audio-track-selectmenu.html
@@ -43,9 +43,11 @@
     <mux-video
       id="video"
       slot="media"
-      src="https://playertest.longtailvideo.com/adaptive/elephants_dream_v4/index.m3u8"
+      src="https://stream.mux.com/Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008.m3u8"
+      poster="https://image.mux.com/Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008/thumbnail.webp?time=13"
       stream-type="on-demand"
       preload="metadata"
+      playsinline
       crossorigin
     ></mux-video>
     <media-control-bar>
@@ -73,12 +75,25 @@
   </p>
 
   <p>
+    Audio: <span id="audioactive">N/A</span>
+  </p>
+
+  <p>
     <button id="loadbtn">Load new clip</button>
   </p>
 
-  <script>
+  <script type="module">
+    video.addEventListener('emptied', () => {
+      renditionactive.textContent = 'N/A';
+      audioactive.textContent = 'N/A';
+    });
+
     video.addEventListener('resize', () => {
       renditionactive.textContent = `${Math.min(video.videoWidth, video.videoHeight)}p`;
+    });
+
+    video.audioTracks.addEventListener('change', () => {
+      audioactive.textContent = [...video.audioTracks ?? []].find(a => a.enabled)?.label;
     });
 
     loadbtn.onclick = () => {

--- a/examples/vanilla/control-elements/media-audio-track-selectmenu.html
+++ b/examples/vanilla/control-elements/media-audio-track-selectmenu.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta name="viewport" content="width=device-width">
+  <title>Media Chrome Audio Track Selectmenu</title>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@mux/mux-video@canary/+esm"></script>
+  <script type="module" src="../../../dist/index.js"></script>
+  <script type="module" src="../../../../dist/experimental/media-rendition-selectmenu.js"></script>
+  <script type="module" src="../../../../dist/experimental/media-audio-track-selectmenu.js"></script>
+  <style>
+    /* Hide custom elements that are not defined yet */
+    :not(:defined) {
+      display: none;
+    }
+
+    /** add styles to prevent CLS (Cumulative Layout Shift) */
+    media-controller:not([audio]) {
+      display: block;         /* expands the container if preload=none */
+      max-width: 540px;       /* allows the container to shrink if small */
+      aspect-ratio: 16 / 9;   /* set container aspect ratio if preload=none */
+    }
+
+    video {
+      width: 100%;      /* prevents video to expand beyond its container */
+    }
+
+    media-audio-track-selectmenu[mediaaudiotrackunavailable],
+    media-rendition-selectmenu[mediarenditionunavailable],
+    media-fullscreen-button[mediafullscreenunavailable],
+    media-pip-button[mediapipunavailable] {
+      display: none;
+    }
+
+    .examples {
+      margin-top: 20px;
+    }
+  </style>
+</head>
+<body>
+  <h1>Audio Track Selectmenu</h1>
+
+  <media-controller id="mc">
+    <mux-video
+      id="video"
+      slot="media"
+      src="https://playertest.longtailvideo.com/adaptive/elephants_dream_v4/index.m3u8"
+      stream-type="on-demand"
+      preload="metadata"
+      crossorigin
+    ></mux-video>
+    <media-control-bar>
+      <media-play-button></media-play-button>
+      <media-time-display showduration></media-time-display>
+      <media-time-range></media-time-range>
+      <media-mute-button></media-mute-button>
+      <media-rendition-selectmenu>
+        <media-rendition-listbox slot="listbox">
+          <div slot="header">Quality</div>
+        </media-rendition-listbox>
+      </media-rendition-selectmenu>
+      <media-audio-track-selectmenu>
+        <media-audio-track-listbox slot="listbox">
+          <div slot="header">Audio</div>
+        </media-audio-track-listbox>
+      </media-audio-track-selectmenu>
+      <media-pip-button></media-pip-button>
+      <media-fullscreen-button></media-fullscreen-button>
+    </media-control-bar>
+  </media-controller>
+
+  <p>
+    Quality: <span id="renditionactive">N/A</span>
+  </p>
+
+  <p>
+    <button id="loadbtn">Load new clip</button>
+  </p>
+
+  <script>
+    video.addEventListener('resize', () => {
+      renditionactive.textContent = `${Math.min(video.videoWidth, video.videoHeight)}p`;
+    });
+
+    loadbtn.onclick = () => {
+      video.poster = '';
+      video.src = 'https://stream.mux.com/1EFcsL5JET00t00mBv01t00xt00T4QeNQtsXx2cKY6DLd7RM.m3u8';
+    };
+  </script>
+
+  <div class="examples">
+    <a href="../">View more examples</a>
+  </div>
+</body>
+</html>

--- a/examples/vanilla/control-elements/media-rendition-listbox.html
+++ b/examples/vanilla/control-elements/media-rendition-listbox.html
@@ -30,8 +30,8 @@
     <mux-video
       id="video"
       slot="media"
-      src="https://stream.mux.com/O6LdRc0112FEJXH00bGsN9Q31yu5EIVHTgjTKRkKtEq1k.m3u8"
-      poster="https://image.mux.com/O6LdRc0112FEJXH00bGsN9Q31yu5EIVHTgjTKRkKtEq1k/thumbnail.webp"
+      src="https://stream.mux.com/Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008.m3u8"
+      poster="https://image.mux.com/Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008/thumbnail.webp?time=13"
       preload="metadata"
       muted
       crossorigin

--- a/examples/vanilla/control-elements/media-rendition-selectmenu.html
+++ b/examples/vanilla/control-elements/media-rendition-selectmenu.html
@@ -41,8 +41,8 @@
     <mux-video
       id="video"
       slot="media"
-      src="https://stream.mux.com/O6LdRc0112FEJXH00bGsN9Q31yu5EIVHTgjTKRkKtEq1k.m3u8"
-      poster="https://image.mux.com/O6LdRc0112FEJXH00bGsN9Q31yu5EIVHTgjTKRkKtEq1k/thumbnail.webp"
+      src="https://stream.mux.com/Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008.m3u8"
+      poster="https://image.mux.com/Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008/thumbnail.webp"
       preload="metadata"
       muted
       crossorigin

--- a/examples/vanilla/index.html
+++ b/examples/vanilla/index.html
@@ -75,6 +75,7 @@
       <li><a href="control-elements/media-rendition-listbox.html">Rendition listbox</a></li>
       <li><a href="control-elements/media-rendition-selectmenu.html">Rendition selectmenu</a></li>
       <li><a href="control-elements/media-audio-track-listbox.html">Audio track listbox</a></li>
+      <li><a href="control-elements/media-audio-track-selectmenu.html">Audio track selectmenu</a></li>
     </ul>
 
     <h3>Extras</h3>

--- a/examples/vanilla/index.html
+++ b/examples/vanilla/index.html
@@ -74,6 +74,7 @@
       <li><a href="control-elements/media-playback-rate-selectmenu.html">Playback rate selectmenu</a></li>
       <li><a href="control-elements/media-rendition-listbox.html">Rendition listbox</a></li>
       <li><a href="control-elements/media-rendition-selectmenu.html">Rendition selectmenu</a></li>
+      <li><a href="control-elements/media-audio-track-listbox.html">Audio track listbox</a></li>
     </ul>
 
     <h3>Extras</h3>

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -36,6 +36,7 @@ export const MediaUIProps = {
   MEDIA_PIP_UNAVAILABLE: 'mediaPipUnavailable',
   MEDIA_CAST_UNAVAILABLE: 'mediaCastUnavailable',
   MEDIA_RENDITION_UNAVAILABLE: 'mediaRenditionUnavailable',
+  MEDIA_AUDIO_TRACK_UNAVAILABLE: 'mediaAudioTrackUnavailable',
   MEDIA_PAUSED: 'mediaPaused',
   MEDIA_HAS_PLAYED: 'mediaHasPlayed',
   MEDIA_ENDED: 'mediaEnded',

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -19,6 +19,7 @@ export const MediaUIEvents = {
   MEDIA_DISABLE_SUBTITLES_REQUEST: 'mediadisablesubtitlesrequest',
   MEDIA_PLAYBACK_RATE_REQUEST: 'mediaplaybackraterequest',
   MEDIA_RENDITION_REQUEST: 'mediarenditionrequest',
+  MEDIA_AUDIO_TRACK_REQUEST: 'mediaaudiotrackrequest',
   MEDIA_SEEK_TO_LIVE_REQUEST: 'mediaseektoliverequest',
   REGISTER_MEDIA_STATE_RECEIVER: 'registermediastatereceiver',
   UNREGISTER_MEDIA_STATE_RECEIVER: 'unregistermediastatereceiver',
@@ -61,6 +62,8 @@ export const MediaUIProps = {
   MEDIA_TIME_IS_LIVE: 'mediaTimeIsLive',
   MEDIA_RENDITION_LIST: 'mediaRenditionList',
   MEDIA_RENDITION_SELECTED: 'mediaRenditionSelected',
+  MEDIA_AUDIO_TRACK_LIST: 'mediaAudioTrackList',
+  MEDIA_AUDIO_TRACK_ENABLED: 'mediaAudioTrackEnabled',
 };
 
 const MediaUIPropsEntries = /** @type {[keyof MediaUIProps, string][]} */ (

--- a/src/js/controller.js
+++ b/src/js/controller.js
@@ -434,9 +434,7 @@ export const MediaUIStates = {
     get: function (controller) {
       const { media } = controller;
 
-      if (!media) return AvailabilityStates.UNSUPPORTED;
-
-      if (!media.videoRenditions) {
+      if (!media?.videoRenditions) {
         return AvailabilityStates.UNSUPPORTED;
       }
 
@@ -453,9 +451,7 @@ export const MediaUIStates = {
     get: function (controller) {
       const { media } = controller;
 
-      if (!media) return AvailabilityStates.UNSUPPORTED;
-
-      if (!media.audioTracks) {
+      if (!media?.audioTracks) {
         return AvailabilityStates.UNSUPPORTED;
       }
 

--- a/src/js/controller.js
+++ b/src/js/controller.js
@@ -449,6 +449,25 @@ export const MediaUIStates = {
     mediaEvents: ['emptied', 'loadstart'],
     videoRenditionsEvents: ['addrendition', 'removerendition'],
   },
+  MEDIA_AUDIO_TRACK_UNAVAILABLE: {
+    get: function (controller) {
+      const { media } = controller;
+
+      if (!media) return AvailabilityStates.UNSUPPORTED;
+
+      if (!media.audioTracks) {
+        return AvailabilityStates.UNSUPPORTED;
+      }
+
+      if (!media.audioTracks?.length) {
+        return AvailabilityStates.UNAVAILABLE;
+      }
+
+      return undefined;
+    },
+    mediaEvents: ['emptied', 'loadstart'],
+    audioTracksEvents: ['addtrack', 'removetrack'],
+  },
   MEDIA_VOLUME_UNAVAILABLE: {
     get: function (controller) {
       if (volumeSupported !== undefined && !volumeSupported) {

--- a/src/js/controller.js
+++ b/src/js/controller.js
@@ -459,7 +459,8 @@ export const MediaUIStates = {
         return AvailabilityStates.UNSUPPORTED;
       }
 
-      if (!media.audioTracks?.length) {
+      // An audio selection is only possible if there are 2 or more audio tracks.
+      if ((media.audioTracks?.length ?? 0) <= 1) {
         return AvailabilityStates.UNAVAILABLE;
       }
 

--- a/src/js/controller.js
+++ b/src/js/controller.js
@@ -507,6 +507,22 @@ export const MediaUIStates = {
     mediaEvents: ['emptied'],
     videoRenditionsEvents: ['addrendition', 'removerendition', 'change'],
   },
+  MEDIA_AUDIO_TRACK_LIST: {
+    get: function (controller) {
+      const { media } = controller;
+      return [...media?.audioTracks ?? []];
+    },
+    mediaEvents: ['emptied', 'loadstart'],
+    audioTracksEvents: ['addtrack', 'removetrack'],
+  },
+  MEDIA_AUDIO_TRACK_ENABLED: {
+    get: function (controller) {
+      const { media } = controller;
+      return [...media?.audioTracks ?? []].find(audioTrack => audioTrack.enabled)?.id;
+    },
+    mediaEvents: ['emptied'],
+    audioTracksEvents: ['addtrack', 'removetrack', 'change'],
+  },
 };
 
 // Capture request events from UI elements and tranlate to actions
@@ -816,5 +832,17 @@ export const MediaUIRequestHandlers = {
     if (media.videoRenditions.selectedIndex != index) {
       media.videoRenditions.selectedIndex = index;
     }
-  }
+  },
+  MEDIA_AUDIO_TRACK_REQUEST: (media, event) => {
+    if (!media?.audioTracks) {
+      console.warn('MediaController: Audio track selection not supported by this media.');
+      return;
+    }
+
+    const audioTrackId = event.detail;
+
+    for (let track of media.audioTracks) {
+      track.enabled = audioTrackId == track.id;
+    }
+  },
 };

--- a/src/js/experimental/index.js
+++ b/src/js/experimental/index.js
@@ -7,3 +7,4 @@ export { MediaPlaybackRateListbox } from './media-playback-rate-listbox.js';
 export { MediaPlaybackRateSelectMenu } from './media-playback-rate-selectmenu.js';
 export { MediaRenditionListbox } from './media-rendition-listbox.js';
 export { MediaRenditionSelectMenu } from './media-rendition-selectmenu.js';
+export { MediaAudioTrackListbox } from './media-audio-track-listbox.js';

--- a/src/js/experimental/index.js
+++ b/src/js/experimental/index.js
@@ -8,3 +8,4 @@ export { MediaPlaybackRateSelectMenu } from './media-playback-rate-selectmenu.js
 export { MediaRenditionListbox } from './media-rendition-listbox.js';
 export { MediaRenditionSelectMenu } from './media-rendition-selectmenu.js';
 export { MediaAudioTrackListbox } from './media-audio-track-listbox.js';
+export { MediaAudioTrackSelectMenu } from './media-audio-track-selectmenu.js';

--- a/src/js/experimental/media-audio-track-button.js
+++ b/src/js/experimental/media-audio-track-button.js
@@ -4,7 +4,8 @@ import { getStringAttr, setStringAttr } from '../utils/element-utils.js';
 import { MediaUIAttributes } from '../constants.js';
 
 const audioTrackIcon = /*html*/`<svg aria-hidden="true" viewBox="0 0 24 24">
-  <path d="M13.5 2.5h2v6h-2v-2h-11v-2h11v-2Zm4 2h4v2h-4v-2Zm-12 4h2v6h-2v-2h-3v-2h3v-2Zm4 2h12v2h-12v-2Zm1 4h2v6h-2v-2h-8v-2h8v-2Zm4 2h7v2h-7v-2Z" />
+  <path d="M11 17H9.5V7H11v10Zm-3-3H6.5v-4H8v4Zm6-5h-1.5v6H14V9Zm3 7h-1.5V8H17v8Z"/>
+  <path d="M22 12c0 5.523-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2s10 4.477 10 10Zm-2 0a8 8 0 1 0-16 0 8 8 0 0 0 16 0Z"/>
 </svg>`;
 
 const slotTemplate = document.createElement('template');

--- a/src/js/experimental/media-audio-track-button.js
+++ b/src/js/experimental/media-audio-track-button.js
@@ -1,0 +1,52 @@
+import { MediaChromeButton } from '../media-chrome-button.js';
+import { globalThis, document } from '../utils/server-safe-globals.js';
+import { getStringAttr, setStringAttr } from '../utils/element-utils.js';
+import { MediaUIAttributes } from '../constants.js';
+
+const audioTrackIcon = /*html*/`<svg aria-hidden="true" viewBox="0 0 24 24">
+  <path d="M13.5 2.5h2v6h-2v-2h-11v-2h11v-2Zm4 2h4v2h-4v-2Zm-12 4h2v6h-2v-2h-3v-2h3v-2Zm4 2h12v2h-12v-2Zm1 4h2v6h-2v-2h-8v-2h8v-2Zm4 2h7v2h-7v-2Z" />
+</svg>`;
+
+const slotTemplate = document.createElement('template');
+slotTemplate.innerHTML = /*html*/`
+  <slot name="icon">${audioTrackIcon}</slot>
+`;
+
+/**
+ * @attr {string} mediaaudiotrackenabled - (read-only) Set to the selected audio track id.
+ * @attr {(unavailable|unsupported)} mediaaudiotrackunavailable - (read-only) Set if audio track selection is unavailable.
+ *
+ * @cssproperty [--media-audio-track-button-display = inline-flex] - `display` property of button.
+ */
+class MediaAudioTrackButton extends MediaChromeButton {
+  static get observedAttributes() {
+    return [
+      ...super.observedAttributes,
+      MediaUIAttributes.MEDIA_AUDIO_TRACK_ENABLED,
+      MediaUIAttributes.MEDIA_AUDIO_TRACK_UNAVAILABLE,
+    ];
+  }
+
+  constructor() {
+    super({ slotTemplate });
+  }
+
+  /**
+   * Get enabled audio track id.
+   * @return {string}
+   */
+  get mediaAudioTrackEnabled() {
+    return getStringAttr(this, MediaUIAttributes.MEDIA_AUDIO_TRACK_ENABLED);
+  }
+
+  set mediaAudioTrackEnabled(id) {
+    setStringAttr(this, MediaUIAttributes.MEDIA_AUDIO_TRACK_ENABLED, id);
+  }
+}
+
+if (!globalThis.customElements.get('media-audio-track-button')) {
+  globalThis.customElements.define('media-audio-track-button', MediaAudioTrackButton);
+}
+
+export { MediaAudioTrackButton };
+export default MediaAudioTrackButton;

--- a/src/js/experimental/media-audio-track-listbox.js
+++ b/src/js/experimental/media-audio-track-listbox.js
@@ -1,0 +1,116 @@
+import { MediaChromeListbox, createOption, createIndicator } from './media-chrome-listbox.js';
+import './media-chrome-option.js';
+import { globalThis } from '../utils/server-safe-globals.js';
+import { getStringAttr, setStringAttr } from '../utils/element-utils.js';
+import { parseAudioTrackList } from '../utils/utils.js';
+import { MediaUIAttributes, MediaUIEvents } from '../constants.js';
+
+/**
+ * @attr {string} mediaaudiotrackenabled - (read-only) Set to the enabled audio track.
+ * @attr {string} mediaaudiotracklist - (read-only) Set to the audio track list.
+ */
+class MediaAudioTrackListbox extends MediaChromeListbox {
+  static get observedAttributes() {
+    return [
+      ...super.observedAttributes,
+      MediaUIAttributes.MEDIA_AUDIO_TRACK_LIST,
+      MediaUIAttributes.MEDIA_AUDIO_TRACK_ENABLED,
+    ];
+  }
+
+  #audioTrackList = [];
+  #prevState;
+
+  attributeChangedCallback(attrName, oldValue, newValue) {
+    super.attributeChangedCallback(attrName, oldValue, newValue);
+
+    if (attrName === MediaUIAttributes.MEDIA_AUDIO_TRACK_ENABLED && oldValue !== newValue) {
+      this.value = newValue;
+
+    } else if (attrName === MediaUIAttributes.MEDIA_AUDIO_TRACK_LIST && oldValue !== newValue) {
+
+      this.#audioTrackList = parseAudioTrackList(newValue);
+      this.#render();
+    }
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.addEventListener('change', this.#onChange);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.removeEventListener('change', this.#onChange);
+  }
+
+  get mediaAudioTrackList() {
+    return this.#audioTrackList;
+  }
+
+  set mediaAudioTrackList(list) {
+    this.#audioTrackList = list;
+    this.#render();
+  }
+
+  /**
+   * Get enabled audio track id.
+   * @return {string}
+   */
+  get mediaAudioTrackEnabled() {
+    return getStringAttr(this, MediaUIAttributes.MEDIA_AUDIO_TRACK_ENABLED);
+  }
+
+  set mediaAudioTrackEnabled(id) {
+    setStringAttr(this, MediaUIAttributes.MEDIA_AUDIO_TRACK_ENABLED, id);
+  }
+
+  #render() {
+    if (this.#prevState === JSON.stringify(this.mediaAudioTrackList)) return;
+    this.#prevState = JSON.stringify(this.mediaAudioTrackList);
+
+    const audioTrackList = this.mediaAudioTrackList;
+
+    const container = this.shadowRoot.querySelector('#container');
+    container.textContent = '';
+
+    for (const audioTrack of audioTrackList) {
+
+      const text = this.formatOptionText(
+        audioTrack.label,
+        audioTrack
+      );
+
+      /** @type {HTMLOptionElement} */
+      const option = createOption(
+        text,
+        `${audioTrack.id}`,
+        audioTrack.enabled
+      );
+      option.prepend(createIndicator(this, 'select-indicator'));
+
+      container.append(option);
+    }
+  }
+
+  #onChange() {
+    if (this.value == null) return;
+
+    const event = new globalThis.CustomEvent(
+      MediaUIEvents.MEDIA_AUDIO_TRACK_REQUEST,
+      {
+        composed: true,
+        bubbles: true,
+        detail: this.value,
+      }
+    );
+    this.dispatchEvent(event);
+  }
+}
+
+if (!globalThis.customElements.get('media-audio-track-listbox')) {
+  globalThis.customElements.define('media-audio-track-listbox', MediaAudioTrackListbox);
+}
+
+export { MediaAudioTrackListbox };
+export default MediaAudioTrackListbox;

--- a/src/js/experimental/media-audio-track-selectmenu.js
+++ b/src/js/experimental/media-audio-track-selectmenu.js
@@ -28,7 +28,7 @@ class MediaAudioTrackSelectMenu extends MediaChromeSelectMenu {
 
     const audioTrackListbox = document.createElement('media-audio-track-listbox');
     audioTrackListbox.part.add('listbox');
-    audioTrackListbox.setAttribute('exportparts', 'option, indicator');
+    audioTrackListbox.setAttribute('exportparts', 'option, option-selected, indicator');
 
     const buttonSlot = this.shadowRoot.querySelector('slot[name=button]');
     const listboxSlot = this.shadowRoot.querySelector('slot[name=listbox]');

--- a/src/js/experimental/media-audio-track-selectmenu.js
+++ b/src/js/experimental/media-audio-track-selectmenu.js
@@ -1,0 +1,49 @@
+import { MediaChromeSelectMenu } from './media-chrome-selectmenu.js';
+import './media-audio-track-button.js';
+import './media-audio-track-listbox.js';
+import { MediaUIAttributes } from '../constants.js';
+import { globalThis, document, } from '../utils/server-safe-globals.js';
+
+/**
+ * @attr {string} mediaaudiotrackenabled - (read-only) Set to the selected audio track id.
+ * @attr {(unavailable|unsupported)} mediaaudiotrackunavailable - (read-only) Set if audio track selection is unavailable.
+ *
+ * @csspart button - The default button that's in the shadow DOM.
+ * @csspart listbox - The default listbox that's in the shadow DOM.
+ * @csspart option - A part that targets each option of the listbox.
+ */
+class MediaAudioTrackSelectMenu extends MediaChromeSelectMenu {
+  static get observedAttributes() {
+    return [
+      ...super.observedAttributes,
+      MediaUIAttributes.MEDIA_AUDIO_TRACK_ENABLED,
+      MediaUIAttributes.MEDIA_AUDIO_TRACK_UNAVAILABLE,
+    ];
+  }
+
+  init() {
+    const audioTrackButton = document.createElement('media-audio-track-button');
+    audioTrackButton.part.add('button');
+    audioTrackButton.preventClick = true;
+
+    const audioTrackListbox = document.createElement('media-audio-track-listbox');
+    audioTrackListbox.part.add('listbox');
+    audioTrackListbox.setAttribute('exportparts', 'option, indicator');
+
+    const buttonSlot = this.shadowRoot.querySelector('slot[name=button]');
+    const listboxSlot = this.shadowRoot.querySelector('slot[name=listbox]');
+
+    buttonSlot.textContent = '';
+    listboxSlot.textContent = '';
+
+    buttonSlot.append(audioTrackButton);
+    listboxSlot.append(audioTrackListbox);
+  }
+}
+
+if (!globalThis.customElements.get('media-audio-track-selectmenu')) {
+  globalThis.customElements.define('media-audio-track-selectmenu', MediaAudioTrackSelectMenu);
+}
+
+export { MediaAudioTrackSelectMenu };
+export default MediaAudioTrackSelectMenu;

--- a/src/js/experimental/media-chrome-option.js
+++ b/src/js/experimental/media-chrome-option.js
@@ -1,7 +1,7 @@
 import { globalThis, document } from '../utils/server-safe-globals.js';
 
 const template = document.createElement('template');
-template.innerHTML = /*html*/ `
+template.innerHTML = /*html*/`
 <style>
   :host {
     cursor: pointer;

--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -257,6 +257,7 @@ class MediaContainer extends globalThis.HTMLElement {
       // that shouldn't be propagated to this state receiver element.
       .filter(name => ![
         MediaUIAttributes.MEDIA_RENDITION_LIST,
+        MediaUIAttributes.MEDIA_AUDIO_TRACK_LIST,
       ].includes(name));
   }
 

--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -10,7 +10,7 @@
 import { MediaContainer } from './media-container.js';
 import { globalThis } from './utils/server-safe-globals.js';
 import { AttributeTokenList } from './utils/attribute-token-list.js';
-import { constToCamel, delay, stringifyRenditionList } from './utils/utils.js';
+import { constToCamel, delay, stringifyRenditionList, stringifyAudioTrackList } from './utils/utils.js';
 import { stringifyTextTrackList, toggleSubsCaps } from './utils/captions.js';
 import {
   MediaUIEvents,
@@ -179,6 +179,7 @@ class MediaController extends MediaContainer {
         rootEvents,
         textTracksEvents,
         videoRenditionsEvents,
+        audioTracksEvents,
       } = MediaUIStates[key];
 
       const handler = this._mediaStatePropagators[key];
@@ -200,6 +201,11 @@ class MediaController extends MediaContainer {
 
       videoRenditionsEvents?.forEach((eventName) => {
         media.videoRenditions?.addEventListener(eventName, handler);
+        handler();
+      });
+
+      audioTracksEvents?.forEach((eventName) => {
+        media.audioTracks?.addEventListener(eventName, handler);
         handler();
       });
     });
@@ -227,6 +233,7 @@ class MediaController extends MediaContainer {
         rootEvents,
         textTracksEvents,
         videoRenditionsEvents,
+        audioTracksEvents,
       } = MediaUIStates[key];
 
       const handler = this._mediaStatePropagators[key];
@@ -245,6 +252,11 @@ class MediaController extends MediaContainer {
 
       videoRenditionsEvents?.forEach((eventName) => {
         media.videoRenditions?.removeEventListener(eventName, handler);
+        handler();
+      });
+
+      audioTracksEvents?.forEach((eventName) => {
+        media.audioTracks?.removeEventListener(eventName, handler);
         handler();
       });
     });
@@ -537,6 +549,7 @@ const CustomAttrSerializer = {
   [MediaUIAttributes.MEDIA_BUFFERED]: (tuples) => tuples?.map(serializeTuple).join(' '),
   [MediaUIAttributes.MEDIA_PREVIEW_COORDS]: (coords) => coords?.join(' '),
   [MediaUIAttributes.MEDIA_RENDITION_LIST]: stringifyRenditionList,
+  [MediaUIAttributes.MEDIA_AUDIO_TRACK_LIST]: stringifyAudioTrackList,
 };
 
 const setAttr = async (child, attrName, attrValue) => {

--- a/src/js/utils/utils.js
+++ b/src/js/utils/utils.js
@@ -25,6 +25,32 @@ export function parseRendition(rendition) {
   }
 }
 
+export function stringifyAudioTrackList(audioTracks) {
+  return audioTracks
+    ?.map(stringifyAudioTrack)
+    .join(' ');
+}
+
+export function parseAudioTrackList(audioTracks) {
+  return audioTracks
+    ?.split(/\s+/)
+    .map(parseAudioTrack);
+}
+
+export function stringifyAudioTrack(audioTrack) {
+  if (audioTrack) {
+    const { id, kind, language, label } = audioTrack;
+    return [id, kind, language, label].filter(a => a != null).join(':')
+  }
+}
+
+export function parseAudioTrack(audioTrack) {
+  if (audioTrack) {
+    const [id, kind, language, label] = audioTrack.split(':');
+    return { id, kind, language, label };
+  }
+}
+
 export function dashedToCamel(word) {
   return word
     .split('-')


### PR DESCRIPTION
~todo: fix rendition selection broken after audio track change~
this is a hls.js issue https://github.com/video-dev/hls.js/issues/5749

adds an experimental audio track selectmenu

test url:
- https://media-chrome-git-fork-luwes-audio-tracks-mux.vercel.app/examples/vanilla/control-elements/media-audio-track-selectmenu.html
- https://media-chrome-git-fork-luwes-audio-tracks-mux.vercel.app/examples/vanilla/control-elements/media-audio-track-listbox.html