### PR TITLE
fix: improve selectmenu overflow

### DIFF
--- a/examples/vanilla/control-elements/media-captions-selectmenu.html
+++ b/examples/vanilla/control-elements/media-captions-selectmenu.html
@@ -10,7 +10,7 @@
     /** add styles to prevent CLS (Cumulative Layout Shift) */
     media-controller:not([audio]) {
       display: block;         /* expands the container if preload=none */
-      max-width: 960px;       /* allows the container to shrink if small */
+      max-width: 640px;       /* allows the container to shrink if small */
       aspect-ratio: 16/9;   /* set container aspect ratio if preload=none */
     }
 

--- a/examples/vanilla/control-elements/media-rendition-selectmenu.html
+++ b/examples/vanilla/control-elements/media-rendition-selectmenu.html
@@ -41,8 +41,8 @@
     <mux-video
       id="video"
       slot="media"
-      src="https://stream.mux.com/Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008.m3u8"
-      poster="https://image.mux.com/Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008/thumbnail.webp"
+      src="https://stream.mux.com/fss00bwClhYMynhxeE2Hv757J02VI68KY5.m3u8"
+      poster="https://image.mux.com/fss00bwClhYMynhxeE2Hv757J02VI68KY5/thumbnail.webp"
       preload="metadata"
       muted
       crossorigin
@@ -77,7 +77,7 @@
 
     loadbtn.onclick = () => {
       video.poster = '';
-      video.src = 'https://stream.mux.com/1EFcsL5JET00t00mBv01t00xt00T4QeNQtsXx2cKY6DLd7RM.m3u8';
+      video.src = 'https://stream.mux.com/Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008.m3u8';
     };
   </script>
 

--- a/examples/vanilla/disabled.html
+++ b/examples/vanilla/disabled.html
@@ -4,6 +4,7 @@
     <meta name="viewport" content="width=device-width" />
     <title>Media Chrome Disabled-Controls Video Usage Example</title>
     <script type="module" src="../../dist/index.js"></script>
+    <script type="module" src="../../../dist/experimental/index.js"></script>
     <style>
       /** add styles to prevent CLS (Cumulative Layout Shift) */
       media-controller:not([audio]) {
@@ -72,6 +73,7 @@
           <media-time-range disabled aria-disabled="true"></media-time-range>
           <media-time-display showduration remaining disabled aria-disabled="true"></media-time-display>
           <media-captions-button default-showing disabled aria-disabled="true"></media-captions-button>
+          <media-captions-selectmenu disabled aria-disabled="true"></media-captions-selectmenu>
           <media-playback-rate-button disabled aria-disabled="true"></media-playback-rate-button>
           <media-pip-button disabled aria-disabled="true"></media-pip-button>
           <media-fullscreen-button disabled aria-disabled="true"></media-fullscreen-button>

--- a/src/js/experimental/media-chrome-listbox.js
+++ b/src/js/experimental/media-chrome-listbox.js
@@ -357,7 +357,7 @@ class MediaChromeListbox extends globalThis.HTMLElement {
     }
 
     if (this.selectedOptions.some((opt, i) => opt != oldSelectedOptions[i])) {
-      this.dispatchEvent(new Event('change'));
+      this.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
     }
   }
 

--- a/src/js/experimental/media-chrome-listbox.js
+++ b/src/js/experimental/media-chrome-listbox.js
@@ -50,14 +50,21 @@ template.innerHTML = /*html*/`
     color: var(--media-text-color, var(--media-primary-color, rgb(238 238 238)));
     background: var(--media-listbox-background, var(--media-control-background, var(--media-secondary-color, rgb(20 20 30 / .8))));
     border-radius: var(--media-listbox-border-radius);
-    display: inline-block;
-    padding-block: .5em;
+    display: inline-flex;
+    flex-direction: column;
+    position: relative;
+    box-sizing: border-box;
   }
 
   ::slotted([slot="header"]) {
-    padding: 0 1.4em .4em;
-    margin-bottom: .5em;
+    padding: .4em 1.4em;
     border-bottom: 1px solid rgb(255 255 255 / .25);
+  }
+
+  #container {
+    display: block;
+    overflow: hidden auto;
+    padding-block: .5em;
   }
 
   media-chrome-option {

--- a/src/js/experimental/media-chrome-selectmenu.js
+++ b/src/js/experimental/media-chrome-selectmenu.js
@@ -19,13 +19,12 @@ template.innerHTML = /*html*/`
     flex-shrink: .5;
   }
 
