### PR TITLE
feat: add control-menu prototype (WIP)

### DIFF
--- a/examples/vanilla/control-elements/media-control-menu.html
+++ b/examples/vanilla/control-elements/media-control-menu.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width" />
+    <title>Media Control Menu</title>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@mux/mux-video/+esm"></script>
+    <script type="module" src="../../../dist/index.js"></script>
+    <script type="module" src="../../../dist/experimental/index.js"></script>
+    <style>
+      /* Hide custom elements that are not defined yet */
+      :not(:defined) {
+        display: none;
+      }
+
+      /** add styles to prevent CLS (Cumulative Layout Shift) */
+      media-controller:not([audio]) {
+        display: block;         /* expands the container if preload=none */
+        max-width: 540px;       /* allows the container to shrink if small */
+        aspect-ratio: 16 / 9;   /* set container aspect ratio if preload=none */
+      }
+
+      mux-video {
+        width: 100%;      /* prevents video to expand beyond its container */
+      }
+
+      .examples {
+        margin-top: 20px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>MediaControlMenu</h1>
+
+    <h2>&lt;select&gt; children</h2>
+
+    <media-controller id="mc" defaultsubtitles>
+      <mux-video
+        slot="media"
+        src="https://stream.mux.com/fss00bwClhYMynhxeE2Hv757J02VI68KY5.m3u8"
+        poster="https://image.mux.com/fss00bwClhYMynhxeE2Hv757J02VI68KY5/thumbnail.webp"
+        preload="metadata"
+        muted
+        crossorigin
+      ></mux-video>
+      <media-control-menu hidden>
+        <!-- Imagine this being <media-rendition-select>, simple & recognizable suffix -->
+        <media-rendition-selectmenu>
+          <media-rendition-button slot="button">
+            <span slot="icon">Quality</span>
+          </media-rendition-button>
+        </media-rendition-selectmenu>
+        <!-- Imagine this being <media-playback-rate-select> -->
+        <media-playback-rate-selectmenu>
+          <media-playback-rate-button slot="button">
+            <span slot="icon">Speed</span>
+          </media-playback-rate-button>
+        </media-playback-rate-selectmenu>
+      </media-control-menu>
+      <media-control-bar>
+        <media-play-button></media-play-button>
+        <media-mute-button></media-mute-button>
+        <media-time-range></media-time-range>
+        <media-time-display></media-time-display>
+        <media-rendition-selectmenu></media-rendition-selectmenu>
+        <media-control-menu-button></media-control-menu-button>
+        <media-fullscreen-button></media-fullscreen-button>
+      </media-control-bar>
+    </media-controller>
+
+    <h2>&lt;listbox&gt; children</h2>
+
+    <media-controller id="mc" defaultsubtitles>
+      <mux-video
+        slot="media"
+        src="https://stream.mux.com/fss00bwClhYMynhxeE2Hv757J02VI68KY5.m3u8"
+        poster="https://image.mux.com/fss00bwClhYMynhxeE2Hv757J02VI68KY5/thumbnail.webp"
+        preload="metadata"
+        muted
+        crossorigin
+      ></mux-video>
+      <media-control-menu id="settings" hidden style="--media-control-menu-flex-direction: row">
+        <media-rendition-listbox>
+          <div slot="header">
+            Quality
+          </div>
+        </media-rendition-listbox>
+        <media-playback-rate-listbox>
+          <div slot="header">
+            <style>
+              kbd {
+                color: #000;
+                background-color: #fff;
+                padding-inline: .3em;
+                line-height: 1;
+                border-radius: 3px;
+              }
+            </style>
+            Playback Speed <kbd>s</kbd>
+          </div>
+        </media-playback-rate-listbox>
+      </media-control-menu>
+      <media-control-bar>
+        <media-play-button></media-play-button>
+        <media-mute-button></media-mute-button>
+        <media-time-range></media-time-range>
+        <media-time-display></media-time-display>
+        <media-rendition-selectmenu></media-rendition-selectmenu>
+        <!-- Link menu button and menu with target<->id -->
+        <media-control-menu-button target="settings"></media-control-menu-button>
+        <media-fullscreen-button></media-fullscreen-button>
+      </media-control-bar>
+    </media-controller>
+
+    <div class="examples">
+      <a href="../">View more examples</a>
+    </div>
+  </body>
+</html>

--- a/examples/vanilla/index.html
+++ b/examples/vanilla/index.html
@@ -67,6 +67,7 @@
     <h3>Experimental</h3>
     <ul>
       <li><a href="components.html">All components (useful for testing)</a></li>
+      <li><a href="control-elements/media-control-menu.html">Menu</a></li>
       <li><a href="control-elements/media-chrome-listbox.html">Listbox</a></li>
       <li><a href="control-elements/media-captions-listbox.html">Captions listbox</a></li>
       <li><a href="control-elements/media-captions-selectmenu.html">Captions selectmenu</a></li>

--- a/src/js/experimental/index.js
+++ b/src/js/experimental/index.js
@@ -1,3 +1,5 @@
+export { MediaControlMenu } from './media-control-menu.js';
+export { MediaControlMenuButton } from './media-control-menu-button.js';
 export { MediaChromeListbox } from './media-chrome-listbox.js';
 export { MediaChromeOption } from './media-chrome-option.js';
 export { MediaChromeSelectMenu } from './media-chrome-selectmenu.js';

--- a/src/js/experimental/media-chrome-listbox.js
+++ b/src/js/experimental/media-chrome-listbox.js
@@ -50,7 +50,7 @@ template.innerHTML = /*html*/`
     color: var(--media-text-color, var(--media-primary-color, rgb(238 238 238)));
     background: var(--media-listbox-background, var(--media-control-background, var(--media-secondary-color, rgb(20 20 30 / .8))));
     border-radius: var(--media-listbox-border-radius);
-    display: inline-flex;
+    display: var(--media-listbox-display, inline-flex);
     flex-direction: column;
     position: relative;
     box-sizing: border-box;
@@ -63,9 +63,9 @@ template.innerHTML = /*html*/`
 
   #container {
     gap: var(--media-listbox-gap);
-    display: flex;
     flex-direction: var(--media-listbox-flex-direction, column);
-    overflow: hidden auto;
+    overflow: var(--media-listbox-overflow, hidden auto);
+    display: flex;
     padding-block: .5em;
   }
 

