### PR TITLE
docs: update Next.js demo link in documentation.

### DIFF
--- a/docs/src/pages/docs/en/react.md
+++ b/docs/src/pages/docs/en/react.md
@@ -68,4 +68,4 @@ export const MyComponent = () => {
 };
 ```
 
-For a full demo, check out our [NextJS Demo App](https://github.com/muxinc/media-chrome/tree/main/demos/nextjs-with-typescript)
+For a full demo, check out our [NextJS Demo App](https://github.com/muxinc/media-chrome/tree/main/examples/nextjs-with-typescript)


### PR DESCRIPTION
The Next.js example link was not functional.