### PR TITLE
fix: Themes not rendering if no breakpoint is active on load

### DIFF
--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -80,15 +80,16 @@ export const MediaUIAttributes =
   );
 
 export const MediaStateChangeEvents =
-  /** @type {{ [k in keyof MediaUIProps | 'USER_INACTIVE' | 'BREAKPOINTS_CHANGE']: string }} */ (
+  /** @type {{ [k in keyof MediaUIProps | 'USER_INACTIVE' | 'BREAKPOINTS_CHANGE' | 'BREAKPOINTS_COMPUTED']: string }} */ (
     MediaUIPropsEntries.reduce(
       (dictObj, [key, propName]) => {
         dictObj[key] = `${propName.toLowerCase()}`;
         return dictObj;
       },
-      /** @type {Partial<{ [k in keyof MediaUIProps | 'USER_INACTIVE' | 'BREAKPOINTS_CHANGE']: string  }>} */ ({
+      /** @type {Partial<{ [k in keyof MediaUIProps | 'USER_INACTIVE' | 'BREAKPOINTS_CHANGE' | 'BREAKPOINTS_COMPUTED']: string  }>} */ ({
         USER_INACTIVE: 'userinactivechange',
         BREAKPOINTS_CHANGE: 'breakpointchange',
+        BREAKPOINTS_COMPUTED: 'initialbreakpointscomputed',
       })
     )
   );

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -89,7 +89,7 @@ export const MediaStateChangeEvents =
       /** @type {Partial<{ [k in keyof MediaUIProps | 'USER_INACTIVE' | 'BREAKPOINTS_CHANGE' | 'BREAKPOINTS_COMPUTED']: string  }>} */ ({
         USER_INACTIVE: 'userinactivechange',
         BREAKPOINTS_CHANGE: 'breakpointchange',
-        BREAKPOINTS_COMPUTED: 'initialbreakpointscomputed',
+        BREAKPOINTS_COMPUTED: 'breakpointscomputed',
       })
     )
   );

--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -261,7 +261,7 @@ class MediaContainer extends globalThis.HTMLElement {
       ].includes(name));
   }
 
-  breakpointsUncomputed = true;
+  breakpointsComputed = false;
 
   constructor() {
     super();
@@ -336,7 +336,16 @@ class MediaContainer extends globalThis.HTMLElement {
         resizeCallback(entries);
         // Once we've completed, reset the pending cb flag to false
         pendingResizeCb = false;
-        this.breakpointsUncomputed = false;
+
+        if (!this.breakpointsComputed) {
+          this.breakpointsComputed = true;
+          this.dispatchEvent(
+            new CustomEvent(MediaStateChangeEvents.BREAKPOINTS_COMPUTED, {
+              bubbles: true,
+              composed: true
+            })
+          );
+        }
       }, 0);
       pendingResizeCb = true;
     };

--- a/src/js/media-theme-element.js
+++ b/src/js/media-theme-element.js
@@ -69,7 +69,7 @@ export class MediaThemeElement extends globalThis.HTMLElement {
 
     const observer = new MutationObserver((mutationList) => {
       // Only update if `<media-controller>` has computed breakpoints at least once.
-      if (!this.mediaController?.breakpointsComputed) return;
+      if (this.mediaController && !this.mediaController?.breakpointsComputed) return;
 
       if (mutationList.some((mutation) => {
         const target = /** @type {HTMLElement} */ (mutation.target);

--- a/src/js/media-theme-element.js
+++ b/src/js/media-theme-element.js
@@ -103,7 +103,6 @@ export class MediaThemeElement extends globalThis.HTMLElement {
 
     this.addEventListener(MediaStateChangeEvents.BREAKPOINTS_COMPUTED, this.render);
 
-
     // In case the template prop was set before custom element upgrade.
     // https://web.dev/custom-elements-best-practices/#make-properties-lazy
     this.#upgradeProperty('template');

--- a/src/js/media-theme-element.js
+++ b/src/js/media-theme-element.js
@@ -1,3 +1,4 @@
+import { MediaStateChangeEvents } from './constants.js';
 import { globalThis, document } from './utils/server-safe-globals.js';
 import { TemplateInstance } from './utils/template-parts.js';
 import { processor } from './utils/template-processor.js';
@@ -68,7 +69,7 @@ export class MediaThemeElement extends globalThis.HTMLElement {
 
     const observer = new MutationObserver((mutationList) => {
       // Only update if `<media-controller>` has computed breakpoints at least once.
-      if (this.mediaController?.breakpointsUncomputed) return;
+      if (!this.mediaController?.breakpointsComputed) return;
 
       if (mutationList.some((mutation) => {
         const target = /** @type {HTMLElement} */ (mutation.target);
@@ -100,6 +101,9 @@ export class MediaThemeElement extends globalThis.HTMLElement {
       subtree: true,
     });
 
+    this.addEventListener(MediaStateChangeEvents.BREAKPOINTS_COMPUTED, this.render);
+
+
     // In case the template prop was set before custom element upgrade.
     // https://web.dev/custom-elements-best-practices/#make-properties-lazy
     this.#upgradeProperty('template');
@@ -115,7 +119,7 @@ export class MediaThemeElement extends globalThis.HTMLElement {
     }
   }
 
-  /** @type {HTMLElement & { breakpointsUncomputed?: boolean }} */
+  /** @type {HTMLElement & { breakpointsComputed?: boolean }} */
   get mediaController() {
     // Expose the media controller if API access is needed
     return this.renderRoot.querySelector('media-controller');


### PR DESCRIPTION
This fixes an issue where themes don't render any of the theme template **_on page load_** if the player is smaller than the smallest breakpoint defined. This affects all themes.

The default mux player theme (classic) redefined the `sm` breakpoint as 300 instead of the default which makes it unlikely to appear in normal usage. The new 2023 theme defined a larger `sm` breakpoint and so the UI stopped loading on mobile device sizes.

Although this bug is producible through themes using the breakpoint variables, it's a lower level issue around how and when we decide to render a theme template. This bug exists because when no breakpoints are active, we don't set any new properties on the media controller (like `breakpointsm`), and this in turn means the mutation observer on `media-theme-element` doesn't trigger, and that's the only mechanism we have to trigger a render (nothing else calls the render function other than these mutation callbacks).

Additionally `streamtype` is undefined the first time a theme template is processed (if it's being automatically derived), and because most themes use this variable as a top level branching point to show different types of UI (live vs vod), no elements are shown when a theme is first processed. There's likely other variables that could be used to show this behaviour but it's more common to build top level theme logic around `streamtype` and breakpoint variables so they expose it.

This fix bypasses the issue by triggering a render indirectly via a new event that fires after breakpoints are initially processed, even if no breakpoint is active and no attributes will change. This doesn't fix the underlying issue though.