--- a/src/js/experimental/media-chrome-selectmenu.js
+++ b/src/js/experimental/media-chrome-selectmenu.js
@@ -3,6 +3,7 @@ import './media-chrome-listbox.js';
 import { globalThis, document } from '../utils/server-safe-globals.js';
 import { containsComposedNode, closestComposedNode, getOrInsertCSSRule, getActiveElement } from '../utils/element-utils.js';
 import { observeResize, unobserveResize } from '../utils/resize-observer.js';
+import { ToggleEvent } from '../utils/events.js';
 import { MediaStateReceiverAttributes } from '../constants.js';
 
 const template = document.createElement('template');
@@ -22,23 +23,25 @@ template.innerHTML = /*html*/`
 
   [name=listbox]::slotted(*),
   [part=listbox] {
-    position: absolute;
-    bottom: 100%;
-    max-height: 300px;
+    position: var(--media-selectmenu-listbox-position, absolute);
+    opacity: var(--media-selectmenu-listbox-opacity, 1);
+    max-height: var(--media-selectmenu-listbox-max-height, 300px);
+    visibility: var(--media-selectmenu-listbox-visibility, visible);
     transition: var(--media-selectmenu-transition-in,
       visibility 0s, transform .15s ease-out, opacity .15s ease-out);
-    transform: var(--media-listbox-transform-in, translateY(0) scale(1));
-    visibility: visible;
-    opacity: 1;
+    transform: var(--media-selectmenu-transform-in, translateY(0) scale(1));
+    bottom: 100%;
+    overflow: hidden;
   }
 
   [name=listbox][hidden]::slotted(*),
   [hidden] [part=listbox] {
+    opacity: var(--media-selectmenu-listbox-hidden-opacity, 0);
+    max-height: var(--media-selectmenu-listbox-hidden-max-height, var(--media-selectmenu-listbox-max-height, 300px));
+    visibility: var(--media-selectmenu-listbox-hidden-visibility, hidden);
     transition: var(--media-selectmenu-transition-out,
       visibility .15s ease-out, transform .15s ease-out, opacity .15s ease-out);
-    transform: var(--media-listbox-transform-out, translateY(2px) scale(.99));
-    visibility: hidden;
-    opacity: 0;
+    transform: var(--media-selectmenu-transform-out, translateY(2px) scale(.99));
     pointer-events: none;
   }
 
@@ -75,6 +78,7 @@ class MediaChromeSelectMenu extends globalThis.HTMLElement {
   #buttonSlot;
   #listbox;
   #listboxSlot;
+  #hostStyle;
 
   static get observedAttributes() {
     return [
@@ -92,8 +96,8 @@ class MediaChromeSelectMenu extends globalThis.HTMLElement {
       this.shadowRoot.appendChild(template.content.cloneNode(true));
     }
 
-    const { style } = getOrInsertCSSRule(this.shadowRoot, ':host');
-    style.setProperty('display', `var(--media-control-display, var(--${this.localName}-display, inline-flex))`);
+    this.#hostStyle = getOrInsertCSSRule(this.shadowRoot, ':host').style;
+    this.#hostStyle.setProperty('display', `var(--media-control-display, var(--${this.localName}-display, inline-flex))`);
 
     this.init?.();
 
@@ -185,17 +189,33 @@ class MediaChromeSelectMenu extends globalThis.HTMLElement {
   #show() {
     if (!this.#listboxSlot.hidden) return;
 
+    this.dispatchEvent(new ToggleEvent('beforetoggle', {
+      bubbles: true, composed: true,
+      oldState: 'closed', newState: 'open',
+    }));
+
     this.#listboxSlot.hidden = false;
     this.#button.setAttribute('aria-expanded', 'true');
+    this.setAttribute('aria-expanded', 'true');
 
     this.#updateMenuPosition();
     this.#listbox.focus();
 
     observeResize(getBoundsElement(this), this.#updateMenuPosition);
+
+    this.dispatchEvent(new ToggleEvent('toggle', {
+      bubbles: true, composed: true,
+      oldState: 'closed', newState: 'open',
+    }));
   }
 
   #hide() {
     if (this.#listboxSlot.hidden) return;
+
+    this.dispatchEvent(new ToggleEvent('beforetoggle', {
+      bubbles: true, composed: true,
+      oldState: 'open', newState: 'closed',
+    }));
 
     unobserveResize(getBoundsElement(this), this.#updateMenuPosition);
 
@@ -203,10 +223,16 @@ class MediaChromeSelectMenu extends globalThis.HTMLElement {
 
     this.#listboxSlot.hidden = true;
     this.#button.setAttribute('aria-expanded', 'false');
+    this.removeAttribute('aria-expanded');
 
     if (containsComposedNode(this.#listbox, activeElement)) {
       this.#button.focus();
     }
+
+    this.dispatchEvent(new ToggleEvent('toggle', {
+      bubbles: true, composed: true,
+      oldState: 'open', newState: 'closed',
+    }));
   }
 
   #updateMenuPosition = () => {
@@ -241,7 +267,11 @@ class MediaChromeSelectMenu extends globalThis.HTMLElement {
     );
     this.#listbox.style.left = null;
     this.#listbox.style.right = `${position}px`;
-    this.#listbox.style.maxHeight = `${boundsRect.height - buttonRect.height}px`;
+
+    this.#hostStyle.setProperty(
+      '--media-selectmenu-listbox-max-height',
+      `${boundsRect.height - buttonRect.height}px`
+    );
   }
 
   enable() {

--- a/src/js/experimental/media-control-menu-button.js
+++ b/src/js/experimental/media-control-menu-button.js
@@ -1,0 +1,74 @@
+import { MediaChromeButton } from '../media-chrome-button.js';
+import { globalThis, document } from '../utils/server-safe-globals.js';
+import { closestComposedNode } from '../utils/element-utils.js';
+import { MediaStateReceiverAttributes } from '../constants.js';
+
+/** @typedef {import('./media-control-menu.js').MediaControlMenu} MediaControlMenu */
+
+const slotTemplate = document.createElement('template');
+slotTemplate.innerHTML = /*html*/`
+  <slot name="icon">
+    <svg aria-hidden="true" viewBox="0 0 24 24">
+      <path d="M4.5 14.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Zm7.5 0a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Zm7.5 0a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Z"/>
+    </svg>
+  </slot>
+`;
+
+/**
+ * @attr {string} target - CSS id selector for the element to be targeted by the button.
+ */
+class MediaControlMenuButton extends MediaChromeButton {
+  static get observedAttributes() {
+    return [
+      ...super.observedAttributes,
+      'target',
+    ];
+  }
+
+  constructor() {
+    super({ slotTemplate });
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.setAttribute('aria-haspopup', 'menu');
+  }
+
+  get target() {
+    return this.getAttribute('target')
+  }
+
+  set target(value) {
+    this.setAttribute('target', value);
+  }
+
+  handleClick() {
+    const container = getMediaControllerElement(this)
+      ?? /** @type {ShadowRoot|Document} */ (this.getRootNode());
+
+    const target = /** @type {MediaControlMenu} */ (/** @type {unknown} */ (
+      container.querySelector(this.target ? `#${this.target}` : 'media-control-menu')
+    ));
+
+    const hidden = this.getAttribute('aria-expanded') === 'true';
+    this.setAttribute('aria-expanded', `${!hidden}`);
+    target.hidden = hidden;
+  }
+}
+
+function getMediaControllerElement(host) {
+  const mediaControllerId = host.getAttribute(
+    MediaStateReceiverAttributes.MEDIA_CONTROLLER
+  );
+  if (mediaControllerId) {
+    return host.getRootNode()?.getElementById(mediaControllerId);
+  }
+  return closestComposedNode(host, 'media-controller');
+}
+
+if (!globalThis.customElements.get('media-control-menu-button')) {
+  globalThis.customElements.define('media-control-menu-button', MediaControlMenuButton);
+}
+
+export { MediaControlMenuButton };
+export default MediaControlMenuButton;

