### PR TITLE
feat: shifting time box elements with arrow

### DIFF
--- a/docs/src/pages/docs/en/components/media-time-range.mdx
+++ b/docs/src/pages/docs/en/components/media-time-range.mdx
@@ -112,7 +112,7 @@ the timeline as the video progresses.
 
 ## Remove preview elements
 
-Set the `preview` slot to an empty element to remove the default preview elements.
+Set the `preview` and `preview-arrow` slot to an empty element to remove the default preview elements.
 
 <SandpackContainer
   editorHeight={270}
@@ -125,6 +125,7 @@ Set the `preview` slot to an empty element to remove the default preview element
   <media-control-bar>
     <media-time-range>
       <span slot="preview"></span>
+      <span slot="preview-arrow"></span>
     </media-time-range>
   </media-control-bar>
 </media-controller>`}

--- a/docs/src/pages/docs/en/components/media-time-range.mdx
+++ b/docs/src/pages/docs/en/components/media-time-range.mdx
@@ -87,7 +87,7 @@ with a valid VTT file as `src` will add hoverable chapters segments to the time 
 />
 
 
-## Custom current slot
+## Custom current slot with arrow
 
 Add a time display component in the current slot that will slide along 
 the timeline as the video progresses.
@@ -103,6 +103,7 @@ the timeline as the video progresses.
   <media-control-bar>
     <media-time-range>
       <media-time-display slot="current"></media-time-display>
+      <div part="arrow" slot="current"></div>
     </media-time-range>
   </media-control-bar>
 </media-controller>`}
@@ -112,7 +113,7 @@ the timeline as the video progresses.
 
 ## Remove preview elements
 
-Set the `preview` and `preview-arrow` slot to an empty element to remove the default preview elements.
+Set the `preview` slot to an empty element to remove the default preview elements.
 
 <SandpackContainer
   editorHeight={270}
@@ -125,7 +126,6 @@ Set the `preview` and `preview-arrow` slot to an empty element to remove the def
   <media-control-bar>
     <media-time-range>
       <span slot="preview"></span>
-      <span slot="preview-arrow"></span>
     </media-time-range>
   </media-control-bar>
 </media-controller>`}

--- a/examples/vanilla/themes/spotify-theme.html
+++ b/examples/vanilla/themes/spotify-theme.html
@@ -25,8 +25,8 @@
         --media-range-track-height: 4px;
         --media-range-track-background: rgba(255, 255, 255, 0.3);
         --media-range-thumb-box-shadow: rgba(0, 0, 0, 0.5) 0px 2px 4px 0px;
-        --media-preview-time-background: rgba(20,20,30, 1);
-        --media-preview-time-margin: 0 0 -9px;
+        --media-preview-background: rgba(20,20,30, 1);
+        --media-box-margin: 0 0 -9px;
       }
 
       .media-theme-spotify .custom-chrome {

--- a/src/js/experimental/menu/media-settings-menu-item.js
+++ b/src/js/experimental/menu/media-settings-menu-item.js
@@ -1,4 +1,4 @@
-import { globalThis } from '../../utils/server-safe-globals.js';
+import { globalThis, document } from '../../utils/server-safe-globals.js';
 import { MediaChromeMenuItem } from './media-chrome-menu-item.js';
 
 const template = document.createElement('template');

--- a/src/js/experimental/menu/media-settings-menu.js
+++ b/src/js/experimental/menu/media-settings-menu.js
@@ -1,4 +1,4 @@
-import { globalThis } from '../../utils/server-safe-globals.js';
+import { globalThis, document } from '../../utils/server-safe-globals.js';
 import { MediaChromeMenu } from './media-chrome-menu.js';
 import { getMediaController } from '../../utils/element-utils.js';
 

--- a/src/js/media-time-range.js
+++ b/src/js/media-time-range.js
@@ -64,8 +64,6 @@ template.innerHTML = /*html*/`
     }
 
     [part~="box"] {
-      display: var(--media-box-display, flex);
-      margin: var(--media-box-margin, 0 0 5px);
       width: min-content;
       ${/* absolute position is needed here so the box doesn't overflow the bounds */''}
       position: absolute;
@@ -76,12 +74,14 @@ template.innerHTML = /*html*/`
     }
 
     [part~="current-box"] {
-      display: var(--media-current-box-display, flex);
+      display: var(--media-current-box-display, var(--media-box-display, flex));
+      margin: var(--media-current-box-margin, var(--media-box-margin, 0 0 5px));
       visibility: hidden;
     }
 
     [part~="preview-box"] {
-      display: var(--media-preview-box-display, flex);
+      display: var(--media-preview-box-display, var(--media-box-display, flex));
+      margin: var(--media-preview-box-margin, var(--media-box-margin, 0 0 5px));
       transition-property: var(--media-preview-transition-property, visibility, opacity);
       transition-duration: var(--media-preview-transition-duration-out, .25s);
       transition-delay: var(--media-preview-transition-delay-out, 0s);
@@ -153,7 +153,7 @@ template.innerHTML = /*html*/`
       border-radius: var(--media-preview-chapter-border-radius,
         var(--media-preview-border-radius) var(--media-preview-border-radius)
         var(--media-preview-border-radius) var(--media-preview-border-radius));
-      padding: var(--media-preview-chapter-padding, 4px 9px);
+      padding: var(--media-preview-chapter-padding, 3.5px 9px);
       margin: var(--media-preview-chapter-margin, 0 0 5px);
       text-shadow: var(--media-preview-chapter-text-shadow, 0 0 4px rgb(0 0 0 / .75));
     }
