### PR TITLE
docs: Add a note about img tag in media-poster-image.mdx

### DIFF
--- a/docs/src/pages/docs/en/components/media-poster-image.mdx
+++ b/docs/src/pages/docs/en/components/media-poster-image.mdx
@@ -14,6 +14,8 @@ For example, you can show a blurhash that mirrors the colors that will appear wi
 
 You can either use the `<media-poster-image>` component as a static image on its own, or, add the `slot="poster"` attribute to associate it with the underlying video element for click-to-play.
 
+> This component is reliant on Javascript to load the poster image. If better control or better performance is desired, you can use `<img slot="poster" src="...">` instead. However, it doesn't support a secondary placeholder.
+
 ## With `src`
 
 <SandpackContainer

--- a/docs/src/pages/docs/en/components/media-poster-image.mdx
+++ b/docs/src/pages/docs/en/components/media-poster-image.mdx
@@ -14,7 +14,7 @@ For example, you can show a blurhash that mirrors the colors that will appear wi
 
 You can either use the `<media-poster-image>` component as a static image on its own, or, add the `slot="poster"` attribute to associate it with the underlying video element for click-to-play.
 
-> This component is reliant on Javascript to load the poster image. If better control or better performance is desired, you can use `<img slot="poster" src="...">` instead. However, it doesn't support a secondary placeholder.
+> This component is reliant on Javascript to load the poster image. If better control or better performance is desired, you can use `<img slot="poster" src="...">` instead. Set a placeholder via the `background-image` CSS property in the `style` attribute.
 
 ## With `src`
 


### PR DESCRIPTION
This doc change is inspired by the comment by @luwes here:

https://github.com/muxinc/media-chrome/issues/904#issuecomment-2104699433

PS: Maintainer edits are allowed. Feel free to change the text as you see fit.