### PR TITLE
fix: default subs async complexities

### DIFF
--- a/examples/vanilla/media-elements/mux-video.html
+++ b/examples/vanilla/media-elements/mux-video.html
@@ -8,9 +8,14 @@
       src="https://cdn.jsdelivr.net/npm/@mux/mux-video/+esm"
     ></script>
     <script type="module" src="../../../dist/index.js"></script>
+    <script type="module" src="../../../../dist/experimental/menu/index.js"></script>
     <style>
       .examples {
         margin-top: 20px;
+      }
+
+      mux-video {
+        width: 50vw;
       }
     </style>
   </head>
@@ -22,11 +27,9 @@
           slot="media"
           preload="auto"
           playback-id="ihZa7qP1zY8oyLSQW9TS602VgwQvNdyIvlk9LInEGU2s"
-          metadata-video-id="video-id-12345"
-          metadata-video-title="Mad Max: Fury Road Trailer"
-          metadata-viewer-user-id="user-id-6789"
-          stream-type="on-demand"
           muted
+          crossorigin
+          autoplay
         >
           <track
             label="thumbnails"
@@ -35,6 +38,15 @@
             src="https://image.mux.com/ihZa7qP1zY8oyLSQW9TS602VgwQvNdyIvlk9LInEGU2s/storyboard.vtt"
           />
         </mux-video>
+        <media-audio-track-menu hidden>
+          <div slot="header">Audio</div>
+        </media-audio-track-menu>
+        <media-playback-rate-menu hidden>
+          <div slot="header">Playback Rate</div>
+        </media-playback-rate-menu>
+        <media-captions-menu hidden>
+          <div slot="header">Subtitles</div>
+        </media-captions-menu>
         <media-control-bar>
           <media-play-button></media-play-button>
           <media-seek-backward-button></media-seek-backward-button>
@@ -42,9 +54,10 @@
           <media-mute-button></media-mute-button>
           <media-volume-range></media-volume-range>
           <media-time-range></media-time-range>
-          <media-time-display showduration remaining></media-time-display>
-          <media-captions-button></media-captions-button>
-          <media-playback-rate-button></media-playback-rate-button>
+          <media-time-display showduration></media-time-display>
+          <media-audio-track-menu-button></media-audio-track-menu-button>
+          <media-captions-menu-button></media-captions-menu-button>
+          <media-playback-rate-menu-button></media-playback-rate-menu-button>
           <media-pip-button></media-pip-button>
           <media-fullscreen-button></media-fullscreen-button>
         </media-control-bar>

--- a/examples/vanilla/media-elements/mux-video.html
+++ b/examples/vanilla/media-elements/mux-video.html
@@ -38,9 +38,12 @@
             src="https://image.mux.com/ihZa7qP1zY8oyLSQW9TS602VgwQvNdyIvlk9LInEGU2s/storyboard.vtt"
           />
         </mux-video>
-        <media-audio-track-menu hidden>
+        <!-- <media-audio-track-menu hidden>
           <div slot="header">Audio</div>
-        </media-audio-track-menu>
+        </media-audio-track-menu> -->
+        <media-rendition-menu hidden>
+          <div slot="header">Quality</div>
+        </media-rendition-menu>
         <media-playback-rate-menu hidden>
           <div slot="header">Playback Rate</div>
         </media-playback-rate-menu>
@@ -55,7 +58,8 @@
           <media-volume-range></media-volume-range>
           <media-time-range></media-time-range>
           <media-time-display showduration></media-time-display>
-          <media-audio-track-menu-button></media-audio-track-menu-button>
+          <!-- <media-audio-track-menu-button></media-audio-track-menu-button> -->
+          <media-rendition-menu-button></media-rendition-menu-button>
           <media-captions-menu-button></media-captions-menu-button>
           <media-playback-rate-menu-button></media-playback-rate-menu-button>
           <media-pip-button></media-pip-button>

--- a/src/js/controller.js
+++ b/src/js/controller.js
@@ -508,7 +508,8 @@ export const MediaUIStates = {
       // will also respect `defaultsubtitles` (CJP)
       if (
         controller.hasAttribute('defaultsubtitles') &&
-        ['addtrack', 'removetrack'].includes(event?.type)
+        ['addtrack', 'removetrack'].includes(event?.type) &&
+        [TextTrackKinds.CAPTIONS, TextTrackKinds.SUBTITLES].includes(event?.track?.kind)
       ) {
         MediaUIRequestHandlers.MEDIA_TOGGLE_SUBTITLES_REQUEST(undefined, { detail: true }, controller);
       }

--- a/src/js/controller.js
+++ b/src/js/controller.js
@@ -510,7 +510,7 @@ export const MediaUIStates = {
         controller.hasAttribute('defaultsubtitles') &&
         ['addtrack', 'removetrack'].includes(event?.type)
       ) {
-        MediaUIRequestHandlers.MEDIA_TOGGLE_SUBTITLES_REQUEST(controller.media, { detail: true }, controller);
+        MediaUIRequestHandlers.MEDIA_TOGGLE_SUBTITLES_REQUEST(undefined, { detail: true }, controller);
       }
       return getShowingSubtitleTracks(controller).map(({ kind, label, language }) => ({ kind, label, language }));
     },
@@ -832,7 +832,7 @@ export const MediaUIRequestHandlers = {
     const { detail: tracksToUpdate = [] } = event;
     updateTracksModeTo(TextTrackModes.DISABLED, tracks, tracksToUpdate);
   },
-  MEDIA_TOGGLE_SUBTITLES_REQUEST: (media, event, controller) => {
+  MEDIA_TOGGLE_SUBTITLES_REQUEST: (_media, event, controller) => {
     // NOTE: Like Element::toggleAttribute(), this event uses the detail for an optional "force"
     // value. When present, this means "toggle to" "on" (aka showing, even if something's already showing)
     // or "off" (aka disabled, even if all tracks are currently disabled).
@@ -874,7 +874,7 @@ export const MediaUIRequestHandlers = {
       updateTracksModeTo(TextTrackModes.DISABLED, tracks, showingSubitleTracks);
       updateTracksModeTo(
         TextTrackModes.SHOWING,
-        media.textTracks,
+        tracks,
         [{ language, label, kind }]
       );
     }


### PR DESCRIPTION
While `defaultsubtitles` and user preference subtitles worked for simple cases, there were various async considerations that were causing issues, including e.g. `autoplay`. This PR updates the logic to be potentially less efficient but more reflective of dev + user preferences and avoids some odd state mismatch possibilities that could result from the prior implementation.


**Example**: Consider cases where the developer has enabled `defaultsubtitles`. Let's say my navigator languages includes English, and my local storage preferred language is Japanese. If the first track asynchronously added is Swedish, none of my subtitle language prefs will match, so I'll pick the Swedish track to show. Then, an English track is added asynchronously. I'll end up here again, and, although the "most preferred" language is Japanese, I'll update the showing subtitle track to the English one, since it's more reflective of the user's preferences/environment than Swedish. Finally, a Japanese track is added, so I'll end up selecting that one.

**NOTE**: This code _**could**_ be further optimized to still bail if the current selected showing track is the same as the one that will be selected, but I'd rather hold off unless/until that becomes a real concern (unless folks feel strongly).

To smoke test, use https://media-chrome-9gxm13m21-mux.vercel.app/examples/vanilla/media-elements/mux-video.html