### PR TITLE
fix: selectmenu anchor right + add listbox row layout

### DIFF
--- a/examples/vanilla/control-elements/media-playback-rate-selectmenu.html
+++ b/examples/vanilla/control-elements/media-playback-rate-selectmenu.html
@@ -82,7 +82,7 @@
     </media-control-bar>
   </media-controller>
 
-  <h2>Row layout</h2>
+  <h2>Row layout w/ header</h2>
 
   <media-controller id="mc">
     <video
@@ -99,8 +99,21 @@
       <media-time-display showduration></media-time-display>
       <media-time-range></media-time-range>
       <media-mute-button></media-mute-button>
-      <media-playback-rate-selectmenu>
-        <media-playback-rate-listbox slot="listbox" row></media-playback-rate-listbox>
+      <media-playback-rate-selectmenu style="--media-listbox-layout: row;">
+        <media-playback-rate-listbox slot="listbox">
+          <div slot="header">
+            <style>
+              kbd {
+                color: #000;
+                background-color: #fff;
+                padding-inline: .3em;
+                line-height: 1;
+                border-radius: 3px;
+              }
+            </style>
+            Playback Speed <kbd>s</kbd>
+          </div>
+        </media-playback-rate-listbox>
       </media-playback-rate-selectmenu>
       <media-pip-button></media-pip-button>
       <media-fullscreen-button></media-fullscreen-button>

--- a/examples/vanilla/control-elements/media-playback-rate-selectmenu.html
+++ b/examples/vanilla/control-elements/media-playback-rate-selectmenu.html
@@ -99,8 +99,8 @@
       <media-time-display showduration></media-time-display>
       <media-time-range></media-time-range>
       <media-mute-button></media-mute-button>
-      <media-playback-rate-selectmenu style="--media-listbox-layout: row;">
-        <media-playback-rate-listbox slot="listbox">
+      <media-playback-rate-selectmenu>
+        <media-playback-rate-listbox slot="listbox" style="--media-listbox-layout: row;">
           <div slot="header">
             <style>
               kbd {

--- a/examples/vanilla/control-elements/media-playback-rate-selectmenu.html
+++ b/examples/vanilla/control-elements/media-playback-rate-selectmenu.html
@@ -30,6 +30,8 @@
 <body>
   <h1>Playback Rate Selectmenu</h1>
 
+  <h2>Column layout w/ custom icon</h2>
+
   <media-controller id="mc">
     <video
       id="video"
@@ -74,6 +76,31 @@
             </style>
           </span>
         </media-playback-rate-listbox>
+      </media-playback-rate-selectmenu>
+      <media-pip-button></media-pip-button>
+      <media-fullscreen-button></media-fullscreen-button>
+    </media-control-bar>
+  </media-controller>
+
+  <h2>Row layout</h2>
+
+  <media-controller id="mc">
+    <video
+      id="video"
+      slot="media"
+      src="https://stream.mux.com/O6LdRc0112FEJXH00bGsN9Q31yu5EIVHTgjTKRkKtEq1k/high.mp4"
+      poster="https://image.mux.com/O6LdRc0112FEJXH00bGsN9Q31yu5EIVHTgjTKRkKtEq1k/thumbnail.webp"
+      preload="metadata"
+      muted
+      crossorigin
+    ></video>
+    <media-control-bar>
+      <media-play-button></media-play-button>
+      <media-time-display showduration></media-time-display>
+      <media-time-range></media-time-range>
+      <media-mute-button></media-mute-button>
+      <media-playback-rate-selectmenu>
+        <media-playback-rate-listbox slot="listbox" row></media-playback-rate-listbox>
       </media-playback-rate-selectmenu>
       <media-pip-button></media-pip-button>
       <media-fullscreen-button></media-fullscreen-button>

--- a/src/js/experimental/media-chrome-listbox.js
+++ b/src/js/experimental/media-chrome-listbox.js
@@ -62,7 +62,9 @@ template.innerHTML = /*html*/`
   }
 
   #container {
-    display: block;
+    gap: var(--media-listbox-gap);
+    display: flex;
+    flex-direction: column;
     overflow: hidden auto;
     padding-block: .5em;
   }
@@ -82,11 +84,30 @@ template.innerHTML = /*html*/`
   }
 
   [part~="select-indicator"] {
+    display: var(--media-option-select-indicator-display);
     visibility: hidden;
   }
 
   [aria-selected="true"] > [part~="select-indicator"] {
     visibility: visible;
+  }
+
+  :host([row]) #container {
+    gap: var(--media-listbox-gap, .25em);
+    flex-direction: row;
+    padding-inline: .5em;
+  }
+
+  :host([row]) media-chrome-option {
+    padding: .3em;
+  }
+
+  :host([row]) media-chrome-option[aria-selected="true"] {
+    background: var(--media-option-selected-background, rgb(255 255 255 / .2));
+  }
+
+  :host([row]) [part~="select-indicator"] {
+    display: var(--media-option-select-indicator-display, none);
   }
 </style>
 <slot name="header"></slot>

