### PR TITLE
Feat/default duration

### DIFF
--- a/docs/src/pages/docs/en/components/media-controller.md
+++ b/docs/src/pages/docs/en/components/media-controller.md
@@ -66,6 +66,21 @@ as `breakpointx` attributes on media-controller and as `breakpointx`
 
 When enabled, this will cause captions or subtitles to be turned on by default, if available.
 
+### defaultduration
+
+`defaultduration` (number, in seconds)
+
+When enabled, this will use the value of `defaultduration` as the `mediaduration` before the media has been loaded. This is useful when you want to avoid preloading the media (e.g. for cost or network usage reasons) but still want the UI to show what the (already known) duration will be.
+
+Example:
+
+```html
+<media-controller defaultduration="134"> <!-- aka 2:14 -->
+  <video slot="media" src="..." preload="none"></video> <!-- don't automatically load the media -->
+  <media-time-display showduration></media-time-display> <!-- This will show 0:00 / 2:14 before the media is loaded and the actual duration after -->
+</media-controller>
+```
+
 ### defaultstreamtype
 
 `defaultstreamtype` (values: `live`, `on-demand`)

--- a/docs/src/pages/docs/en/components/media-time-display.mdx
+++ b/docs/src/pages/docs/en/components/media-time-display.mdx
@@ -32,14 +32,17 @@ The `<media-time-display>` component is used to show the current or remaining ti
 
 Showing the duration can be configured with the `showduration` attribute.
 
+ Media Controller also sets the `defaultduration` to use before the media is loaded.
+
 <SandpackContainer
   editorHeight={265}
-  html={`<media-controller defaultsubtitles>
+  html={`<media-controller defaultduration="134">
   <video
     slot="media"
     src="https://stream.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/low.mp4"
     playsinline
     muted
+    preload="none"
   >
   </video>
   <media-control-bar>
@@ -55,7 +58,7 @@ Showing the remaining time by default can be configured with the `remaining` att
 
 <SandpackContainer
   editorHeight={265}
-  html={`<media-controller defaultsubtitles>
+  html={`<media-controller>
   <video
     slot="media"
     src="https://stream.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/low.mp4"

--- a/examples/vanilla/advanced.html
+++ b/examples/vanilla/advanced.html
@@ -31,13 +31,14 @@
   <body>
     <main>
       <h1>Media Chrome Advanced Video Usage Example</h1>
-      <media-controller defaultsubtitles>
+      <media-controller defaultsubtitles defaultduration="134">
         <video
           slot="media"
           src="https://stream.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/high.mp4"
           muted
           crossorigin
           playsinline
+          preload="none"
         >
           <track
             label="thumbnails"

--- a/src/js/controller.js
+++ b/src/js/controller.js
@@ -150,18 +150,24 @@ export const MediaUIStates = {
   MEDIA_DURATION: {
     get: function (controller) {
       const { media } = controller;
-      const defaultDuration = controller.hasAttribute('defaultduration')
-        ? +controller.getAttribute('defaultduration')
-        : NaN;
 
-      // TODO: What if duration is infinity/live? (heff)
-      if (!media || !Number.isFinite(media.duration)) {
-        return defaultDuration;
+      // If `defaultduration` is set and we don't yet have a usable `duration`
+      // available, use the default duration.
+      if (
+        controller.hasAttribute('defaultduration') &&
+        (!media ||
+          !media.duration ||
+          Number.isNaN(media.duration) ||
+          !Number.isFinite(media.duration))
+      ) {
+        return +controller.getAttribute('defaultduration');
       }
 
-      // Apply defaultDuration if it's set and the media is not yet ready
-      if (!(media.readyState || Number.isNaN(defaultDuration))) {
-        return defaultDuration;
+      // If `defaultduration` is unset, we still want to propagate `NaN`
+      // for some cases to ensure appropriate media state receiver updates.
+      // TODO: What if duration is infinity/live? (heff)
+      if (!media || !Number.isFinite(media.duration)) {
+        return Number.NaN;
       }
 
       return media.duration;

--- a/src/js/controller.js
+++ b/src/js/controller.js
@@ -150,10 +150,18 @@ export const MediaUIStates = {
   MEDIA_DURATION: {
     get: function (controller) {
       const { media } = controller;
+      const defaultDuration = controller.hasAttribute('defaultduration')
+        ? +controller.getAttribute('defaultduration')
+        : NaN;
 
       // TODO: What if duration is infinity/live? (heff)
       if (!media || !Number.isFinite(media.duration)) {
-        return NaN;
+        return defaultDuration;
+      }
+
+      // Apply defaultDuration if it's set and the media is not yet ready
+      if (!(media.readyState || Number.isNaN(defaultDuration))) {
+        return defaultDuration;
       }
 
       return media.duration;

--- a/src/js/controller.js
+++ b/src/js/controller.js
@@ -165,7 +165,6 @@ export const MediaUIStates = {
 
       // If `defaultduration` is unset, we still want to propagate `NaN`
       // for some cases to ensure appropriate media state receiver updates.
-      // TODO: What if duration is infinity/live? (heff)
       if (!media || !Number.isFinite(media.duration)) {
         return Number.NaN;
       }

--- a/src/js/media-controller.js
+++ b/src/js/media-controller.js
@@ -29,6 +29,7 @@ const DEFAULT_TIME = 0;
 export const Attributes = {
   DEFAULT_SUBTITLES: 'defaultsubtitles',
   DEFAULT_STREAM_TYPE: 'defaultstreamtype',
+  DEFAULT_DURATION: 'defaultduration',
   FULLSCREEN_ELEMENT: 'fullscreenelement',
   HOTKEYS: 'hotkeys',
   KEYS_USED: 'keysused',
@@ -43,6 +44,7 @@ export const Attributes = {
  *
  * @attr {boolean} defaultsubtitles
  * @attr {string} defaultstreamtype
+ * @attr {string} defaultduration
  * @attr {string} fullscreenelement
  * @attr {boolean} nohotkeys
  * @attr {string} hotkeys
@@ -56,7 +58,8 @@ class MediaController extends MediaContainer {
       Attributes.NO_HOTKEYS,
       Attributes.HOTKEYS,
       Attributes.DEFAULT_STREAM_TYPE,
-      Attributes.DEFAULT_SUBTITLES
+      Attributes.DEFAULT_SUBTITLES,
+      Attributes.DEFAULT_DURATION,
     );
   }
 


### PR DESCRIPTION
Adds support for `defaultduration` to apply before media is loaded.

**NOTE:** The `<media-time-range>` can still be interacted with before the media has loaded, but that was already true.