### PR TITLE
docs: add Media Chrome + Tailwind CSS example

### DIFF
--- a/docs/src/pages/docs/en/examples/[...example].astro
+++ b/docs/src/pages/docs/en/examples/[...example].astro
@@ -96,6 +96,14 @@ export function getStaticPaths({ paginate }: GetStaticPathsOptions) {
       }
     },
     {
+      params: { example: 'tailwind-audio-theme' },
+      props: {
+        title: 'Tailwind Audio Theme',
+        group: 'Themes',
+        sourcePath: 'examples/vanilla/themes/tailwind-audio-theme/index.html',
+      }
+    },
+    {
       params: { example: 'minimal-theme' },
       props: {
         title: 'Minimal Theme',
@@ -179,6 +187,11 @@ const head = html.childNodes.find(node => node.nodeName === 'head')
 const body = html.childNodes.find(node => node.nodeName === 'body')
 const main = body.childNodes.find(node => node.nodeName === 'main')
 
+const htmlClass = html.attrs.find(attr => attr.name === 'class')?.value ?? ''
+const htmlClassArgs = htmlClass.split(' ').map(c => `'${c}'`).join(', ')
+const bodyClass = body.attrs.find(attr => attr.name === 'class')?.value ?? ''
+const bodyClassArgs = bodyClass.split(' ').map(c => `'${c}'`).join(', ')
+
 const scripts = head.childNodes
   .filter(node => node.nodeName === 'script' && node.attrs.find(attr => attr.name === 'src' && attr.value))
   .map(node => ({
@@ -226,6 +239,15 @@ transformVttSrc(body)
 const repoRootDir = path.resolve('../')
 
 const files = {}
+
+files['copy.js'] = {
+  code: `
+    ${htmlClass ? `document.documentElement.classList.add(${htmlClassArgs});` : ''}
+    ${bodyClass ? `document.body.classList.add(${bodyClassArgs});` : ''}
+  `,
+  hidden: true,
+}
+
 try {
   for (let { src } of validScripts) {
     const baseDir = src.includes('/src/js/') ? path.resolve(process.cwd(), '../src/js/') :

--- a/examples/vanilla/themes/tailwind-audio-theme/index.html
+++ b/examples/vanilla/themes/tailwind-audio-theme/index.html
@@ -4,15 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width">
     <title>Media Theme TailwindCSS Audio</title>
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preload" fetchpriority="high" as="style" href="https://media-chrome.mux.dev/examples/vanilla/themes/tailwind-audio-theme/output.css">
     <script type="module" src="../../../../dist/index.js"></script>
     <script type="module" src="../../../../dist/media-theme-element.js"></script>
+    <script src="https://cdn.tailwindcss.com"></script>
   </head>
   <body class="max-w-screen-md h-5/6 flex flex-col items-center justify-center p-5 mx-auto">
 
     <template id="media-theme-tailwind-audio">
       <style>
-        @import "./output.css";
+        @import "https://media-chrome.mux.dev/examples/vanilla/themes/tailwind-audio-theme/output.css";
       </style>
 
       <svg class="hidden">


### PR DESCRIPTION
test url: https://media-chrome-docs-git-fork-luwes-tailwind-mux.vercel.app/docs/en/examples/tailwind-audio-theme

used a remote static CSS URL for now because Sandpack doesn't seem to support static local assets without bundling them? 

https://github.com/codesandbox/sandpack/discussions/1101