--- a/src/js/experimental/media-chrome-listbox.js
+++ b/src/js/experimental/media-chrome-listbox.js
@@ -99,7 +99,7 @@ template.innerHTML = /*html*/`
   }
 
   :host([row]) media-chrome-option {
-    padding: .3em;
+    padding: .3em .24em;
   }
 
   :host([row]) media-chrome-option[aria-selected="true"] {

--- a/src/js/experimental/media-chrome-listbox.js
+++ b/src/js/experimental/media-chrome-listbox.js
@@ -305,9 +305,10 @@ class MediaChromeListbox extends globalThis.HTMLElement {
   }
 
   attributeChangedCallback(attrName, oldValue, newValue) {
-    this.#updateLayoutStyle();
 
-    if (attrName === MediaStateReceiverAttributes.MEDIA_CONTROLLER) {
+    if (attrName === 'style' && newValue !== oldValue) {
+      this.#updateLayoutStyle();
+    } else if (attrName === MediaStateReceiverAttributes.MEDIA_CONTROLLER) {
       if (oldValue) {
         this.#mediaController?.unassociateElement?.(this);
         this.#mediaController = null;

--- a/src/js/experimental/media-chrome-listbox.js
+++ b/src/js/experimental/media-chrome-listbox.js
@@ -136,6 +136,9 @@ template.innerHTML = /*html*/`
  * @cssproperty --media-text-color - `color` of text.
  *
  * @cssproperty --media-control-background - `background` of control.
+ * @cssproperty --media-listbox-layout - Set to `row` for a horizontal listbox design.
+ * @cssproperty --media-listbox-flex-direction - `flex-direction` of listbox.
+ * @cssproperty --media-listbox-gap - `gap` between listbox options.
  * @cssproperty --media-listbox-background - `background` of listbox.
  * @cssproperty --media-listbox-border-radius - `border-radius` of listbox.
  *
@@ -145,11 +148,11 @@ template.innerHTML = /*html*/`
  * @cssproperty --media-font-size - `font-size` property.
  * @cssproperty --media-text-content-height - `line-height` of text.
  *
- * @cssproperty --media-option-indicator-fill - `fill` color of indicator icon.
  * @cssproperty --media-icon-color - `fill` color of icon.
- *
+ * @cssproperty --media-option-indicator-fill - `fill` color of indicator icon.
  * @cssproperty --media-option-indicator-height - `height` of option indicator.
  * @cssproperty --media-option-indicator-vertical-align - `vertical-align` of option indicator.
+ * @cssproperty --media-option-select-indicator-display - `display` of select indicator.
  */
 class MediaChromeListbox extends globalThis.HTMLElement {
   static get observedAttributes() {

--- a/src/js/experimental/media-chrome-option.js
+++ b/src/js/experimental/media-chrome-option.js
@@ -10,7 +10,6 @@ template.innerHTML = /*html*/`
     white-space: nowrap;
     white-space-collapse: collapse;
     text-wrap: nowrap;
-    min-height: 1.2em;
     padding: .4em .5em;
     transition: var(--media-option-transition);
     outline: var(--media-option-outline, 0);

