### PR TITLE
fix: cc icon vertical alignment

### DIFF
--- a/src/js/experimental/menu/media-chrome-menu-item.js
+++ b/src/js/experimental/menu/media-chrome-menu-item.js
@@ -57,6 +57,7 @@ template.innerHTML = /*html*/`
 
     slot:not([name="submenu"]) {
       display: inline-flex;
+      align-items: center;
       transition: inherit;
       opacity: var(--media-menu-item-opacity, 1);
     }


### PR DESCRIPTION
the suffix cc icon in the menu item was too high, not aligned vertically

![SCR-20240216-hknu](https://github.com/muxinc/media-chrome/assets/360826/b668ed8e-6680-4a5c-971c-9904f6cc20f4)

