### PR TITLE
fix: hide cursor on media when controls fade out

### DIFF
--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -157,6 +157,10 @@ template.innerHTML = /*html*/`
       transition: opacity 1s;
     }
 
+    :host([${Attributes.USER_INACTIVE}]:not([${MediaUIAttributes.MEDIA_PAUSED}]):not([${MediaUIAttributes.MEDIA_IS_CASTING}]):not([${Attributes.AUDIO}])) ::slotted([slot=media]) {
+      cursor: none;
+    }
+
     ::slotted(media-control-bar)  {
       align-self: stretch;
     }


### PR DESCRIPTION
#756