### PR TITLE
fix: missing sheet typeerror

### DIFF
--- a/src/js/utils/element-utils.js
+++ b/src/js/utils/element-utils.js
@@ -200,6 +200,18 @@ export function insertCSSRule(styleParent, selectorText) {
   const styles = styleParent.querySelectorAll('style') ?? [];
   const style = styles?.[styles.length - 1];
 
+  // If there is no style sheet return an empty style rule.
+  if (!style?.sheet) {
+    return {
+      // @ts-ignore
+      style: {
+        setProperty: () => {},
+        removeProperty: () => '',
+        getPropertyValue: () => '',
+      },
+    };
+  }
+
   style?.sheet.insertRule(`${selectorText}{}`, style.sheet.cssRules.length);
   return /** @type {CSSStyleRule} */(style.sheet.cssRules?.[style.sheet.cssRules.length - 1]);
 }


### PR DESCRIPTION
fixes a type error 

```
media-chrome.js?v=705b1957:419 Uncaught TypeError: Cannot read properties of null (reading 'insertRule')
    at insertCSSRule (media-chrome.js?v=705b1957:419:40)
    at getOrInsertCSSRule (media-chrome.js?v=705b1957:397:10)
    at new MediaChromeRange (media-chrome.js?v=705b1957:3418:23)
    at new MediaTimeRange (media-chrome.js?v=705b1957:5473:5)
    at element (chunk-XL73LIG3.js?v=705b1957:444:19)
    at Object.create [as c] (**.svelte:863:99)
    at Object.update [as p] (**.svelte:870:42)
    at update (chunk-XL73LIG3.js?v=705b1957:1333:32)
    at flush (chunk-XL73LIG3.js?v=705b1957:1299:9)
```