-  [name="listbox"]::slotted(*),
+  [name=listbox]::slotted(*),
   [part=listbox] {
     position: absolute;
     left: 0;
     bottom: 100%;
     max-height: 300px;
-    overflow: hidden auto;
     transition: var(--media-selectmenu-transition-in,
       visibility 0s, transform .15s ease-out, opacity .15s ease-out);
     transform: var(--media-listbox-transform-in, translateY(0) scale(1));
@@ -33,7 +32,7 @@ template.innerHTML = /*html*/`
     opacity: 1;
   }
 
-  [name="listbox"][hidden]::slotted(*),
+  [name=listbox][hidden]::slotted(*),
   [hidden] [part=listbox] {
     transition: var(--media-selectmenu-transition-out,
       visibility .15s ease-out, transform .15s ease-out, opacity .15s ease-out);
@@ -43,7 +42,7 @@ template.innerHTML = /*html*/`
     pointer-events: none;
   }
 
-  slot[name="listbox"][hidden] {
+  slot[name=listbox][hidden] {
     display: block;
   }
   </style>
@@ -199,8 +198,8 @@ class MediaChromeSelectMenu extends globalThis.HTMLElement {
     this.#toggleExpanded(closeOnly);
 
     if (!this.#listboxSlot.hidden) {
-      this.#listbox.focus();
       this.#updateMenuPosition();
+      this.#listbox.focus();
     } else if (this.shadowRoot.activeElement === this.#listbox || this.#listbox.contains(this.shadowRoot.activeElement)) {
       this.#button.focus();
     }
@@ -214,7 +213,7 @@ class MediaChromeSelectMenu extends globalThis.HTMLElement {
 
     // if we're outside of the controller,
     // one of the components should have a mediacontroller attribute.
-    // There isn't a good way now to differentiate between default buttons or
+    // There isn't a good way now to differentiate between default buttons
     // or a slotted button but outside of the media-controller.
     // So, a regular declarative selectmenu may default to open up rather than down.
     if (
@@ -232,7 +231,7 @@ class MediaChromeSelectMenu extends globalThis.HTMLElement {
     const bounds =
       (this.getAttribute('bounds')
         ? closestComposedNode(this, `#${this.getAttribute('bounds')}`)
-        : this.parentElement) ?? this;
+        : (getMediaControllerEl(this) || this.parentElement)) ?? this;
 
     // Choose .offsetWidth which is not affected by CSS transforms.
     const listboxWidth = this.#listbox.offsetWidth;
@@ -240,6 +239,7 @@ class MediaChromeSelectMenu extends globalThis.HTMLElement {
     const position = -Math.max(buttonRect.x + listboxWidth - boundsRect.right, 0);
 
     this.#listbox.style.left = `${position}px`;
+    this.#listbox.style.maxHeight = `${boundsRect.height - buttonRect.height}px`;
   }
 
   #toggleExpanded(closeOnly = false) {
@@ -320,6 +320,16 @@ class MediaChromeSelectMenu extends globalThis.HTMLElement {
   get keysUsed() {
     return ['Enter', 'Escape', ' ', 'ArrowUp', 'ArrowDown', 'f', 'c', 'k', 'm'];
   }
+}
+
+function getMediaControllerEl(controlEl) {
+  const mediaControllerId = controlEl.getAttribute(
+    MediaStateReceiverAttributes.MEDIA_CONTROLLER
+  );
+  if (mediaControllerId) {
+    return controlEl.getRootNode()?.getElementById(mediaControllerId);
+  }
+  return closestComposedNode(controlEl, 'media-controller');
 }
 
 if (!globalThis.customElements.get('media-chrome-selectmenu')) {

--- a/src/js/experimental/media-chrome-selectmenu.js
+++ b/src/js/experimental/media-chrome-selectmenu.js
@@ -78,7 +78,6 @@ class MediaChromeSelectMenu extends globalThis.HTMLElement {
   #buttonSlot;
   #listbox;
   #listboxSlot;
-  #expanded = false;
 
   static get observedAttributes() {
     return [
@@ -190,17 +189,30 @@ class MediaChromeSelectMenu extends globalThis.HTMLElement {
   }
 
   #handleOptionChange_() {
-    this.#toggle(true);
+    this.#hide();
   }
 
-  #toggle(closeOnly) {
-    this.#listboxSlot.hidden = !this.#listboxSlot.hidden || closeOnly;
-    this.#toggleExpanded(closeOnly);
+  #toggle() {
+    if (this.#listboxSlot.hidden) {
+      this.#show();
+    } else {
+      this.#hide();
+    }
+  }
 
-    if (!this.#listboxSlot.hidden) {
-      this.#updateMenuPosition();
-      this.#listbox.focus();
-    } else if (this.shadowRoot.activeElement === this.#listbox || this.#listbox.contains(this.shadowRoot.activeElement)) {
+  #show() {
+    this.#listboxSlot.hidden = false;
+    this.#button.setAttribute('aria-expanded', 'true');
+
+    this.#updateMenuPosition();
+    this.#listbox.focus();
+  }
+
+  #hide() {
+    this.#listboxSlot.hidden = true;
+    this.#button.setAttribute('aria-expanded', 'false');
+
+    if (this.shadowRoot.activeElement === this.#listbox || this.#listbox.contains(this.shadowRoot.activeElement)) {
       this.#button.focus();
     }
   }
@@ -242,17 +254,12 @@ class MediaChromeSelectMenu extends globalThis.HTMLElement {
     this.#listbox.style.maxHeight = `${boundsRect.height - buttonRect.height}px`;
   }
 
-  #toggleExpanded(closeOnly = false) {
-    this.#expanded = !this.#expanded || closeOnly;
-    this.#button.setAttribute('aria-expanded', this.#expanded);
-  }
-
   enable() {
     this.#button.removeAttribute('disabled');
+    this.#button.setAttribute('aria-expanded', 'false');
     this.#button.addEventListener('click', this.#handleButtonClick);
     this.#button.addEventListener('keydown', this.#keydownListener);
     this.#listbox.addEventListener('keydown', this.#keydownListener);
-    this.#toggleExpanded();
     this.#listbox.addEventListener('change', this.#handleOptionChange);
     document.addEventListener('click', this.#documentClickHandler);
   }

--- a/src/js/experimental/media-chrome-selectmenu.js
+++ b/src/js/experimental/media-chrome-selectmenu.js
@@ -192,7 +192,7 @@ class MediaChromeSelectMenu extends globalThis.HTMLElement {
     this.#updateMenuPosition();
     this.#listbox.focus();
 
-    observeResize(getBoundsElement(this), () => this.#updateMenuPosition());
+    observeResize(getBoundsElement(this), this.#updateMenuPosition);
   }
 
   #hide() {
@@ -207,10 +207,10 @@ class MediaChromeSelectMenu extends globalThis.HTMLElement {
       this.#button.focus();
     }
 
-    unobserveResize(getBoundsElement(this));
+    unobserveResize(getBoundsElement(this), this.#updateMenuPosition);
   }
 
-  #updateMenuPosition() {
+  #updateMenuPosition = () => {
     // if the menu is hidden, skip updating the menu position
     if (this.#listbox.offsetWidth === 0) return;
 
@@ -297,12 +297,12 @@ class MediaChromeSelectMenu extends globalThis.HTMLElement {
     }
 
     if (!this.#listboxSlot.hidden) {
-      observeResize(getBoundsElement(this), () => this.#updateMenuPosition());
+      observeResize(getBoundsElement(this), this.#updateMenuPosition);
     }
   }
 
   disconnectedCallback() {
-    unobserveResize(getBoundsElement(this));
+    unobserveResize(getBoundsElement(this), this.#updateMenuPosition);
     this.disable();
 
     // Use cached mediaController, getRootNode() doesn't work if disconnected.

--- a/src/js/experimental/media-chrome-selectmenu.js
+++ b/src/js/experimental/media-chrome-selectmenu.js
@@ -1,7 +1,7 @@
 import '../media-chrome-button.js';
 import './media-chrome-listbox.js';
 import { globalThis, document } from '../utils/server-safe-globals.js';
-import { closestComposedNode, getOrInsertCSSRule } from '../utils/element-utils.js';
+import { closestComposedNode, getOrInsertCSSRule, getActiveElement } from '../utils/element-utils.js';
 import { MediaStateReceiverAttributes } from '../constants.js';
 
 const template = document.createElement('template');
@@ -212,7 +212,8 @@ class MediaChromeSelectMenu extends globalThis.HTMLElement {
     this.#listboxSlot.hidden = true;
     this.#button.setAttribute('aria-expanded', 'false');
 
-    if (this.shadowRoot.activeElement === this.#listbox || this.#listbox.contains(this.shadowRoot.activeElement)) {
+    const activeElement = getActiveElement();
+    if (activeElement === this.#listbox || this.#listbox.contains(activeElement)) {
       this.#button.focus();
     }
   }

--- a/src/js/experimental/media-chrome-selectmenu.js
+++ b/src/js/experimental/media-chrome-selectmenu.js
@@ -1,7 +1,7 @@
 import '../media-chrome-button.js';
 import './media-chrome-listbox.js';
 import { globalThis, document } from '../utils/server-safe-globals.js';
-import { closestComposedNode, getOrInsertCSSRule, getActiveElement } from '../utils/element-utils.js';
+import { containsComposedNode, closestComposedNode, getOrInsertCSSRule, getActiveElement } from '../utils/element-utils.js';
 import { MediaStateReceiverAttributes } from '../constants.js';
 
 const template = document.createElement('template');
@@ -218,7 +218,7 @@ class MediaChromeSelectMenu extends globalThis.HTMLElement {
     this.#listboxSlot.hidden = true;
     this.#button.setAttribute('aria-expanded', 'false');
 
-    if (activeElement === this.#listbox || this.#listbox.contains(activeElement)) {
+    if (containsComposedNode(this.#listbox, activeElement)) {
       this.#button.focus();
     }
 

--- a/src/js/experimental/media-chrome-selectmenu.js
+++ b/src/js/experimental/media-chrome-selectmenu.js
@@ -72,7 +72,6 @@ template.innerHTML = /*html*/`
  */
 class MediaChromeSelectMenu extends globalThis.HTMLElement {
   #mediaController;
-  #enabledState = true;
   #button;
   #buttonSlot;
   #listbox;
@@ -109,34 +108,22 @@ class MediaChromeSelectMenu extends globalThis.HTMLElement {
       // if the slotted button is the built-in, nothing to do
       if (!newButton) return;
 
-      // disconnect previous button
-      this.disable();
-
-      // update button reference if necessary
       this.#button = newButton;
-
-      // if it's a media-chrome-button, ask it to not handle the click event
       this.#button.preventClick = true;
 
-      if (this.#button.hasAttribute('disabled')) {
-        this.#enabledState = false;
-      }
+      const disabled = this.hasAttribute('disabled') || this.#button.hasAttribute('disabled');
 
-      // reconnect new button
-      if (this.#enabledState) {
+      if (disabled) {
+        this.disable();
+      } else {
         this.enable();
         this.#button.setAttribute('aria-haspopup', 'listbox');
-      } else {
-        this.disable();
       }
     });
 
     this.#listboxSlot = this.shadowRoot.querySelector('slot[name=listbox]');
     this.#listboxSlot.addEventListener('slotchange', () => {
-      this.disable();
-      // update listbox reference if necessary
       this.#listbox = this.#listboxSlot.assignedElements()[0] || this.#listbox;
-      this.enable();
     });
   }
 
@@ -289,10 +276,8 @@ class MediaChromeSelectMenu extends globalThis.HTMLElement {
       }
     } else if (attrName === 'disabled' && newValue !== oldValue) {
       if (newValue == null) {
-        this.#enabledState = true;
         this.enable();
       } else {
-        this.#enabledState = false;
         this.disable();
       }
     }

--- a/src/js/utils/element-utils.js
+++ b/src/js/utils/element-utils.js
@@ -165,3 +165,25 @@ export function setStringAttr(el, attrName, value) {
 
   el.setAttribute(attrName, nextValue);
 }
+
+/**
+ * Get the active element, accounting for Shadow DOM subtrees.
+ * @author Cory LaViska
+ * @see https://www.abeautifulsite.net/posts/finding-the-active-element-in-a-shadow-root/
+ */
+export function getActiveElement(root = document) {
+  const activeEl = root.activeElement;
+
+  if (!activeEl) return null;
+
+  // If there’s a shadow root, recursively find the active element within it.
+  // If the recursive call returns null, return the active element
+  // of the top-level Document.
+  if (activeEl.shadowRoot) {
+    // @ts-ignore
+    return getActiveElement(activeEl.shadowRoot) || document.activeElement;
+  }
+
+  // If not, we can just return the active element
+  return activeEl;
+}

--- a/src/js/utils/element-utils.js
+++ b/src/js/utils/element-utils.js
@@ -29,6 +29,16 @@ export const closestComposedNode = (childNode, selector) => {
 };
 
 /**
+ * Get the active element, accounting for Shadow DOM subtrees.
+ * @param {Document|ShadowRoot} root
+ */
+export function getActiveElement(root = document) {
+  const activeEl = root?.activeElement;
+  if (!activeEl) return null;
+  return getActiveElement(activeEl.shadowRoot) ?? activeEl;
+}
+
+/**
  * Get or insert a CSS rule with a selector in an element containing <style> tags.
  * @param  {Element|ShadowRoot} styleParent
  * @param  {string} selectorText
@@ -164,26 +174,4 @@ export function setStringAttr(el, attrName, value) {
   if (getStringAttr(el, attrName, undefined) === nextValue) return;
 
   el.setAttribute(attrName, nextValue);
-}
-
-/**
- * Get the active element, accounting for Shadow DOM subtrees.
- * @author Cory LaViska
- * @see https://www.abeautifulsite.net/posts/finding-the-active-element-in-a-shadow-root/
- */
-export function getActiveElement(root = document) {
-  const activeEl = root.activeElement;
-
-  if (!activeEl) return null;
-
-  // If there’s a shadow root, recursively find the active element within it.
-  // If the recursive call returns null, return the active element
-  // of the top-level Document.
-  if (activeEl.shadowRoot) {
-    // @ts-ignore
-    return getActiveElement(activeEl.shadowRoot) || document.activeElement;
-  }
-
-  // If not, we can just return the active element
-  return activeEl;
 }

--- a/src/js/utils/resize-observer.js
+++ b/src/js/utils/resize-observer.js
@@ -3,20 +3,32 @@ import { globalThis } from './server-safe-globals.js';
 // Use 1 resize observer instance for many elements for best performance.
 // https://groups.google.com/a/chromium.org/g/blink-dev/c/z6ienONUb5A/m/F5-VcUZtBAAJ
 
-const callbacks = new WeakMap();
+const callbacksMap = new WeakMap();
+
+const getCallbacks = (element) => {
+  let callbacks = callbacksMap.get(element);
+  if (!callbacks) callbacksMap.set(element, (callbacks = new Set()));
+  return callbacks;
+}
 
 const observer = new globalThis.ResizeObserver((entries) => {
   for (let entry of entries) {
-    callbacks.get(entry.target)?.(entry);
+    for (let callback of getCallbacks(entry.target)) {
+      callback(entry);
+    }
   }
 });
 
 export function observeResize(element, callback) {
-  callbacks.set(element, callback);
+  getCallbacks(element).add(callback);
   observer.observe(element);
 }
 
-export function unobserveResize(element) {
-  callbacks.delete(element);
-  observer.unobserve(element);
+export function unobserveResize(element, callback) {
+  const callbacks = getCallbacks(element);
+  callbacks.delete(callback);
+
+  if (!callbacks.size) {
+    observer.unobserve(element);
+  }
 }

--- a/src/js/utils/resize-observer.js
+++ b/src/js/utils/resize-observer.js
@@ -1,0 +1,22 @@
+import { globalThis } from './server-safe-globals.js';
+
+// Use 1 resize observer instance for many elements for best performance.
+// https://groups.google.com/a/chromium.org/g/blink-dev/c/z6ienONUb5A/m/F5-VcUZtBAAJ
+
+const callbacks = new WeakMap();
+
+const observer = new globalThis.ResizeObserver((entries) => {
+  for (let entry of entries) {
+    callbacks.get(entry.target)?.(entry);
+  }
+});
+
+export function observeResize(element, callback) {
+  callbacks.set(element, callback);
+  observer.observe(element);
+}
+
+export function unobserveResize(element) {
+  callbacks.delete(element);
+  observer.unobserve(element);
+}

--- a/src/js/utils/server-safe-globals.js
+++ b/src/js/utils/server-safe-globals.js
@@ -68,6 +68,7 @@ export const GlobalThis = isServer && !isShimmed ? globalThisShim : globalThis;
 /**
   * @type { document & { webkitExitFullscreen? } |
   * {createElement,
+  * activeElement,
   * fullscreenElement?,
   * webkitExitFullscreen?,
   * getElementById?,

--- a/src/js/utils/server-safe-globals.js
+++ b/src/js/utils/server-safe-globals.js
@@ -68,7 +68,7 @@ export const GlobalThis = isServer && !isShimmed ? globalThisShim : globalThis;
 /**
   * @type { document & { webkitExitFullscreen? } |
   * {createElement,
-  * activeElement,
+  * activeElement?,
   * fullscreenElement?,
   * webkitExitFullscreen?,
   * getElementById?,

--- a/src/js/utils/server-safe-globals.js
+++ b/src/js/utils/server-safe-globals.js
@@ -8,6 +8,8 @@ class EventTarget {
 
 class ResizeObserver {
   observe() {}
+  unobserve() {}
+  disconnect() {}
 }
 
 const documentShim = {


### PR DESCRIPTION
related resize observer performance issue:
https://github.com/WICG/resize-observer/issues/59

test url:
https://media-chrome-git-fork-luwes-selectmenu-overflow-mux.vercel.app/examples/vanilla/control-elements/media-rendition-selectmenu.html

before:

![SCR-20230914-cp9](https://github.com/muxinc/media-chrome/assets/360826/79d96b15-e2f6-4c98-bb08-a0937537229d)

after (w/ scrolling):

![SCR-20230914-h68](https://github.com/muxinc/media-chrome/assets/360826/09e1c30c-60fe-4d42-856d-c5a5f608d1c8)
