### PR TITLE
fix: Android toggle controls on tapping

### DIFF
--- a/src/js/media-container.js
+++ b/src/js/media-container.js
@@ -518,7 +518,7 @@ class MediaContainer extends globalThis.HTMLElement {
       // On mobile we toggle the controls on a tap which is handled in pointerup,
       // but Android fires pointermove events even when the user is just tapping.
       // Prevent calling setActive() on tap because it will mess with the toggle logic.
-      const MAX_TAP_DURATION = 200;
+      const MAX_TAP_DURATION = 250;
       // If the move duration exceeds 200ms then it's a drag and we should show the controls.
       if (event.timeStamp - this.#pointerDownTimeStamp < MAX_TAP_DURATION) return;
     }


### PR DESCRIPTION
this change fixes an issue where tapping the player on Android would show and hide the controls right away instead of scheduling the hiding after a timeout.

also fixes a small issue where the time range animation would not start right away when the time range became visible,
the animation is disabled when it gets hidden to save CPU.