--- a/src/js/experimental/media-control-menu.js
+++ b/src/js/experimental/media-control-menu.js
@@ -1,0 +1,115 @@
+import { globalThis, document } from '../utils/server-safe-globals.js';
+import { getActiveElement, containsComposedNode } from '../utils/element-utils.js';
+
+const template = document.createElement('template');
+template.innerHTML = /*html*/`
+  <style>
+    :host {
+      --media-button-justify-content: start;
+      --media-button-padding: 10px;
+      --media-listbox-display: flex;
+      --media-selectmenu-listbox-position: static;
+      --media-selectmenu-listbox-hidden-opacity: 1;
+      --media-selectmenu-listbox-hidden-max-height: 0;
+      --media-selectmenu-transform-in: none;
+      --media-selectmenu-transform-out: none;
+      --media-selectmenu-transition-in: visibility 0s, max-height .2s ease-in-out;
+      --media-selectmenu-transition-out: visibility .2s ease-in-out, max-height .2s ease-in-out;
+
+      position: relative;
+      align-self: end;
+      line-height: 0;
+      min-width: 110px;
+      height: 100%;
+      overflow: hidden;
+      flex-direction: var(--media-control-menu-flex-direction, column);
+      justify-content: end;
+      pointer-events: none !important;
+    }
+
+    :host(:not([hidden])) {
+      display: flex;
+    }
+
+    ::slotted(*) {
+      pointer-events: all;
+      flex-direction: column;
+      overflow: hidden;
+      transition: max-height 0s .15s ease-out;
+      max-height: 100%;
+    }
+
+    slot.has-expanded::slotted(:not([aria-expanded=true])) {
+      transition: max-height 0s;
+      max-height: 0;
+    }
+  </style>
+  <slot></slot>
+`;
+
+class MediaControlMenu extends globalThis.HTMLElement {
+  static observedAttributes = ['hidden'];
+
+  #slot;
+  #previouslyFocused;
+
+  constructor() {
+    super();
+
+    if (!this.shadowRoot) {
+      // Set up the Shadow DOM if not using Declarative Shadow DOM.
+      this.attachShadow({ mode: 'open' });
+      this.shadowRoot.appendChild(template.content.cloneNode(true));
+    }
+
+    this.#slot = this.shadowRoot.querySelector('slot');
+
+    this.addEventListener('beforetoggle', this);
+    this.addEventListener('focusout', this);
+  }
+
+  handleEvent(event) {
+    switch (event.type) {
+      case 'focusout':
+        if (!containsComposedNode(this, event.relatedTarget)) {
+          this.#previouslyFocused.focus();
+        }
+        break;
+      case 'beforetoggle':
+        this.#handleBeforeToggle(event);
+        break;
+    }
+  }
+
+  #handleBeforeToggle(event) {
+    this.#slot.classList.toggle('has-expanded', event.newState === 'open');
+  }
+
+  connectedCallback() {
+    if (!this.hasAttribute('role')) {
+      this.setAttribute('role', 'menu');
+    }
+  }
+
+  attributeChangedCallback(attrName) {
+    if (attrName === 'hidden') {
+      if (!this.hidden) {
+        this.focus();
+      }
+    }
+  }
+
+  focus() {
+    this.#previouslyFocused = getActiveElement();
+
+    const focusable = this.querySelectorAll('button, [href], input, select, [tabindex]:not([tabindex="-1"])');
+    focusable?.[0]?.focus();
+  }
+}
+
+if (!globalThis.customElements.get('media-control-menu')) {
+  globalThis.customElements.define('media-control-menu', MediaControlMenu);
+}
+
+export { MediaControlMenu };
+export default MediaControlMenu;

