### PR TITLE
docs: Fix react web-components link

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ You can find the [documentation for v0.x of media-chrome here.](https://v0.media
 
 ## Use with React
 
-While you technically can use Media Chrome elements directly with React, it can sometimes be a bit clunky to work with Web Components in React, and some things just don't feel idiomatic to the framework (for example: having to use `class=` instead of `className=`, see [React's official docs regarding web components](https://reactjs.org/docs/web-components.html) for more details). To help with this, we've published some React wrapper components for all of our core Elements. You can read up on using them [here](https://www.media-chrome.org/docs/en/react).
+While you technically can use Media Chrome elements directly with React, it can sometimes be a bit clunky to work with Web Components in React, and some things just don't feel idiomatic to the framework (for example: having to use `class=` instead of `className=`, see [React's official docs regarding web components](https://react.dev/reference/react-dom/components#custom-html-elements) for more details). To help with this, we've published some React wrapper components for all of our core Elements. You can read up on using them [here](https://www.media-chrome.org/docs/en/react).
 
 ## Why?
 


### PR DESCRIPTION
The current link to the React web-components docs is to the deprecated doc site.

OLD: https://reactjs.org/docs/web-components.html
NEW: https://react.dev/reference/react-dom/components#custom-html-elements