### PR TITLE
fix: access sheet before connected to DOM

### DIFF
--- a/src/js/experimental/media-chrome-selectmenu.js
+++ b/src/js/experimental/media-chrome-selectmenu.js
@@ -92,9 +92,6 @@ class MediaChromeSelectMenu extends globalThis.HTMLElement {
       this.shadowRoot.appendChild(template.content.cloneNode(true));
     }
 
-    const { style } = getOrInsertCSSRule(this.shadowRoot, ':host');
-    style.setProperty('display', `var(--media-control-display, var(--${this.localName}-display, inline-flex))`);
-
     this.init?.();
 
     this.#button = this.shadowRoot.querySelector('[part=button]');
@@ -284,6 +281,9 @@ class MediaChromeSelectMenu extends globalThis.HTMLElement {
   }
 
   connectedCallback() {
+    const { style } = getOrInsertCSSRule(this.shadowRoot, ':host');
+    style.setProperty('display', `var(--media-control-display, var(--${this.localName}-display, inline-flex))`);
+
     const mediaControllerId = this.getAttribute(MediaStateReceiverAttributes.MEDIA_CONTROLLER);
     if (mediaControllerId) {
       // @ts-ignore

--- a/src/js/media-chrome-range.js
+++ b/src/js/media-chrome-range.js
@@ -321,13 +321,6 @@ class MediaChromeRange extends globalThis.HTMLElement {
       this.shadowRoot.appendChild(template.content.cloneNode(true));
     }
 
-    const { style } = getOrInsertCSSRule(this.shadowRoot, ':host');
-    style.setProperty('display', `var(--media-control-display, var(--${this.localName}-display, inline-flex))`);
-
-    this.#cssRules.pointer = getOrInsertCSSRule(this.shadowRoot, '#pointer');
-    this.#cssRules.progress = getOrInsertCSSRule(this.shadowRoot, '#progress');
-    this.#cssRules.thumb = getOrInsertCSSRule(this.shadowRoot, '#thumb');
-
     this.container = this.shadowRoot.querySelector('#container');
     this.#startpoint = this.shadowRoot.querySelector('#startpoint');
     this.#endpoint = this.shadowRoot.querySelector('#endpoint');
@@ -377,6 +370,13 @@ class MediaChromeRange extends globalThis.HTMLElement {
   }
 
   connectedCallback() {
+    const { style } = getOrInsertCSSRule(this.shadowRoot, ':host');
+    style.setProperty('display', `var(--media-control-display, var(--${this.localName}-display, inline-flex))`);
+
+    this.#cssRules.pointer = getOrInsertCSSRule(this.shadowRoot, '#pointer');
+    this.#cssRules.progress = getOrInsertCSSRule(this.shadowRoot, '#progress');
+    this.#cssRules.thumb = getOrInsertCSSRule(this.shadowRoot, '#thumb');
+
     const mediaControllerId = this.getAttribute(
       MediaStateReceiverAttributes.MEDIA_CONTROLLER
     );

--- a/src/js/media-loading-indicator.js
+++ b/src/js/media-loading-indicator.js
@@ -102,7 +102,6 @@ svg, img, ::slotted(svg), ::slotted(img) {
 class MediaLoadingIndicator extends globalThis.HTMLElement {
   #mediaController;
   #delay = DEFAULT_LOADING_DELAY;
-  #style;
 
   static get observedAttributes() {
     return [
@@ -122,9 +121,6 @@ class MediaLoadingIndicator extends globalThis.HTMLElement {
       const indicatorHTML = template.content.cloneNode(true);
       shadow.appendChild(indicatorHTML);
     }
-
-    const { style } = getOrInsertCSSRule(this.shadowRoot, ':host');
-    this.#style = style;
   }
 
   attributeChangedCallback(attrName, oldValue, newValue) {
@@ -170,7 +166,8 @@ class MediaLoadingIndicator extends globalThis.HTMLElement {
   set loadingDelay(delay) {
     this.#delay = delay;
 
-    this.#style.setProperty(
+    const { style } = getOrInsertCSSRule(this.shadowRoot, ':host');
+    style.setProperty(
       '--_loading-indicator-delay',
       `var(--media-loading-indicator-transition-delay, ${delay}ms)`
     );

--- a/src/js/media-text-display.js
+++ b/src/js/media-text-display.js
@@ -80,9 +80,6 @@ class MediaTextDisplay extends globalThis.HTMLElement {
       this.attachShadow({ mode: 'open' });
       this.shadowRoot.appendChild(template.content.cloneNode(true));
     }
-
-    const { style } = getOrInsertCSSRule(this.shadowRoot, ':host');
-    style.setProperty('display', `var(--media-control-display, var(--${this.localName}-display, inline-flex))`);
   }
 
   attributeChangedCallback(attrName, oldValue, newValue) {
@@ -100,6 +97,9 @@ class MediaTextDisplay extends globalThis.HTMLElement {
   }
 
   connectedCallback() {
+    const { style } = getOrInsertCSSRule(this.shadowRoot, ':host');
+    style.setProperty('display', `var(--media-control-display, var(--${this.localName}-display, inline-flex))`);
+
     const mediaControllerId = this.getAttribute(
       MediaStateReceiverAttributes.MEDIA_CONTROLLER
     );

--- a/src/js/media-time-display.js
+++ b/src/js/media-time-display.js
@@ -96,7 +96,9 @@ class MediaTimeDisplay extends MediaTextDisplay {
 
     this.#slot = this.shadowRoot.querySelector('slot');
     this.#slot.innerHTML = `${formatTimesLabel(this)}`;
+  }
 
+  connectedCallback() {
     const { style } = getOrInsertCSSRule(
       this.shadowRoot,
       ':host(:hover:not([notoggle]))'
@@ -106,9 +108,7 @@ class MediaTimeDisplay extends MediaTextDisplay {
       'background',
       'var(--media-control-hover-background, rgba(50 50 70 / .7))'
     );
-  }
 
-  connectedCallback() {
     if (!this.hasAttribute('disabled')) {
       this.enable();
     }

--- a/src/js/utils/element-utils.js
+++ b/src/js/utils/element-utils.js
@@ -202,6 +202,10 @@ export function insertCSSRule(styleParent, selectorText) {
 
   // If there is no style sheet return an empty style rule.
   if (!style?.sheet) {
+    // The style tag must be connected to the DOM before it has a sheet.
+    // This could indicate a bug. Should the code be moved to connectedCallback?
+    console.warn('Media Chrome: No style sheet found on style tag of', styleParent);
+
     return {
       // @ts-ignore
       style: {


### PR DESCRIPTION
same than the previous bug fix. 

good it uncovered some more issues that are related to trying to access a style sheet before connected to the DOM which seems not possible.

we still keep the dummy CSSStyleRule in the return to not have type errors but I added a warning and a comment to indicate there might be an issue in the code. 