### PR TITLE
fix: segments.length typerror

### DIFF
--- a/src/js/media-chrome-range.js
+++ b/src/js/media-chrome-range.js
@@ -427,7 +427,7 @@ class MediaChromeRange extends globalThis.HTMLElement {
     const clipping = this.shadowRoot.querySelector('#segments-clipping');
     clipping.textContent = '';
 
-    this.container.classList.toggle('segments', !!segments.length);
+    this.container.classList.toggle('segments', !!segments?.length);
 
     if (!segments?.length) return;
 


### PR DESCRIPTION
just noticed this bug in Codesandbox. my bad.

<img width="663" alt="SCR-20240306-rbxd" src="https://github.com/muxinc/media-chrome/assets/360826/30ff5a67-8488-4e4b-aa85-dbcbc18eb4e1">
