### PR TITLE
feat: add option-selected part for selected option elements

### DIFF
--- a/src/js/experimental/media-chrome-option.js
+++ b/src/js/experimental/media-chrome-option.js
@@ -105,6 +105,11 @@ class MediaChromeOption extends globalThis.HTMLElement {
     this.#dirty = true;
     // Firefox doesn't support the property .ariaSelected.
     this.setAttribute('aria-selected', value ? 'true' : 'false');
+    if (value) {
+      this.part.add('option-selected');
+    } else {
+      this.part.remove('option-selected');
+    }
   }
 
   enable() {


### PR DESCRIPTION
Allows you to select only selected options via css `::part(selected-option)` as `::part` doesn't support combining with other selectors like `[aria-selected="true"]`.