### PR TITLE
fix: add way to hide menuitems w/ unfilled submenu

### DIFF
--- a/examples/vanilla/advanced.html
+++ b/examples/vanilla/advanced.html
@@ -34,6 +34,14 @@
         display: none;
       }
 
+      media-settings-menu-item[aria-haspopup]:is(
+        :not([submenusize]),
+        [submenusize="0"],
+        [submenusize="1"]
+      ) {
+        display: none;
+      }
+
       .examples {
         margin-top: 20px;
       }

--- a/examples/vanilla/control-elements/media-settings-menu.html
+++ b/examples/vanilla/control-elements/media-settings-menu.html
@@ -21,6 +21,15 @@
 
       mux-video {
         width: 100%;      /* prevents video to expand beyond its container */
+        height: fit-content;  /* Fix Safari aspect-ratio overflow glitch for custom media elements */
+      }
+
+      media-settings-menu-item[aria-haspopup]:is(
+        :not([submenusize]),
+        [submenusize="0"],
+        [submenusize="1"]
+      ) {
+        display: none;
       }
 
       .examples {
@@ -39,7 +48,7 @@
         src="https://stream.mux.com/Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008.m3u8"
         poster="https://image.mux.com/Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008/thumbnail.webp?time=13"
         stream-type="on-demand"
-        preload="metadata"
+        preload="none"
         playsinline
         crossorigin
       ></mux-video>

--- a/src/js/experimental/menu/media-chrome-menu-item.js
+++ b/src/js/experimental/menu/media-chrome-menu-item.js
@@ -42,6 +42,10 @@ template.innerHTML = /*html*/`
       background: var(--media-menu-item-checked-background);
     }
 
+    :host([hidden]) {
+      display: none;
+    }
+
     :host([disabled]) {
       pointer-events: none;
       color: rgba(255, 255, 255, .3);
@@ -364,10 +368,14 @@ class MediaChromeMenuItem extends globalThis.HTMLElement {
    * is populated with the text of the first checked item.
    */
   #handleMenuItem = () => {
+    this.setAttribute('submenusize', `${this.submenuElement.items.length}`);
+
     const descriptionSlot = this.shadowRoot.querySelector('slot[name="description"]');
     const description = this.submenuElement.checkedItems?.[0]?.text;
+
     const span = document.createElement('span');
     span.textContent = description ?? '';
+
     descriptionSlot.replaceChildren(span);
   }
 


### PR DESCRIPTION
adds a way to hide a menu item based on the size of the submenu items

```css
      media-settings-menu-item[aria-haspopup]:is(
        :not([submenusize]),
        [submenusize="0"],
        [submenusize="1"]
      ) {
        display: none;
      }
```