--- a/src/js/media-chrome-button.js
+++ b/src/js/media-chrome-button.js
@@ -14,10 +14,10 @@ template.innerHTML = /*html*/`
       var(--media-font-family, helvetica neue, segoe ui, roboto, arial, sans-serif));
     color: var(--media-text-color, var(--media-primary-color, rgb(238 238 238)));
     background: var(--media-control-background, var(--media-secondary-color, rgb(20 20 30 / .7)));
-    padding: var(--media-control-padding, 10px);
+    padding: var(--media-button-padding, var(--media-control-padding, 10px));
+    justify-content: var(--media-button-justify-content, center);
     display: inline-flex;
     align-items: center;
-    justify-content: center;
     vertical-align: middle;
     box-sizing: border-box;
     transition: background .15s linear;

--- a/src/js/media-playback-rate-button.js
+++ b/src/js/media-playback-rate-button.js
@@ -17,10 +17,10 @@ slotTemplate.innerHTML = /*html*/`
   <style>
     :host {
       min-width: 5ch;
-      padding: var(--media-control-padding, 10px 5px);
+      padding: var(--media-button-padding, var(--media-control-padding, 10px 5px));
     }
   </style>
-  <span id="container"></span>
+  <slot name="icon"></slot>
 `;
 
 /**
@@ -42,7 +42,7 @@ class MediaPlaybackRateButton extends MediaChromeButton {
 
   constructor(options = {}) {
     super({ slotTemplate, ...options });
-    this.container = this.shadowRoot.querySelector('#container');
+    this.container = this.shadowRoot.querySelector('slot[name="icon"]');
     this.container.innerHTML = `${DEFAULT_RATE}x`;
   }
 

--- a/src/js/utils/element-utils.js
+++ b/src/js/utils/element-utils.js
@@ -64,6 +64,7 @@ export function isElementVisible(el) {
  * { style: {
  * setProperty: () => void,
  * removeProperty: () => void,
+ * getPropertyValue: () => string,
  * width?: string,
  * height?: string,
  * display?: string,
@@ -92,6 +93,7 @@ export function getOrInsertCSSRule(styleParent, selectorText) {
       style: {
         setProperty: () => {},
         removeProperty: () => {},
+        getPropertyValue: () => '',
       },
     };
   }

--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -1,0 +1,19 @@
+/**
+ * Similar to the popover toggle event in anticipation of using <selectlist>.
+ * https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent
+ */
+export class ToggleEvent extends Event {
+  /** @type {'open' | 'closed'} */
+  newState;
+  /** @type {'open' | 'closed'} */
+  oldState;
+  /**
+   * @param  {string} type
+   * @param  {EventInit & { newState: 'open' | 'closed', oldState: 'open' | 'closed' }} init
+   */
+  constructor(type, { newState, oldState, ...options }) {
+    super(type, options);
+    this.newState = newState;
+    this.oldState = oldState;
+  }
+}


### PR DESCRIPTION
test url: https://media-chrome-git-fork-luwes-control-menu-mux.vercel.app/examples/vanilla/control-elements/media-control-menu.html

adds 2 new elements `<media-control-menu>` and `<media-control-menu-button>`.

`<media-control-menu>` is meant to be above the control bar and can be shown / hidden w/ `<media-control-menu-button>`

the linking is automatically done contained in `media-controller` or you can link them with `target`, `id` attributes.

there's a bunch of stuff missing, this is just a prototype.