--- a/src/js/experimental/media-chrome-selectmenu.js
+++ b/src/js/experimental/media-chrome-selectmenu.js
@@ -23,7 +23,6 @@ template.innerHTML = /*html*/`
   [name=listbox]::slotted(*),
   [part=listbox] {
     position: absolute;
-    right: 0;
     bottom: 100%;
     max-height: 300px;
     transition: var(--media-selectmenu-transition-in,
@@ -214,13 +213,11 @@ class MediaChromeSelectMenu extends globalThis.HTMLElement {
     // if the menu is hidden, skip updating the menu position
     if (this.#listbox.offsetWidth === 0) return;
 
+    // Choose .offsetWidth which is not affected by CSS transforms.
+    const listboxWidth = this.#listbox.offsetWidth;
     const buttonRect = this.#button.getBoundingClientRect();
 
-    // if we're outside of the controller,
-    // one of the components should have a mediacontroller attribute.
-    // There isn't a good way now to differentiate between default buttons
-    // or a slotted button but outside of the media-controller.
-    // So, a regular declarative selectmenu may default to open up rather than down.
+    // If this select element is outside of the controller open downward.
     if (
       this.hasAttribute('mediacontroller') ||
       this.#button.hasAttribute('mediacontroller') ||
@@ -228,21 +225,21 @@ class MediaChromeSelectMenu extends globalThis.HTMLElement {
     ) {
       this.#listbox.style.zIndex = '1';
       this.#listbox.style.bottom = 'unset';
-      this.#listbox.style.top = buttonRect.height + 'px'
+      this.#listbox.style.right = null;
+      this.#listbox.style.left = '0';
+      this.#listbox.style.top = `${buttonRect.height}px`
       return;
     }
 
     // Get the element that enforces the bounds for the list boxes.
     const bounds = getBoundsElement(this);
-
-    // Choose .offsetWidth which is not affected by CSS transforms.
-    const listboxWidth = this.#listbox.offsetWidth;
     const boundsRect = bounds.getBoundingClientRect();
     const listboxRight = buttonRect.x + listboxWidth;
     const position = Math.max(
       buttonRect.right - listboxRight,
       buttonRect.right - boundsRect.right
     );
+    this.#listbox.style.left = null;
     this.#listbox.style.right = `${position}px`;
     this.#listbox.style.maxHeight = `${boundsRect.height - buttonRect.height}px`;
   }

--- a/src/js/experimental/media-chrome-selectmenu.js
+++ b/src/js/experimental/media-chrome-selectmenu.js
@@ -23,7 +23,7 @@ template.innerHTML = /*html*/`
   [name=listbox]::slotted(*),
   [part=listbox] {
     position: absolute;
-    left: 0;
+    right: 0;
     bottom: 100%;
     max-height: 300px;
     transition: var(--media-selectmenu-transition-in,
@@ -198,6 +198,8 @@ class MediaChromeSelectMenu extends globalThis.HTMLElement {
   #hide() {
     if (this.#listboxSlot.hidden) return;
 
+    unobserveResize(getBoundsElement(this), this.#updateMenuPosition);
+
     const activeElement = getActiveElement();
 
     this.#listboxSlot.hidden = true;
@@ -206,8 +208,6 @@ class MediaChromeSelectMenu extends globalThis.HTMLElement {
     if (containsComposedNode(this.#listbox, activeElement)) {
       this.#button.focus();
     }
-
-    unobserveResize(getBoundsElement(this), this.#updateMenuPosition);
   }
 
   #updateMenuPosition = () => {
@@ -238,9 +238,12 @@ class MediaChromeSelectMenu extends globalThis.HTMLElement {
     // Choose .offsetWidth which is not affected by CSS transforms.
     const listboxWidth = this.#listbox.offsetWidth;
     const boundsRect = bounds.getBoundingClientRect();
-    const position = -Math.max(buttonRect.x + listboxWidth - boundsRect.right, 0);
-
-    this.#listbox.style.left = `${position}px`;
+    const listboxRight = buttonRect.x + listboxWidth;
+    const position = Math.max(
+      buttonRect.right - listboxRight,
+      buttonRect.right - boundsRect.right
+    );
+    this.#listbox.style.right = `${position}px`;
     this.#listbox.style.maxHeight = `${boundsRect.height - buttonRect.height}px`;
   }
 

--- a/src/js/media-playback-rate-button.js
+++ b/src/js/media-playback-rate-button.js
@@ -9,7 +9,7 @@ export const Attributes = {
   RATES: 'rates',
 };
 
-export const DEFAULT_RATES = [1, 1.25, 1.5, 1.75, 2];
+export const DEFAULT_RATES = [1, 1.2, 1.5, 1.7, 2];
 export const DEFAULT_RATE = 1;
 
 const slotTemplate = document.createElement('template');

--- a/src/js/media-playback-rate-button.js
+++ b/src/js/media-playback-rate-button.js
@@ -13,7 +13,13 @@ export const DEFAULT_RATES = [1, 1.2, 1.5, 1.7, 2];
 export const DEFAULT_RATE = 1;
 
 const slotTemplate = document.createElement('template');
-slotTemplate.innerHTML = `
+slotTemplate.innerHTML = /*html*/`
+  <style>
+    :host {
+      min-width: 5ch;
+      padding: var(--media-control-padding, 10px 5px);
+    }
+  </style>
   <span id="container"></span>
 `;
 
@@ -41,6 +47,8 @@ class MediaPlaybackRateButton extends MediaChromeButton {
   }
 
   attributeChangedCallback(attrName, oldValue, newValue) {
+    super.attributeChangedCallback(attrName, oldValue, newValue);
+
     if (attrName === Attributes.RATES) {
       this.#rates.value = newValue;
     }
@@ -51,9 +59,7 @@ class MediaPlaybackRateButton extends MediaChromeButton {
         : DEFAULT_RATE;
       this.container.innerHTML = `${playbackRate}x`;
       this.setAttribute('aria-label', nouns.PLAYBACK_RATE({ playbackRate }));
-      return;
     }
-    super.attributeChangedCallback(attrName, oldValue, newValue);
   }
 
   /**


### PR DESCRIPTION
https://media-chrome-git-fork-luwes-playbackrate-menu-mux.vercel.app/examples/vanilla/control-elements/media-playback-rate-selectmenu.html

- [x] change default rates to `1, 1.2, 1.5, 1.7, 2`
- [x] anchor selectmenu's by right of button (because generally they are on right side of player)
- [x] make playbackrate button a minimum width for default rates so there is no jump when changing 2 characters
- [x] add new `--media-listbox-layout: row` CSS var on listbox for a flex row layout + style tweaks for that layout