### PR TITLE
fix: remove pointer events from hidden list boxes

### DIFF
--- a/src/js/experimental/media-chrome-selectmenu.js
+++ b/src/js/experimental/media-chrome-selectmenu.js
@@ -40,6 +40,7 @@ template.innerHTML = /*html*/`
     transform: var(--media-listbox-transform-out, translateY(2px) scale(.99));
     visibility: hidden;
     opacity: 0;
+    pointer-events: none;
   }
 
   slot[name="listbox"][hidden] {


### PR DESCRIPTION
<img width="327" alt="image" src="https://github.com/muxinc/media-chrome/assets/9952680/c7aeb91e-0c14-43d2-8758-b12fa3a48bb4">

Some parts of a hidden listbox are still selectable even though they are hidden, particularly the nested SVG's. This makes them grab focus when moving the cursor or clicking.