@@ -162,7 +162,7 @@ template.innerHTML = /*html*/`
     :host([${MediaUIAttributes.MEDIA_PREVIEW_IMAGE}]) ::slotted(media-preview-chapter-display) {
       transition-delay: var(--media-preview-transition-delay-in, .25s);
       border-radius: var(--media-preview-chapter-border-radius, 0);
-      padding: var(--media-preview-chapter-padding, 4px 9px 0);
+      padding: var(--media-preview-chapter-padding, 3.5px 9px 0);
       margin: var(--media-preview-chapter-margin, 0);
       min-width: 100%;
     }
@@ -186,7 +186,7 @@ template.innerHTML = /*html*/`
       border-radius: var(--media-preview-time-border-radius,
         var(--media-preview-border-radius) var(--media-preview-border-radius)
         var(--media-preview-border-radius) var(--media-preview-border-radius));
-      padding: var(--media-preview-time-padding, 4px 9px);
+      padding: var(--media-preview-time-padding, 3.5px 9px);
       margin: var(--media-preview-time-margin, 0);
       text-shadow: var(--media-preview-time-text-shadow, 0 0 4px rgb(0 0 0 / .75));
       transform: translateX(min(
@@ -232,7 +232,7 @@ template.innerHTML = /*html*/`
       <media-preview-thumbnail></media-preview-thumbnail>
       <media-preview-chapter-display></media-preview-chapter-display>
       <media-preview-time-display></media-preview-time-display>
-      <slot name="preview-arrow" part="arrow"></slot>
+      <slot name="preview-arrow"><div part="arrow"></div></slot>
     </slot>
   </div>
   <div id="current-rail">
@@ -308,6 +308,13 @@ const calcTimeFromRangeValue = (el, value = el.range.valueAsNumber) => {
  * @cssproperty --media-box-margin - `margin` of range box.
  * @cssproperty --media-box-padding-left - `padding-left` of range box.
  * @cssproperty --media-box-padding-right - `padding-right` of range box.
+ * @cssproperty --media-box-border-radius - `border-radius` of range box.
+ *
+ * @cssproperty --media-preview-box-display - `display` of range preview box.
+ * @cssproperty --media-preview-box-margin - `margin` of range preview box.
+ *
+ * @cssproperty --media-current-box-display - `display` of range current box.
+ * @cssproperty --media-current-box-margin - `margin` of range current box.
  *
  * @cssproperty --media-box-arrow-display - `display` of range box arrow.
  * @cssproperty --media-box-arrow-background - `border-top-color` of range box arrow.

--- a/src/js/media-time-range.js
+++ b/src/js/media-time-range.js
@@ -36,13 +36,17 @@ const template = document.createElement('template');
 template.innerHTML = /*html*/`
   <style>
     :host {
-      --media-box-border-radius: 3px;
+      --media-box-border-radius: 4px;
       --media-box-padding-left: 10px;
       --media-box-padding-right: 10px;
       --media-preview-border-radius: var(--media-box-border-radius);
       --media-box-arrow-offset: var(--media-box-border-radius);
       --_control-background: var(--media-control-background, var(--media-secondary-color, rgb(20 20 30 / .7)));
       --_preview-background: var(--media-preview-background, var(--_control-background));
+
+      ${/* 1% rail width trick was off in Safari, contain: layout seems to
+        prevent the horizontal overflow as well. */ ''}
+      contain: layout;
     }
 
     #highlight {
@@ -51,8 +55,7 @@ template.innerHTML = /*html*/`
 
     #preview-rail,
     #current-rail {
-      ${/* 1% of parent element and upscale by 100 in the translateX() */ ''}
-      width: 1%;
+      width: 100%;
       position: absolute;
       left: 0;
       bottom: 100%;
@@ -63,10 +66,10 @@ template.innerHTML = /*html*/`
     [part~="box"] {
       display: var(--media-box-display, flex);
       margin: var(--media-box-margin, 0 0 5px);
+      width: min-content;
       ${/* absolute position is needed here so the box doesn't overflow the bounds */''}
       position: absolute;
       bottom: 100%;
-      display: flex;
       flex-direction: column;
       align-items: center;
       transform: translateX(-50%);
@@ -139,8 +142,9 @@ template.innerHTML = /*html*/`
 
     media-preview-chapter-display,
     ::slotted(media-preview-chapter-display) {
+      font-size: var(--media-font-size, 13px);
+      line-height: 17px;
       display: none;
-      line-height: 1.3;
       min-width: 0;
       ${/* delay changing these CSS props until the preview box transition is ended */''}
       transition: min-width 0s, border-radius 0s, margin 0s, padding 0s;
@@ -149,7 +153,7 @@ template.innerHTML = /*html*/`
       border-radius: var(--media-preview-chapter-border-radius,
         var(--media-preview-border-radius) var(--media-preview-border-radius)
         var(--media-preview-border-radius) var(--media-preview-border-radius));
-      padding: var(--media-preview-chapter-padding, 4px 10px);
+      padding: var(--media-preview-chapter-padding, 4px 9px);
       margin: var(--media-preview-chapter-margin, 0 0 5px);
       text-shadow: var(--media-preview-chapter-text-shadow, 0 0 4px rgb(0 0 0 / .75));
     }
@@ -158,7 +162,7 @@ template.innerHTML = /*html*/`
     :host([${MediaUIAttributes.MEDIA_PREVIEW_IMAGE}]) ::slotted(media-preview-chapter-display) {
       transition-delay: var(--media-preview-transition-delay-in, .25s);
       border-radius: var(--media-preview-chapter-border-radius, 0);
-      padding: var(--media-preview-chapter-padding, 4px 10px 0);
+      padding: var(--media-preview-chapter-padding, 4px 9px 0);
       margin: var(--media-preview-chapter-margin, 0);
       min-width: 100%;
     }
@@ -172,7 +176,8 @@ template.innerHTML = /*html*/`
     ::slotted(media-preview-time-display),
     media-time-display,
     ::slotted(media-time-display) {
-      line-height: 1.3;
+      font-size: var(--media-font-size, 13px);
+      line-height: 17px;
       min-width: 0;
       ${/* delay changing these CSS props until the preview box transition is ended */''}
       transition: min-width 0s, border-radius 0s;
@@ -181,7 +186,7 @@ template.innerHTML = /*html*/`
       border-radius: var(--media-preview-time-border-radius,
         var(--media-preview-border-radius) var(--media-preview-border-radius)
         var(--media-preview-border-radius) var(--media-preview-border-radius));
-      padding: var(--media-preview-time-padding, 4px 10px);
+      padding: var(--media-preview-time-padding, 4px 9px);
       margin: var(--media-preview-time-margin, 0);
       text-shadow: var(--media-preview-time-text-shadow, 0 0 4px rgb(0 0 0 / .75));
       transform: translateX(min(
@@ -206,7 +211,7 @@ template.innerHTML = /*html*/`
 
     [part~="arrow"],
     ::slotted([part~="arrow"]) {
-      display: var(--media-box-arrow-display, flex);
+      display: var(--media-box-arrow-display, inline-block);
       transform: translateX(min(
         max(calc(50% - var(--_box-width) / 2 + var(--media-box-arrow-offset)),
         calc(var(--_box-shift, 0))),
@@ -674,20 +679,20 @@ class MediaTimeRange extends MediaChromeRange {
    * @return {string}
    */
   #getBoxPosition(rects, ratio) {
-    let position = `${ratio * 100 * 100}%`;
+    let position = `${ratio * 100}%`;
     const { width, min, max } = rects.box;
 
     if (!width) return position;
 
     if (!Number.isNaN(min)) {
       const pad = `var(--media-box-padding-left)`;
-      const minPos = `calc(1 / var(--_range-width) * 100 * 100 * ${min}% + ${pad})`;
+      const minPos = `calc(1 / var(--_range-width) * 100 * ${min}% + ${pad})`;
       position = `max(${minPos}, ${position})`;
     }
 
     if (!Number.isNaN(max)) {
       const pad = `var(--media-box-padding-right)`;
-      const maxPos = `calc(1 / var(--_range-width) * 100 * 100 * ${max}% - ${pad})`;
+      const maxPos = `calc(1 / var(--_range-width) * 100 * ${max}% - ${pad})`;
       position = `min(${position}, ${maxPos})`;
     }
 

--- a/src/js/media-time-range.js
+++ b/src/js/media-time-range.js
@@ -41,6 +41,8 @@ template.innerHTML = /*html*/`
       --media-box-padding-right: 10px;
       --media-preview-border-radius: var(--media-box-border-radius);
       --media-box-arrow-offset: var(--media-box-border-radius);
+      --_control-background: var(--media-control-background, var(--media-secondary-color, rgb(20 20 30 / .7)));
+      --_preview-background: var(--media-preview-background, var(--_control-background));
     }
 
     #highlight {
@@ -59,6 +61,8 @@ template.innerHTML = /*html*/`
     }
 
     [part~="box"] {
+      display: var(--media-box-display, flex);
+      margin: var(--media-box-margin, 0 0 5px);
       ${/* absolute position is needed here so the box doesn't overflow the bounds */''}
       position: absolute;
       bottom: 100%;
@@ -69,10 +73,12 @@ template.innerHTML = /*html*/`
     }
 
     [part~="current-box"] {
+      display: var(--media-current-box-display, flex);
       visibility: hidden;
     }
 
     [part~="preview-box"] {
+      display: var(--media-preview-box-display, flex);
       transition-property: var(--media-preview-transition-property, visibility, opacity);
       transition-duration: var(--media-preview-transition-duration-out, .25s);
       transition-delay: var(--media-preview-transition-delay-out, 0s);
@@ -102,7 +108,7 @@ template.innerHTML = /*html*/`
       ${/* delay changing these CSS props until the preview box transition is ended */''}
       transition: visibility 0s .25s;
       transition-delay: calc(var(--media-preview-transition-delay-out, 0s) + var(--media-preview-transition-duration-out, .25s));
-      background: var(--media-preview-thumbnail-background, var(--media-preview-background, var(--media-control-background, var(--media-secondary-color, rgb(20 20 30 / .7)))));
+      background: var(--media-preview-thumbnail-background, var(--_preview-background));
       box-shadow: var(--media-preview-thumbnail-box-shadow, 0 0 4px rgb(0 0 0 / .2));
       max-width: var(--media-preview-thumbnail-max-width, 180px);
       max-height: var(--media-preview-thumbnail-max-height, 160px);
@@ -139,7 +145,7 @@ template.innerHTML = /*html*/`
       ${/* delay changing these CSS props until the preview box transition is ended */''}
       transition: min-width 0s, border-radius 0s, margin 0s, padding 0s;
       transition-delay: calc(var(--media-preview-transition-delay-out, 0s) + var(--media-preview-transition-duration-out, .25s));
-      background: var(--media-preview-chapter-background, var(--media-preview-background, var(--media-control-background, var(--media-secondary-color, rgb(20 20 30 / .7)))));
+      background: var(--media-preview-chapter-background, var(--_preview-background));
       border-radius: var(--media-preview-chapter-border-radius,
         var(--media-preview-border-radius) var(--media-preview-border-radius)
         var(--media-preview-border-radius) var(--media-preview-border-radius));
@@ -171,16 +177,16 @@ template.innerHTML = /*html*/`
       ${/* delay changing these CSS props until the preview box transition is ended */''}
       transition: min-width 0s, border-radius 0s;
       transition-delay: calc(var(--media-preview-transition-delay-out, 0s) + var(--media-preview-transition-duration-out, .25s));
-      background: var(--media-preview-time-background, var(--media-preview-background, var(--media-control-background, var(--media-secondary-color, rgb(20 20 30 / .7)))));
+      background: var(--media-preview-time-background, var(--_preview-background));
       border-radius: var(--media-preview-time-border-radius,
         var(--media-preview-border-radius) var(--media-preview-border-radius)
         var(--media-preview-border-radius) var(--media-preview-border-radius));
       padding: var(--media-preview-time-padding, 4px 10px);
-      margin: var(--media-preview-time-margin, 0 0 10px);
+      margin: var(--media-preview-time-margin, 0);
       text-shadow: var(--media-preview-time-text-shadow, 0 0 4px rgb(0 0 0 / .75));
       transform: translateX(min(
         max(calc(50% - var(--_box-width) / 2),
-          calc(var(--_box-shift, 0))),
+        calc(var(--_box-shift, 0))),
         calc(var(--_box-width) / 2 - 50%)
       ));
     }
@@ -198,53 +204,38 @@ template.innerHTML = /*html*/`
       --media-time-range-hover-display: block;
     }
 
-    .arrow,
-    slot[name="preview-arrow"]::slotted(*),
-    slot[name="current-arrow"]::slotted(*) {
+    [part~="arrow"],
+    ::slotted([part~="arrow"]) {
       display: var(--media-box-arrow-display, flex);
       transform: translateX(min(
         max(calc(50% - var(--_box-width) / 2 + var(--media-box-arrow-offset)),
-          calc(var(--_box-shift, 0))),
+        calc(var(--_box-shift, 0))),
         calc(var(--_box-width) / 2 - 50% - var(--media-box-arrow-offset))
       ));
+      ${/* border-color has to come before border-top-color! */''}
+      border-color: transparent;
+      border-top-color: var(--media-box-arrow-background, var(--_control-background));
+      border-width: var(--media-box-arrow-border-width,
+        var(--media-box-arrow-height, 5px) var(--media-box-arrow-width, 6px) 0);
+      border-style: solid;
       justify-content: center;
       height: 0;
     }
-
-    .arrow::before {
-      border-color: transparent;
-      border-top-color: var(--media-box-arrow-background,
-        var(--media-box-background,
-        var(--media-control-background,
-        var(--media-secondary-color, rgb(20 20 30 / .7)))));
-      border-width: var(--media-box-arrow-border-width, 5px 6px 0);
-      top: var(--media-box-arrow-top, -10px);
-      content: '';
-      display: block;
-      width: 0;
-      height: 0;
-      position: relative;
-      border-style: solid;
-    }
   </style>
   <div id="preview-rail">
-    <div part="box preview-box">
-      <slot name="preview">
-        <media-preview-thumbnail></media-preview-thumbnail>
-        <media-preview-chapter-display></media-preview-chapter-display>
-        <media-preview-time-display></media-preview-time-display>
-      </slot>
-      <slot name="preview-arrow"><div class="arrow"></div></slot>
-    </div>
+    <slot name="preview" part="box preview-box">
+      <media-preview-thumbnail></media-preview-thumbnail>
+      <media-preview-chapter-display></media-preview-chapter-display>
+      <media-preview-time-display></media-preview-time-display>
+      <slot name="preview-arrow" part="arrow"></slot>
+    </slot>
   </div>
   <div id="current-rail">
-    <div part="box current-box">
-      <slot name="current">
-        ${/* Example: add the current time to the playhead
-          <media-time-display></media-time-display> */''}
-      </slot>
-      <slot name="current-arrow"><div class="arrow"></div></slot>
-    </div>
+    <slot name="current" part="box current-box">
+      ${/* Example: add the current time w/ arrow to the playhead
+        <media-time-display slot="current"></media-time-display>
+        <div part="arrow" slot="current"></div> */''}
+    </slot>
   </div>
 `;
 
@@ -261,6 +252,7 @@ const calcTimeFromRangeValue = (el, value = el.range.valueAsNumber) => {
 
 /**
  * @slot preview - An element that slides along the timeline to the position of the pointer hovering.
+ * @slot preview-arrow - An arrow element that slides along the timeline to the position of the pointer hovering.
  * @slot current - An element that slides along the timeline to the position of the current time.
  *
  * @attr {string} mediabuffered - (read-only) Set to the buffered time ranges.
@@ -276,6 +268,7 @@ const calcTimeFromRangeValue = (el, value = el.range.valueAsNumber) => {
  * @csspart box - A CSS part that selects both the preview and current box elements.
  * @csspart preview-box - A CSS part that selects the preview box element.
  * @csspart current-box - A CSS part that selects the current box element.
+ * @csspart arrow - A CSS part that selects the arrow element.
  *
  * @cssproperty [--media-time-range-display = inline-block] - `display` property of range.
  *
@@ -305,6 +298,18 @@ const calcTimeFromRangeValue = (el, value = el.range.valueAsNumber) => {
  * @cssproperty --media-preview-time-padding - `padding` of range preview time display.
  * @cssproperty --media-preview-time-margin - `margin` of range preview time display.
  * @cssproperty --media-preview-time-text-shadow - `text-shadow` of range preview time display.
+ *
+ * @cssproperty --media-box-display - `display` of range box.
+ * @cssproperty --media-box-margin - `margin` of range box.
+ * @cssproperty --media-box-padding-left - `padding-left` of range box.
+ * @cssproperty --media-box-padding-right - `padding-right` of range box.
+ *
+ * @cssproperty --media-box-arrow-display - `display` of range box arrow.
+ * @cssproperty --media-box-arrow-background - `border-top-color` of range box arrow.
+ * @cssproperty --media-box-arrow-border-width - `border-width` of range box arrow.
+ * @cssproperty --media-box-arrow-height - `height` of range box arrow.
+ * @cssproperty --media-box-arrow-width - `width` of range box arrow.
+ * @cssproperty --media-box-arrow-offset - `translateX` offset of range box arrow.
  */
 class MediaTimeRange extends MediaChromeRange {
   static get observedAttributes() {

--- a/src/js/themes/microvideo.js
+++ b/src/js/themes/microvideo.js
@@ -188,7 +188,7 @@ template.innerHTML = /*html*/`
     --media-range-padding-left: 0;
     --media-range-padding-right: 0;
     --media-preview-time-background: var(--_secondary-color);
-    --media-preview-time-margin: 0 0 8px;
+    --media-preview-box-margin: 0 0 3px;
 
     display: var(--controls, var(--time-range, inline-block));
     width: 100%;

--- a/src/js/themes/netflix.js
+++ b/src/js/themes/netflix.js
@@ -19,8 +19,8 @@ template.innerHTML = /*html*/`
     --media-range-track-transition: height 0.2s ease;
     --media-range-track-background: #555;
     --media-range-bar-color: rgb(229, 9, 20);
-    --media-control-hover-background: none;
-    --media-control-background: none;
+    --media-control-hover-background: transparent;
+    --media-control-background: transparent;
 
     --media-button-icon-height: 35px;
     --media-button-icon-transform: scale(1);

--- a/src/js/themes/youtube.js
+++ b/src/js/themes/youtube.js
@@ -30,7 +30,7 @@ template.innerHTML = /*html*/`
     --media-range-thumb-border-radius: 13px;
     --media-preview-thumbnail-border: 2px solid #fff;
     --media-preview-thumbnail-border-radius: 2px;
-    --media-preview-time-margin: 10px 0;
+    --media-preview-time-margin: 5px 0 0;
 
   }
 


### PR DESCRIPTION
test url: https://media-chrome-docs-git-fork-luwes-range-box-arrow-mux.vercel.app/docs/en/components/media-time-range

- [x] adds logic so children in the time range boxes shift closer to the time position, works for the preview and current box
- [x] adds a built-in arrow which also shifts similarly to `media-time-display` and `media-preview-time-display`