### PR TITLE
feat!: Tooltips

### DIFF
--- a/examples/vanilla/images/spacebar.svg
+++ b/examples/vanilla/images/spacebar.svg
@@ -1,0 +1,6 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<rect x="0.5" y="0.5" width="15" height="15" rx="2.5" stroke="black"/>
+	<rect x="3" y="8" width="10" height="2" fill="black"/>
+	<rect x="2" y="6" width="2" height="2" fill="black"/>
+	<rect x="12" y="6" width="2" height="2" fill="black"/>
+</svg> 

--- a/examples/vanilla/images/spacebar.svg
+++ b/examples/vanilla/images/spacebar.svg
@@ -1,6 +1,6 @@
 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-	<rect x="0.5" y="0.5" width="15" height="15" rx="2.5" stroke="black"/>
-	<rect x="3" y="8" width="10" height="2" fill="black"/>
-	<rect x="2" y="6" width="2" height="2" fill="black"/>
-	<rect x="12" y="6" width="2" height="2" fill="black"/>
+	<rect x="0.5" y="0.5" width="15" height="15" rx="2.5" stroke="white"/>
+	<rect x="3" y="8" width="10" height="2" fill="white"/>
+	<rect x="2" y="6" width="2" height="2" fill="white"/>
+	<rect x="12" y="6" width="2" height="2" fill="white"/>
 </svg> 

--- a/examples/vanilla/index.html
+++ b/examples/vanilla/index.html
@@ -73,6 +73,7 @@
     <h3>Extras</h3>
     <ul>
       <li><a href="control-elements/media-clip-selector.html">Clip selector</a></li>
+      <li><a href="tooltips.html">Tooltips</a></li>
     </ul>
   </body>
 </html>

--- a/examples/vanilla/index.html
+++ b/examples/vanilla/index.html
@@ -23,6 +23,7 @@
       <li><a href="pwa/">Progressive Web Application (PWA)</a></li>
       <li><a href="responsive.html">Responsive controls using Container Queries</a></li>
       <li><a href="responsive-attribute.html">Responsive controls using breakpoint attributes</a></li>
+      <li><a href="tooltips.html">Tooltips</a></li>
     </ul>
 
     <h2>Media element examples</h2>
@@ -73,7 +74,6 @@
     <h3>Extras</h3>
     <ul>
       <li><a href="control-elements/media-clip-selector.html">Clip selector</a></li>
-      <li><a href="tooltips.html">Tooltips</a></li>
     </ul>
   </body>
 </html>

--- a/examples/vanilla/tooltips.html
+++ b/examples/vanilla/tooltips.html
@@ -57,11 +57,11 @@
       <h2>On their own (no arrows when <code>position="none"</code>)</h2>
 
       <div>
-        <media-tooltip position="none">Settings</media-tooltip>
+        <media-tooltip placement="none">Settings</media-tooltip>
         <br><br>
-        <media-tooltip position="none">Play</media-tooltip>
+        <media-tooltip placement="none">Play</media-tooltip>
         <br><br>
-        <media-tooltip position="none">Pause</media-tooltip>
+        <media-tooltip placement="none">Pause</media-tooltip>
       </div>
 
       <h2>As part of button controls</h2>
@@ -106,19 +106,19 @@
       <div style="display: flex; gap: 25px;">
         <div>
           <div>Top</div>
-          <media-play-button tooltipposition="top"></media-play-button>  
+          <media-play-button tooltipplacement="top"></media-play-button>  
         </div>
         <div>
           <div>Right</div>
-          <media-play-button tooltipposition="right"></media-play-button>  
+          <media-play-button tooltipplacement="right"></media-play-button>  
         </div>
         <div>
           <div>Bottom</div>
-          <media-play-button tooltipposition="bottom"></media-play-button>  
+          <media-play-button tooltipplacement="bottom"></media-play-button>  
         </div>
         <div>
           <div>Left</div>
-          <media-play-button tooltipposition="left"></media-play-button>
+          <media-play-button tooltipplacement="left"></media-play-button>
         </div>
       </div>
 
@@ -202,7 +202,7 @@
 
       <h2>Placing within a custom button</h2>
       <div style="display: flex;">
-        <div class="custom-btn">+<media-tooltip position="right">Add</media-tooltip></div>
+        <div class="custom-btn">+<media-tooltip placement="right">Add</media-tooltip></div>
       </div>
 
 	    <div class="examples">

--- a/examples/vanilla/tooltips.html
+++ b/examples/vanilla/tooltips.html
@@ -38,6 +38,10 @@
         <span slot="tooltip">Play the <strong>damn</strong> movie</span>
       </media-play-button>
 
+      <h2>Hiding with CSS</h2>
+
+      <media-play-button style="--media-tooltip-display: none;"></media-play-button>
+
 	    <div class="examples">
         <a href="./">View more examples</a>
       </div>

--- a/examples/vanilla/tooltips.html
+++ b/examples/vanilla/tooltips.html
@@ -25,6 +25,29 @@
       code {
         color: maroon;
       }
+
+      .custom-btn {
+        position: relative;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        background: lightblue;
+        border: 2px solid #333;
+        color: #333;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        font-size: 24px;
+        font-weight: bold;
+        cursor: pointer;
+      }
+      .custom-btn media-tooltip {
+        opacity: 0;
+        transition: opacity .3s;
+      }
+      .custom-btn:hover media-tooltip {
+        opacity: 1;
+      }
     </style>
   </head>
   <body>     
@@ -176,6 +199,11 @@
           "></media-play-button>
         </media-control-bar>
       </media-controller>
+
+      <h2>Placing within a custom button</h2>
+      <div style="display: flex;">
+        <div class="custom-btn">+<media-tooltip position="right">Add</media-tooltip></div>
+      </div>
 
 	    <div class="examples">
         <a href="./">View more examples</a>

--- a/examples/vanilla/tooltips.html
+++ b/examples/vanilla/tooltips.html
@@ -27,11 +27,11 @@
       <h2>On their own</h2>
 
       <div>
-        <media-tooltip>Settings</media-tooltip>
+        <media-tooltip position="none">Settings</media-tooltip>
         <br><br>
-        <media-tooltip>Play</media-tooltip>
+        <media-tooltip position="none">Play</media-tooltip>
         <br><br>
-        <media-tooltip>Pause</media-tooltip>
+        <media-tooltip position="none">Pause</media-tooltip>
       </div>
 
       <h2>As part of button controls</h2>
@@ -65,6 +65,27 @@
       <h2>Hiding with CSS</h2>
 
       <media-play-button style="--media-tooltip-display: none;"></media-play-button>
+
+      <h2>Positioning</h2>
+
+      <div style="display: flex; gap: 25px;">
+        <div>
+          <div>Top</div>
+          <media-play-button tooltipposition="top"></media-play-button>  
+        </div>
+        <div>
+          <div>Right</div>
+          <media-play-button tooltipposition="right"></media-play-button>  
+        </div>
+        <div>
+          <div>Bottom</div>
+          <media-play-button tooltipposition="bottom"></media-play-button>  
+        </div>
+        <div>
+          <div>Left</div>
+          <media-play-button tooltipposition="left"></media-play-button>
+        </div>
+      </div>
 
 	    <div class="examples">
         <a href="./">View more examples</a>

--- a/examples/vanilla/tooltips.html
+++ b/examples/vanilla/tooltips.html
@@ -54,7 +54,7 @@
         </media-control-bar>
       </media-controller>
 
-      <h2>Overriding tooltip label</h2>
+      <h2>Overriding tooltip label <small>(and constraining x position)</small></h2>
       <media-controller>
         <video
           slot="media"

--- a/examples/vanilla/tooltips.html
+++ b/examples/vanilla/tooltips.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width" />
+    <title>Media Chrome Tooltips</title>
+    <script type="module" src="../../dist/index.js"></script>
+    <style>
+      body {
+        background: #eee;
+      }
+      .examples {
+        margin-top: 20px;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Tooltips</h1>
+      
+      <h2>On their own</h2>
+
+      <div>
+        <media-tooltip>Settings</media-tooltip>
+        <br><br>
+        <media-tooltip>Play</media-tooltip>
+        <br><br>
+        <media-tooltip>Pause</media-tooltip>
+      </div>
+
+      <h2>As part of button controls</h2>
+
+      <media-play-button></media-play-button>
+
+	    <div class="examples">
+        <a href="./">View more examples</a>
+      </div>
+    </main>
+  </body>
+</html>

--- a/examples/vanilla/tooltips.html
+++ b/examples/vanilla/tooltips.html
@@ -154,7 +154,7 @@
             --media-primary-color: #0f0;
             --media-secondary-color: #333;
             --media-tooltip-background: #000;
-            --media-tooltip-arrow-background-color: #0f0;
+            --media-tooltip-arrow-color: #0f0;
             --media-tooltip-arrow-width: 20px;
             --media-tooltip-arrow-height: 5px;
             --media-tooltip-border: 1px solid #0f0;

--- a/examples/vanilla/tooltips.html
+++ b/examples/vanilla/tooltips.html
@@ -11,6 +11,9 @@
       .examples {
         margin-top: 20px;
       }
+      media-controller {
+        max-width: 500px;
+      }
     </style>
   </head>
   <body>
@@ -29,8 +32,17 @@
 
       <h2>As part of button controls</h2>
 
-      <media-play-button></media-play-button>
-      <media-airplay-button></media-airplay-button>
+      <media-controller>
+        <video
+          slot="media"
+          src="https://stream.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/high.mp4"
+          muted
+        ></video>
+        <media-control-bar>
+          <media-play-button></media-play-button>
+          <media-airplay-button></media-airplay-button>
+        </media-control-bar>
+      </media-controller>
 
       <h2>Overriding tooltip label</h2>
       <media-airplay-button></media-airplay-button>

--- a/examples/vanilla/tooltips.html
+++ b/examples/vanilla/tooltips.html
@@ -53,6 +53,33 @@
   <body>     
     <main>
       <h1>Tooltips</h1>
+
+      <h2>All buttons</h2>
+
+      <media-controller style="--media-tooltip-container-margin: 10px; min-width: 700px;">
+        <video
+          slot="media"
+          src="https://stream.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/high.mp4"
+          muted
+        ></video>
+        <media-control-bar style="display: flexbox; gap: 5px;">
+          <media-airplay-button></media-airplay-button>
+          <media-audio-track-menu-button></media-audio-track-menu-button>
+          <media-captions-menu-button></media-captions-menu-button>
+          <media-captions-button></media-captions-button>
+          <media-cast-button></media-cast-button>
+          <media-fullscreen-button></media-fullscreen-button>
+          <media-mute-button></media-mute-button>
+          <media-pip-button></media-pip-button>
+          <media-play-button></media-play-button>
+          <media-playback-rate-button></media-playback-rate-button>
+          <media-playback-rate-menu-button></media-playback-rate-menu-button>
+          <media-rendition-menu-button></media-rendition-menu-button>
+          <media-seek-backward-button></media-seek-backward-button>
+          <media-seek-forward-button></media-seek-forward-button>
+          <media-settings-menu-button></media-settings-menu-button>
+        </media-control-bar>
+      </media-controller>
       
       <h2>On their own (no arrows when <code>position="none"</code>)</h2>
 

--- a/examples/vanilla/tooltips.html
+++ b/examples/vanilla/tooltips.html
@@ -15,6 +15,9 @@
       media-controller {
         max-width: 300px;
       }
+      media-control-bar {
+        margin: 10px;
+      }
     </style>
   </head>
   <body>     

--- a/examples/vanilla/tooltips.html
+++ b/examples/vanilla/tooltips.html
@@ -61,7 +61,11 @@
           slot="media"
           src="https://stream.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/high.mp4"
           muted
-        ></video>
+        >
+          <track label="English" kind="captions" srclang="en" src="../vtt/elephantsdream/captions.en.vtt" default></track>
+        </video>
+        <media-playback-rate-menu anchor="auto" hidden></media-playback-rate-menu>
+        <media-captions-menu anchor="auto" hidden></media-captions-menu>
         <media-control-bar style="display: flex; gap: 5px;">
           <media-airplay-button></media-airplay-button>
           <media-audio-track-menu-button></media-audio-track-menu-button>

--- a/examples/vanilla/tooltips.html
+++ b/examples/vanilla/tooltips.html
@@ -7,16 +7,17 @@
     <style>
       body {
         background: #eee;
+        padding: 50px;
       }
       .examples {
         margin-top: 20px;
       }
       media-controller {
-        max-width: 500px;
+        max-width: 300px;
       }
     </style>
   </head>
-  <body>
+  <body>     
     <main>
       <h1>Tooltips</h1>
       
@@ -40,15 +41,23 @@
         ></video>
         <media-control-bar>
           <media-play-button></media-play-button>
-          <media-airplay-button></media-airplay-button>
         </media-control-bar>
       </media-controller>
 
       <h2>Overriding tooltip label</h2>
-      <media-airplay-button></media-airplay-button>
-      <media-play-button>
-        <span slot="tooltip">Play the <strong>damn</strong> movie</span>
-      </media-play-button>
+      <media-controller>
+        <video
+          slot="media"
+          src="https://stream.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/high.mp4"
+          muted
+        ></video>
+        <media-control-bar>
+          <media-play-button>
+            <span slot="tooltip-play"><strong>Play</strong> the movie! <img src="/examples/vanilla/images/spacebar.svg" width="12"></span>
+            <span slot="tooltip-pause">Please <i>stop</i>... <img src="/examples/vanilla/images/spacebar.svg" width="12"></strong></span>
+          </media-play-button>
+        </media-control-bar>
+      </media-controller>
 
       <h2>Hiding with CSS</h2>
 

--- a/examples/vanilla/tooltips.html
+++ b/examples/vanilla/tooltips.html
@@ -30,6 +30,13 @@
       <h2>As part of button controls</h2>
 
       <media-play-button></media-play-button>
+      <media-airplay-button></media-airplay-button>
+
+      <h2>Overriding tooltip label</h2>
+      <media-airplay-button></media-airplay-button>
+      <media-play-button>
+        <span slot="tooltip">Play the <strong>damn</strong> movie</span>
+      </media-play-button>
 
 	    <div class="examples">
         <a href="./">View more examples</a>

--- a/examples/vanilla/tooltips.html
+++ b/examples/vanilla/tooltips.html
@@ -100,41 +100,54 @@
 
       <h2>Entirely custom tooltip element</h2>
 
-      <media-play-button style="margin-top: 1.5em">
-        <style>
-          .my-tooltip {
-            position: absolute;
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            left: 50%;
-            bottom: calc(100% + 5px);
-            transform: translate(-50%, 0);
-            color: #fff;
-            font-weight: 700;
-            background: linear-gradient(45deg, red, yellow, blue, red);
-            white-space: nowrap;
-            width: 110px;
-            height: 26px;
-            border-radius: 13px;
-            opacity: 0;
-            pointer-events: none;
-            scale: 0;
-            transition: all .3s cubic-bezier(0.34, 2.5, 0.7, 1);
-            transform-origin: 0 bottom;
-            font-family: "Comic Sans MS", "Comic Sans", cursive;
-            font-size: 18px;
-          }
-          .my-tooltip marquee { display: block; }
-          media-play-button:hover .my-tooltip {
-            opacity: 1;
-            scale: 1;
-          }
-        </style>
-        <div slot="tooltip" class="my-tooltip">
-          <marquee>HellooOOoo!!</marquee>
-        </div>
-      </media-play-button>
+      <media-controller>
+        <video
+          slot="media"
+          src="https://stream.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/high.mp4"
+          muted
+        ></video>
+        <media-play-button style="margin-top: 1.5em">
+          <style>
+            .my-tooltip {
+              position: absolute;
+              display: flex;
+              justify-content: center;
+              align-items: center;
+              left: 50%;
+              bottom: calc(100% + 5px);
+              transform: translate(-50%, 0);
+              color: #fff;
+              font-weight: 700;
+              background: linear-gradient(45deg, red, yellow, blue, red);
+              white-space: nowrap;
+              width: 110px;
+              height: 26px;
+              border-radius: 13px;
+              opacity: 0;
+              pointer-events: none;
+              scale: 0;
+              transition: all .3s cubic-bezier(0.34, 2.5, 0.7, 1);
+              transform-origin: 0 bottom;
+              font-family: "Comic Sans MS", "Comic Sans", cursive;
+              font-size: 18px;
+            }
+            media-play-button:hover .my-tooltip {
+              opacity: 1;
+              scale: 1;
+            }
+            media-play-button[mediapaused] #play { display: block; }
+            media-play-button[mediapaused] #pause { display: none; }
+            media-play-button #play { display: none; }
+            media-play-button #pause { display: block; }
+          </style>
+          <div slot="tooltip" class="my-tooltip">
+            <marquee>
+              <div id="play">Play</div>
+              <div id="pause">Pause</div>
+            </marquee>
+          </div>
+        </media-play-button>
+      </media-controller>
 
       <h2>Theming</h2>
 

--- a/examples/vanilla/tooltips.html
+++ b/examples/vanilla/tooltips.html
@@ -97,9 +97,15 @@
         </media-control-bar>
       </media-controller>
 
-      <h2>Hiding with CSS</h2>
+      <h2>Hiding</h2>
+
+      <h3>with CSS</h3>
 
       <media-play-button style="--media-tooltip-display: none;"></media-play-button>
+
+      <h3>with an empty <code>tooltip</code> attribute</h3>
+
+      <media-play-button tooltip=""></media-play-button>
 
       <h2>Positioning</h2>
 
@@ -204,6 +210,16 @@
       <div style="display: flex;">
         <div class="custom-btn">+<media-tooltip placement="right">Add</media-tooltip></div>
       </div>
+
+      <h2>Dynamic label changes via <code>tooltip</code> attribute (+ hiding when label is empty)</h2>
+      <p><input id="dynamicInput" type="text" value="Custom..."></p>
+      <media-play-button id="dynamicPlay"></media-play-button>
+      <script>
+        window.dynamicInput.oninput = (event) => {
+          window.dynamicPlay.tooltip = event.target.value;
+        }
+        window.dynamicPlay.setAttribute('tooltip', window.dynamicInput.value);
+      </script>
 
 	    <div class="examples">
         <a href="./">View more examples</a>

--- a/examples/vanilla/tooltips.html
+++ b/examples/vanilla/tooltips.html
@@ -9,14 +9,21 @@
         background: #eee;
         padding: 50px;
       }
+      
       .examples {
         margin-top: 20px;
       }
+      
       media-controller {
         max-width: 300px;
       }
+      
       media-control-bar {
         margin: 10px;
+      }
+
+      code {
+        color: maroon;
       }
     </style>
   </head>
@@ -24,7 +31,7 @@
     <main>
       <h1>Tooltips</h1>
       
-      <h2>On their own</h2>
+      <h2>On their own (no arrows when <code>position="none"</code>)</h2>
 
       <div>
         <media-tooltip position="none">Settings</media-tooltip>

--- a/examples/vanilla/tooltips.html
+++ b/examples/vanilla/tooltips.html
@@ -54,10 +54,14 @@
           src="https://stream.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/high.mp4"
           muted
         ></video>
-        <media-control-bar>
+        <media-control-bar style="display: flexbox; justify-content: space-between;">
           <media-play-button>
             <span slot="tooltip-play"><strong>Play</strong> the movie! <img src="/examples/vanilla/images/spacebar.svg" width="12"></span>
             <span slot="tooltip-pause">Please <i>stop</i>... <img src="/examples/vanilla/images/spacebar.svg" width="12"></strong></span>
+          </media-play-button>
+          <media-play-button>
+            <span slot="tooltip-play">Play......</span>
+            <span slot="tooltip-pause">Pause........</span>
           </media-play-button>
         </media-control-bar>
       </media-controller>

--- a/examples/vanilla/tooltips.html
+++ b/examples/vanilla/tooltips.html
@@ -136,6 +136,21 @@
         </div>
       </media-play-button>
 
+      <h2>Theming</h2>
+
+      <media-controller>
+        <video
+          slot="media"
+          src="https://stream.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/high.mp4"
+          muted
+        ></video>
+        <media-control-bar style="gap: 10px">
+          <media-play-button style="--media-primary-color: #000; --media-secondary-color: #fff;"></media-play-button>
+          <media-play-button style="--media-primary-color: #f00; --media-secondary-color: #00f;"></media-play-button>
+          <media-play-button style="--media-primary-color: #0f0; --media-secondary-color: #333;"></media-play-button>
+        </media-control-bar>
+      </media-controller>
+
 	    <div class="examples">
         <a href="./">View more examples</a>
       </div>

--- a/examples/vanilla/tooltips.html
+++ b/examples/vanilla/tooltips.html
@@ -147,7 +147,13 @@
         <media-control-bar style="gap: 10px">
           <media-play-button style="--media-primary-color: #000; --media-secondary-color: #fff;"></media-play-button>
           <media-play-button style="--media-primary-color: #f00; --media-secondary-color: #00f;"></media-play-button>
-          <media-play-button style="--media-primary-color: #0f0; --media-secondary-color: #333;"></media-play-button>
+          <media-play-button style="
+            --media-primary-color: #0f0;
+            --media-secondary-color: #333;
+            --media-tooltip-arrow-background-color: #0f0;
+            --media-tooltip-arrow-width: 20px;
+            --media-tooltip-arrow-height: 5px;
+          "></media-play-button>
         </media-control-bar>
       </media-controller>
 

--- a/examples/vanilla/tooltips.html
+++ b/examples/vanilla/tooltips.html
@@ -103,9 +103,9 @@
 
       <media-play-button style="--media-tooltip-display: none;"></media-play-button>
 
-      <h3>with an empty <code>tooltip</code> attribute</h3>
+      <h3>with a <code>notooltip</code> attribute</h3>
 
-      <media-play-button tooltip=""></media-play-button>
+      <media-play-button notooltip></media-play-button>
 
       <h2>Positioning</h2>
 
@@ -210,16 +210,6 @@
       <div style="display: flex;">
         <div class="custom-btn">+<media-tooltip placement="right">Add</media-tooltip></div>
       </div>
-
-      <h2>Dynamic label changes via <code>tooltip</code> attribute (+ hiding when label is empty)</h2>
-      <p><input id="dynamicInput" type="text" value="Custom..."></p>
-      <media-play-button id="dynamicPlay"></media-play-button>
-      <script>
-        window.dynamicInput.oninput = (event) => {
-          window.dynamicPlay.tooltip = event.target.value;
-        }
-        window.dynamicPlay.setAttribute('tooltip', window.dynamicInput.value);
-      </script>
 
 	    <div class="examples">
         <a href="./">View more examples</a>

--- a/examples/vanilla/tooltips.html
+++ b/examples/vanilla/tooltips.html
@@ -98,6 +98,44 @@
         </div>
       </div>
 
+      <h2>Entirely custom tooltip element</h2>
+
+      <media-play-button style="margin-top: 1.5em">
+        <style>
+          .my-tooltip {
+            position: absolute;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            left: 50%;
+            bottom: calc(100% + 5px);
+            transform: translate(-50%, 0);
+            color: #fff;
+            font-weight: 700;
+            background: linear-gradient(45deg, red, yellow, blue, red);
+            white-space: nowrap;
+            width: 110px;
+            height: 26px;
+            border-radius: 13px;
+            opacity: 0;
+            pointer-events: none;
+            scale: 0;
+            transition: all .25s;
+            transform-origin: 0 bottom;
+            font-family: "Comic Sans MS", "Comic Sans", cursive;
+            font-size: 18px;
+          }
+          .my-tooltip marquee { display: block; }
+          media-play-button:hover .my-tooltip {
+            opacity: 1;
+            scale: 1;
+          }
+        </style>
+        <div slot="tooltip" class="my-tooltip">
+          <marquee>HellooOOoo!!</marquee>
+        </div>
+      </media-play-button>
+
 	    <div class="examples">
         <a href="./">View more examples</a>
       </div>

--- a/examples/vanilla/tooltips.html
+++ b/examples/vanilla/tooltips.html
@@ -146,13 +146,19 @@
         ></video>
         <media-control-bar style="gap: 10px">
           <media-play-button style="--media-primary-color: #000; --media-secondary-color: #fff;"></media-play-button>
-          <media-play-button style="--media-primary-color: #f00; --media-secondary-color: #00f;"></media-play-button>
+          <media-play-button style="
+            --media-primary-color: #f00;
+            --media-secondary-color: cyan;
+          "></media-play-button>
           <media-play-button style="
             --media-primary-color: #0f0;
             --media-secondary-color: #333;
+            --media-tooltip-background: #000;
             --media-tooltip-arrow-background-color: #0f0;
             --media-tooltip-arrow-width: 20px;
             --media-tooltip-arrow-height: 5px;
+            --media-tooltip-border: 1px solid #0f0;
+            --media-tooltip-border-radius: 2px;
           "></media-play-button>
         </media-control-bar>
       </media-controller>

--- a/examples/vanilla/tooltips.html
+++ b/examples/vanilla/tooltips.html
@@ -43,19 +43,20 @@
 
       <h2>As part of button controls</h2>
 
-      <media-controller>
+      <media-controller style="--media-tooltip-container-margin: 10px;">
         <video
           slot="media"
           src="https://stream.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/high.mp4"
           muted
         ></video>
-        <media-control-bar>
+        <media-control-bar style="display: flexbox; justify-content: space-between;">
+          <media-play-button></media-play-button>
           <media-play-button></media-play-button>
         </media-control-bar>
       </media-controller>
 
       <h2>Overriding tooltip label <small>(and constraining x position)</small></h2>
-      <media-controller>
+      <media-controller style="--media-tooltip-container-margin: 10px;">
         <video
           slot="media"
           src="https://stream.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/high.mp4"

--- a/examples/vanilla/tooltips.html
+++ b/examples/vanilla/tooltips.html
@@ -62,7 +62,7 @@
           src="https://stream.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/high.mp4"
           muted
         ></video>
-        <media-control-bar style="display: flexbox; gap: 5px;">
+        <media-control-bar style="display: flex; gap: 5px;">
           <media-airplay-button></media-airplay-button>
           <media-audio-track-menu-button></media-audio-track-menu-button>
           <media-captions-menu-button></media-captions-menu-button>
@@ -99,7 +99,7 @@
           src="https://stream.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/high.mp4"
           muted
         ></video>
-        <media-control-bar style="display: flexbox; justify-content: space-between;">
+        <media-control-bar style="display: flex; justify-content: space-between;">
           <media-play-button></media-play-button>
           <media-play-button></media-play-button>
         </media-control-bar>
@@ -112,7 +112,7 @@
           src="https://stream.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/high.mp4"
           muted
         ></video>
-        <media-control-bar style="display: flexbox; justify-content: space-between;">
+        <media-control-bar style="display: flex; justify-content: space-between;">
           <media-play-button>
             <span slot="tooltip-play"><strong>Play</strong> the movie! <img src="/examples/vanilla/images/spacebar.svg" width="12"></span>
             <span slot="tooltip-pause">Please <i>stop</i>... <img src="/examples/vanilla/images/spacebar.svg" width="12"></strong></span>

--- a/examples/vanilla/tooltips.html
+++ b/examples/vanilla/tooltips.html
@@ -120,7 +120,7 @@
             opacity: 0;
             pointer-events: none;
             scale: 0;
-            transition: all .25s;
+            transition: all .3s cubic-bezier(0.34, 2.5, 0.7, 1);
             transform-origin: 0 bottom;
             font-family: "Comic Sans MS", "Comic Sans", cursive;
             font-size: 18px;

--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -42,6 +42,7 @@ import MediaSettingsMenuButton from './media-settings-menu-button.js';
 import MediaSettingsMenuItem from './media-settings-menu-item.js';
 import MediaTimeDisplay from './media-time-display.js';
 import MediaTimeRange from './media-time-range.js';
+import MediaTooltip from './media-tooltip.js';
 import MediaVolumeRange from './media-volume-range.js';
 
 export {
@@ -83,5 +84,6 @@ export {
   MediaSettingsMenuItem,
   MediaTimeDisplay,
   MediaTimeRange,
+  MediaTooltip,
   MediaVolumeRange,
 };

--- a/src/js/labels/labels.ts
+++ b/src/js/labels/labels.ts
@@ -1,5 +1,29 @@
 export type LabelOptions = { seekOffset?: number; playbackRate?: number };
 
+export const tooltipLabels = {
+  ENTER_AIRPLAY: 'Start airplay',
+  EXIT_AIRPLAY: 'Stop airplay',
+  AUDIO_TRACK_MENU: 'Audio',
+  CAPTIONS: 'Captions',
+  ENABLE_CAPTIONS: 'Enable captions',
+  DISABLE_CAPTIONS: 'Disable captions',
+  START_CAST: 'Start casting',
+  STOP_CAST: 'Stop casting',
+  ENTER_FULLSCREEN: 'Enter fullscreen mode',
+  EXIT_FULLSCREEN: 'Exit fullscreen mode',
+  MUTE: 'Mute',
+  UNMUTE: 'Unmute',
+  ENTER_PIP: 'Enter picture in picture mode',
+  EXIT_PIP: 'Enter picture in picture mode',
+  PLAY: 'Play',
+  PAUSE: 'Pause',
+  PLAYBACK_RATE: 'Playback rate',
+  RENDITIONS: 'Quality',
+  SEEK_BACKWARD: 'Seek backward',
+  SEEK_FORWARD: 'Seek forward',
+  SETTINGS: 'Settings',
+};
+
 export const nouns: Record<string, (options?: LabelOptions) => string> = {
   AUDIO_PLAYER: () => 'audio player',
   VIDEO_PLAYER: () => 'video player',

--- a/src/js/media-airplay-button.ts
+++ b/src/js/media-airplay-button.ts
@@ -17,24 +17,36 @@ const airplayIcon = `<svg aria-hidden="true" viewBox="0 0 26 24">
 const slotTemplate: HTMLTemplateElement = document.createElement('template');
 slotTemplate.innerHTML = /*html*/ `
   <style>
-  :host([${
-    MediaUIAttributes.MEDIA_IS_AIRPLAYING
-  }]) slot:not([name=exit]):not([name=icon]) {
-    display: none !important;
-  }
+    :host([${
+      MediaUIAttributes.MEDIA_IS_AIRPLAYING
+    }]) slot[name=icon] slot:not([name=exit]) {
+      display: none !important;
+    }
 
-  ${/* Double negative, but safer if display doesn't equal 'block' */ ''}
-  :host(:not([${
-    MediaUIAttributes.MEDIA_IS_AIRPLAYING
-  }])) slot:not([name=enter]):not([name=icon]) {
-    display: none !important;
-  }
+    ${/* Double negative, but safer if display doesn't equal 'block' */ ''}
+    :host(:not([${
+      MediaUIAttributes.MEDIA_IS_AIRPLAYING
+    }])) slot[name=icon] slot:not([name=enter]) {
+      display: none !important;
+    }
+
+    :host([${MediaUIAttributes.MEDIA_IS_AIRPLAYING}]) slot[name=tooltip-enter],
+    :host(:not([${
+      MediaUIAttributes.MEDIA_IS_AIRPLAYING
+    }])) slot[name=tooltip-exit] {
+      display: none;
+    }
   </style>
 
   <slot name="icon">
     <slot name="enter">${airplayIcon}</slot>
     <slot name="exit">${airplayIcon}</slot>
   </slot>
+`;
+
+const tooltipContent = /*html*/ `
+  <slot name="tooltip-enter">Start Airplaying</slot>
+  <slot name="tooltip-exit">Stop Airplaying</slot>
 `;
 
 const updateAriaLabel = (el: MediaAirplayButton): void => {
@@ -66,7 +78,7 @@ class MediaAirplayButton extends MediaChromeButton {
   }
 
   constructor(options: { slotTemplate?: HTMLTemplateElement } = {}) {
-    super({ slotTemplate, ...options });
+    super({ slotTemplate, tooltipContent, ...options });
   }
 
   connectedCallback(): void {

--- a/src/js/media-airplay-button.ts
+++ b/src/js/media-airplay-button.ts
@@ -1,14 +1,13 @@
 import { MediaChromeButton } from './media-chrome-button.js';
 import { globalThis, document } from './utils/server-safe-globals.js';
 import { MediaUIEvents, MediaUIAttributes } from './constants.js';
-import { verbs } from './labels/labels.js';
+import { tooltipLabels, verbs } from './labels/labels.js';
 import {
   getStringAttr,
   setStringAttr,
   getBooleanAttr,
   setBooleanAttr,
 } from './utils/element-utils.js';
-import { capitalize } from './utils/utils.js';
 
 const airplayIcon = `<svg aria-hidden="true" viewBox="0 0 26 24">
   <path d="M22.13 3H3.87a.87.87 0 0 0-.87.87v13.26a.87.87 0 0 0 .87.87h3.4L9 16H5V5h16v11h-4l1.72 2h3.4a.87.87 0 0 0 .87-.87V3.87a.87.87 0 0 0-.86-.87Zm-8.75 11.44a.5.5 0 0 0-.76 0l-4.91 5.73a.5.5 0 0 0 .38.83h9.82a.501.501 0 0 0 .38-.83l-4.91-5.73Z"/>
@@ -46,8 +45,8 @@ slotTemplate.innerHTML = /*html*/ `
 `;
 
 const tooltipContent = /*html*/ `
-  <slot name="tooltip-enter">${capitalize(verbs.ENTER_AIRPLAY())}</slot>
-  <slot name="tooltip-exit">${capitalize(verbs.EXIT_AIRPLAY())}</slot>
+  <slot name="tooltip-enter">${tooltipLabels.ENTER_AIRPLAY}</slot>
+  <slot name="tooltip-exit">${tooltipLabels.EXIT_AIRPLAY}</slot>
 `;
 
 const updateAriaLabel = (el: MediaAirplayButton): void => {

--- a/src/js/media-airplay-button.ts
+++ b/src/js/media-airplay-button.ts
@@ -8,6 +8,7 @@ import {
   getBooleanAttr,
   setBooleanAttr,
 } from './utils/element-utils.js';
+import { capitalize } from './utils/utils.js';
 
 const airplayIcon = `<svg aria-hidden="true" viewBox="0 0 26 24">
   <path d="M22.13 3H3.87a.87.87 0 0 0-.87.87v13.26a.87.87 0 0 0 .87.87h3.4L9 16H5V5h16v11h-4l1.72 2h3.4a.87.87 0 0 0 .87-.87V3.87a.87.87 0 0 0-.86-.87Zm-8.75 11.44a.5.5 0 0 0-.76 0l-4.91 5.73a.5.5 0 0 0 .38.83h9.82a.501.501 0 0 0 .38-.83l-4.91-5.73Z"/>
@@ -45,8 +46,8 @@ slotTemplate.innerHTML = /*html*/ `
 `;
 
 const tooltipContent = /*html*/ `
-  <slot name="tooltip-enter">Start Airplaying</slot>
-  <slot name="tooltip-exit">Stop Airplaying</slot>
+  <slot name="tooltip-enter">${capitalize(verbs.ENTER_AIRPLAY())}</slot>
+  <slot name="tooltip-exit">${capitalize(verbs.EXIT_AIRPLAY())}</slot>
 `;
 
 const updateAriaLabel = (el: MediaAirplayButton): void => {

--- a/src/js/media-audio-track-menu-button.ts
+++ b/src/js/media-audio-track-menu-button.ts
@@ -15,6 +15,11 @@ const audioTrackIcon = /*html*/ `<svg aria-hidden="true" viewBox="0 0 24 24">
 
 const slotTemplate: HTMLTemplateElement = document.createElement('template');
 slotTemplate.innerHTML = /*html*/ `
+  <style>
+    :host([aria-expanded="true"]) slot[name=tooltip] {
+      display: none;
+    }
+  </style>
   <slot name="icon">${audioTrackIcon}</slot>
 `;
 
@@ -34,7 +39,7 @@ class MediaAudioTrackMenuButton extends MediaChromeMenuButton {
   }
 
   constructor() {
-    super({ slotTemplate });
+    super({ slotTemplate, tooltipContent: 'Audio' });
   }
 
   connectedCallback(): void {

--- a/src/js/media-audio-track-menu-button.ts
+++ b/src/js/media-audio-track-menu-button.ts
@@ -1,7 +1,7 @@
 import { MediaUIAttributes } from './constants.js';
 import { MediaChromeMenuButton } from './media-chrome-menu-button.js';
 import { globalThis, document } from './utils/server-safe-globals.js';
-import { nouns } from './labels/labels.js';
+import { nouns, tooltipLabels } from './labels/labels.js';
 import {
   getStringAttr,
   setStringAttr,
@@ -39,7 +39,7 @@ class MediaAudioTrackMenuButton extends MediaChromeMenuButton {
   }
 
   constructor() {
-    super({ slotTemplate, tooltipContent: 'Audio' });
+    super({ slotTemplate, tooltipContent: tooltipLabels.AUDIO_TRACK_MENU });
   }
 
   connectedCallback(): void {

--- a/src/js/media-captions-button.ts
+++ b/src/js/media-captions-button.ts
@@ -28,12 +28,22 @@ slotTemplate.innerHTML = /*html*/ `
     :host(:not([aria-checked="true"])) slot[name=on] {
       display: none !important;
     }
+
+    :host([aria-checked="true"]) slot[name=tooltip-enable],
+    :host(:not([aria-checked="true"])) slot[name=tooltip-disable] {
+      display: none;
+    }
   </style>
 
   <slot name="icon">
     <slot name="on">${ccIconOn}</slot>
     <slot name="off">${ccIconOff}</slot>
   </slot>
+`;
+
+const tooltipContent = /*html*/ `
+  <slot name="tooltip-enable">Enable captions</slot>
+  <slot name="tooltip-disable">Disable captions</slot>
 `;
 
 const updateAriaChecked = (el: HTMLElement) => {
@@ -62,7 +72,7 @@ class MediaCaptionsButton extends MediaChromeButton {
   private _captionsReady: boolean;
 
   constructor(options: any = {}) {
-    super({ slotTemplate, ...options });
+    super({ slotTemplate, tooltipContent, ...options });
     // Internal variable to keep track of when we have some or no captions (or subtitles, if using subtitles fallback)
     // Used for `default-showing` behavior.
     this._captionsReady = false;

--- a/src/js/media-captions-button.ts
+++ b/src/js/media-captions-button.ts
@@ -1,7 +1,7 @@
 import { MediaChromeButton } from './media-chrome-button.js';
 import { globalThis, document } from './utils/server-safe-globals.js';
 import { MediaUIAttributes, MediaUIEvents } from './constants.js';
-import { nouns } from './labels/labels.js';
+import { nouns, tooltipLabels } from './labels/labels.js';
 import {
   areSubsOn,
   parseTextTracksStr,
@@ -42,8 +42,8 @@ slotTemplate.innerHTML = /*html*/ `
 `;
 
 const tooltipContent = /*html*/ `
-  <slot name="tooltip-enable">Enable captions</slot>
-  <slot name="tooltip-disable">Disable captions</slot>
+  <slot name="tooltip-enable">${tooltipLabels.ENABLE_CAPTIONS}</slot>
+  <slot name="tooltip-disable">${tooltipLabels.DISABLE_CAPTIONS}</slot>
 `;
 
 const updateAriaChecked = (el: HTMLElement) => {

--- a/src/js/media-captions-menu-button.ts
+++ b/src/js/media-captions-menu-button.ts
@@ -1,6 +1,6 @@
 import { globalThis, document } from './utils/server-safe-globals.js';
 import { MediaUIAttributes } from './constants.js';
-import { nouns } from './labels/labels.js';
+import { nouns, tooltipLabels } from './labels/labels.js';
 import { MediaChromeMenuButton } from './media-chrome-menu-button.js';
 import { getMediaController } from './utils/element-utils.js';
 import {
@@ -67,7 +67,7 @@ class MediaCaptionsMenuButton extends MediaChromeMenuButton {
   #captionsReady: boolean;
 
   constructor(options: Record<string, any> = {}) {
-    super({ slotTemplate, tooltipContent: 'Captions', ...options });
+    super({ slotTemplate, tooltipContent: tooltipLabels.CAPTIONS, ...options });
     // Internal variable to keep track of when we have some or no captions (or subtitles, if using subtitles fallback)
     // Used for `default-showing` behavior.
     this.#captionsReady = false;

--- a/src/js/media-captions-menu-button.ts
+++ b/src/js/media-captions-menu-button.ts
@@ -29,6 +29,10 @@ slotTemplate.innerHTML = /*html*/ `
     :host(:not([aria-checked="true"])) slot[name=on] {
       display: none !important;
     }
+
+    :host([aria-expanded="true"]) slot[name=tooltip] {
+      display: none;
+    }
   </style>
 
   <slot name="icon">
@@ -63,7 +67,7 @@ class MediaCaptionsMenuButton extends MediaChromeMenuButton {
   #captionsReady: boolean;
 
   constructor(options: Record<string, any> = {}) {
-    super({ slotTemplate, ...options });
+    super({ slotTemplate, tooltipContent: 'Captions', ...options });
     // Internal variable to keep track of when we have some or no captions (or subtitles, if using subtitles fallback)
     // Used for `default-showing` behavior.
     this.#captionsReady = false;

--- a/src/js/media-cast-button.ts
+++ b/src/js/media-cast-button.ts
@@ -1,14 +1,13 @@
 import { MediaChromeButton } from './media-chrome-button.js';
 import { globalThis, document } from './utils/server-safe-globals.js';
 import { MediaUIEvents, MediaUIAttributes } from './constants.js';
-import { verbs } from './labels/labels.js';
+import { tooltipLabels, verbs } from './labels/labels.js';
 import {
   getBooleanAttr,
   setBooleanAttr,
   getStringAttr,
   setStringAttr,
 } from './utils/element-utils.js';
-import { capitalize } from './utils/utils.js';
 
 const enterIcon = `<svg aria-hidden="true" viewBox="0 0 24 24"><g><path class="cast_caf_icon_arch0" d="M1,18 L1,21 L4,21 C4,19.3 2.66,18 1,18 L1,18 Z"/><path class="cast_caf_icon_arch1" d="M1,14 L1,16 C3.76,16 6,18.2 6,21 L8,21 C8,17.13 4.87,14 1,14 L1,14 Z"/><path class="cast_caf_icon_arch2" d="M1,10 L1,12 C5.97,12 10,16.0 10,21 L12,21 C12,14.92 7.07,10 1,10 L1,10 Z"/><path class="cast_caf_icon_box" d="M21,3 L3,3 C1.9,3 1,3.9 1,5 L1,8 L3,8 L3,5 L21,5 L21,19 L14,19 L14,21 L21,21 C22.1,21 23,20.1 23,19 L23,5 C23,3.9 22.1,3 21,3 L21,3 Z"/></g></svg>`;
 
@@ -45,8 +44,8 @@ slotTemplate.innerHTML = /*html*/ `
 `;
 
 const tooltipContent = /*html*/ `
-  <slot name="tooltip-enter">${capitalize(verbs.ENTER_CAST())}</slot>
-  <slot name="tooltip-exit">${capitalize(verbs.EXIT_CAST())}</slot>
+  <slot name="tooltip-enter">${tooltipLabels.START_CAST}</slot>
+  <slot name="tooltip-exit">${tooltipLabels.STOP_CAST}</slot>
 `;
 
 const updateAriaLabel = (el: MediaCastButton) => {

--- a/src/js/media-cast-button.ts
+++ b/src/js/media-cast-button.ts
@@ -18,22 +18,34 @@ slotTemplate.innerHTML = /*html*/ `
   <style>
   :host([${
     MediaUIAttributes.MEDIA_IS_CASTING
-  }]) slot:not([name=exit]):not([name=icon]) {
+  }]) slot[name=icon] slot:not([name=exit]) {
     display: none !important;
   }
 
   ${/* Double negative, but safer if display doesn't equal 'block' */ ''}
   :host(:not([${
     MediaUIAttributes.MEDIA_IS_CASTING
-  }])) slot:not([name=enter]):not([name=icon]) {
+  }])) slot[name=icon] slot:not([name=enter]) {
     display: none !important;
   }
+
+  :host([${MediaUIAttributes.MEDIA_IS_CASTING}]) slot[name=tooltip-enter],
+    :host(:not([${
+      MediaUIAttributes.MEDIA_IS_CASTING
+    }])) slot[name=tooltip-exit] {
+      display: none;
+    }
   </style>
 
   <slot name="icon">
     <slot name="enter">${enterIcon}</slot>
     <slot name="exit">${exitIcon}</slot>
   </slot>
+`;
+
+const tooltipContent = /*html*/ `
+  <slot name="tooltip-enter">Start casting</slot>
+  <slot name="tooltip-exit">Stop casting</slot>
 `;
 
 const updateAriaLabel = (el: MediaCastButton) => {
@@ -61,7 +73,7 @@ class MediaCastButton extends MediaChromeButton {
   }
 
   constructor(options = {}) {
-    super({ slotTemplate, ...options });
+    super({ slotTemplate, tooltipContent, ...options });
   }
 
   connectedCallback(): void {

--- a/src/js/media-cast-button.ts
+++ b/src/js/media-cast-button.ts
@@ -8,6 +8,7 @@ import {
   getStringAttr,
   setStringAttr,
 } from './utils/element-utils.js';
+import { capitalize } from './utils/utils.js';
 
 const enterIcon = `<svg aria-hidden="true" viewBox="0 0 24 24"><g><path class="cast_caf_icon_arch0" d="M1,18 L1,21 L4,21 C4,19.3 2.66,18 1,18 L1,18 Z"/><path class="cast_caf_icon_arch1" d="M1,14 L1,16 C3.76,16 6,18.2 6,21 L8,21 C8,17.13 4.87,14 1,14 L1,14 Z"/><path class="cast_caf_icon_arch2" d="M1,10 L1,12 C5.97,12 10,16.0 10,21 L12,21 C12,14.92 7.07,10 1,10 L1,10 Z"/><path class="cast_caf_icon_box" d="M21,3 L3,3 C1.9,3 1,3.9 1,5 L1,8 L3,8 L3,5 L21,5 L21,19 L14,19 L14,21 L21,21 C22.1,21 23,20.1 23,19 L23,5 C23,3.9 22.1,3 21,3 L21,3 Z"/></g></svg>`;
 
@@ -44,8 +45,8 @@ slotTemplate.innerHTML = /*html*/ `
 `;
 
 const tooltipContent = /*html*/ `
-  <slot name="tooltip-enter">Start casting</slot>
-  <slot name="tooltip-exit">Stop casting</slot>
+  <slot name="tooltip-enter">${capitalize(verbs.ENTER_CAST())}</slot>
+  <slot name="tooltip-exit">${capitalize(verbs.EXIT_CAST())}</slot>
 `;
 
 const updateAriaLabel = (el: MediaCastButton) => {

--- a/src/js/media-chrome-button.ts
+++ b/src/js/media-chrome-button.ts
@@ -1,5 +1,5 @@
 import { MediaStateReceiverAttributes } from './constants.js';
-import MediaTooltip, { TooltipPosition } from './media-tooltip.js';
+import MediaTooltip, { TooltipPlacement } from './media-tooltip.js';
 import {
   getOrInsertCSSRule,
   getStringAttr,
@@ -8,7 +8,7 @@ import {
 import { globalThis, document } from './utils/server-safe-globals.js';
 
 const Attributes = {
-  TOOLTIP_POSITION: 'tooltipposition',
+  TOOLTIP_PLACEMENT: 'tooltipplacement',
 };
 
 const template = document.createElement('template');
@@ -93,7 +93,7 @@ template.innerHTML = /*html*/ `
  *
  * @attr {boolean} disabled - The Boolean disabled attribute makes the element not mutable or focusable.
  * @attr {string} mediacontroller - The element `id` of the media controller to connect to (if not nested within).
- * @attr {('top'|'right'|'bottom'|'left'|'none')} tooltipposition - The position of the tooltip, defaults to "top"
+ * @attr {('top'|'right'|'bottom'|'left'|'none')} tooltipplacement - The placement of the tooltip, defaults to "top"
  *
  * @cssproperty --media-primary-color - Default color of text and icon.
  * @cssproperty --media-secondary-color - Default color of button background.
@@ -126,7 +126,7 @@ class MediaChromeButton extends globalThis.HTMLElement {
   static get observedAttributes() {
     return [
       'disabled',
-      Attributes.TOOLTIP_POSITION,
+      Attributes.TOOLTIP_PLACEMENT,
       MediaStateReceiverAttributes.MEDIA_CONTROLLER,
     ];
   }
@@ -232,11 +232,11 @@ class MediaChromeButton extends globalThis.HTMLElement {
         this.disable();
       }
     } else if (
-      attrName === Attributes.TOOLTIP_POSITION &&
+      attrName === Attributes.TOOLTIP_PLACEMENT &&
       this.tooltip &&
       newValue !== oldValue
     ) {
-      this.tooltip.position = newValue;
+      this.tooltip.placement = newValue;
     }
   }
 
@@ -285,14 +285,14 @@ class MediaChromeButton extends globalThis.HTMLElement {
   }
 
   /**
-   * Get or set tooltip position
+   * Get or set tooltip placement
    */
-  get tooltipPosition(): TooltipPosition | undefined {
-    return getStringAttr(this, Attributes.TOOLTIP_POSITION);
+  get tooltipPlacement(): TooltipPlacement | undefined {
+    return getStringAttr(this, Attributes.TOOLTIP_PLACEMENT);
   }
 
-  set tooltipPosition(value: TooltipPosition | undefined) {
-    setStringAttr(this, Attributes.TOOLTIP_POSITION, value);
+  set tooltipPlacement(value: TooltipPlacement | undefined) {
+    setStringAttr(this, Attributes.TOOLTIP_PLACEMENT, value);
   }
 
   /**
@@ -306,8 +306,8 @@ class MediaChromeButton extends globalThis.HTMLElement {
     this.addEventListener('mouseenter', this.tooltip.updateXOffset);
     this.addEventListener('focus', this.tooltip.updateXOffset);
     this.addEventListener('click', this.#clickListener);
-    const initialPosition = this.tooltipPosition;
-    if (initialPosition) this.tooltip.position = initialPosition;
+    const initialPlacement = this.tooltipPlacement;
+    if (initialPlacement) this.tooltip.placement = initialPlacement;
   }
 }
 

--- a/src/js/media-chrome-button.ts
+++ b/src/js/media-chrome-button.ts
@@ -9,7 +9,6 @@ import { globalThis, document } from './utils/server-safe-globals.js';
 
 const Attributes = {
   TOOLTIP_PLACEMENT: 'tooltipplacement',
-  TOOLTIP: 'tooltip',
 };
 
 const template = document.createElement('template');
@@ -81,7 +80,7 @@ template.innerHTML = /*html*/ `
     opacity: 1;
   }
 
-  :host([tooltip=""]) media-tooltip {
+  :host([notooltip]) slot[name="tooltip"] {
     display: none;
   }
 </style>
@@ -133,7 +132,6 @@ class MediaChromeButton extends globalThis.HTMLElement {
     return [
       'disabled',
       Attributes.TOOLTIP_PLACEMENT,
-      Attributes.TOOLTIP,
       MediaStateReceiverAttributes.MEDIA_CONTROLLER,
     ];
   }
@@ -245,21 +243,6 @@ class MediaChromeButton extends globalThis.HTMLElement {
       newValue !== oldValue
     ) {
       this.tooltipEl.placement = newValue;
-    } else if (
-      attrName === Attributes.TOOLTIP &&
-      this.tooltipEl &&
-      newValue !== oldValue
-    ) {
-      const contentEl = this.tooltipEl.querySelector(
-        'slot[name="tooltip-content"]'
-      );
-      if (!contentEl) return;
-      if (newValue == null) {
-        // reset it to what it was initially configured to be through constructor options
-        contentEl.innerHTML = this.tooltipContent;
-        return;
-      }
-      contentEl.innerHTML = newValue;
     }
   }
 
@@ -316,17 +299,6 @@ class MediaChromeButton extends globalThis.HTMLElement {
 
   set tooltipPlacement(value: TooltipPlacement | undefined) {
     setStringAttr(this, Attributes.TOOLTIP_PLACEMENT, value);
-  }
-
-  /**
-   * Get or set tooltip label
-   */
-  get tooltip(): string | undefined {
-    return getStringAttr(this, Attributes.TOOLTIP);
-  }
-
-  set tooltip(value: string | undefined) {
-    setStringAttr(this, Attributes.TOOLTIP, value);
   }
 
   /**

--- a/src/js/media-chrome-button.ts
+++ b/src/js/media-chrome-button.ts
@@ -80,6 +80,12 @@ template.innerHTML = /*html*/ `
     opacity: 1;
   }
 </style>
+
+<slot name="tooltip">
+  <media-tooltip>
+    <slot name="tooltip-content"></slot>
+  </media-tooltip>
+</slot>
 `;
 
 /**
@@ -129,6 +135,7 @@ class MediaChromeButton extends globalThis.HTMLElement {
     options: Partial<{
       slotTemplate: HTMLTemplateElement;
       defaultContent: string;
+      tooltipContent: string;
     }> = {}
   ) {
     super();
@@ -146,6 +153,11 @@ class MediaChromeButton extends globalThis.HTMLElement {
       if (!slotTemplate) {
         slotTemplate = document.createElement('template');
         slotTemplate.innerHTML = `<slot>${options.defaultContent || ''}</slot>`;
+      }
+
+      if (options.tooltipContent) {
+        buttonHTML.querySelector('slot[name="tooltip-content"]').innerHTML =
+          options.tooltipContent ?? '';
       }
 
       this.nativeEl.appendChild(slotTemplate.content.cloneNode(true));

--- a/src/js/media-chrome-button.ts
+++ b/src/js/media-chrome-button.ts
@@ -69,8 +69,7 @@ template.innerHTML = /*html*/ `
     transition: opacity .3s;
   }
 
-  :host(:hover) media-tooltip,
-  :host(:focus) media-tooltip {
+  :host(:hover) media-tooltip {
     opacity: 1;
   }
 </style>

--- a/src/js/media-chrome-button.ts
+++ b/src/js/media-chrome-button.ts
@@ -7,6 +7,7 @@ const template = document.createElement('template');
 template.innerHTML = /*html*/ `
 <style>
   :host {
+    position: relative;
     font: var(--media-font,
       var(--media-font-weight, bold)
       var(--media-font-size, 14px) /
@@ -60,6 +61,19 @@ template.innerHTML = /*html*/ `
     max-width: 100%;
     max-height: 100%;
     min-width: 100%;
+  }
+
+  media-tooltip {
+    position: absolute;
+    bottom: calc(100% + 12px);
+    left: 50%;
+    transform: translate(-50%, 0);
+    opacity: 0;
+    transition: opacity .3s;
+  }
+
+  :host(:hover) media-tooltip {
+    opacity: 1;
   }
 </style>
 `;

--- a/src/js/media-chrome-button.ts
+++ b/src/js/media-chrome-button.ts
@@ -15,27 +15,36 @@ const updateTooltipPosition = (
 ): void => {
   const containingEl = closestComposedNode(tooltipEl, containingSelector);
   if (!containingEl) return;
-  const { x: containerX } = containingEl.getBoundingClientRect();
-  const { x: tooltipX } = tooltipEl.getBoundingClientRect();
+  const { x: containerX, width: containerWidth } =
+    containingEl.getBoundingClientRect();
+  const { x: tooltipX, width: tooltipWidth } =
+    tooltipEl.getBoundingClientRect();
+  const tooltipRight = tooltipX + tooltipWidth;
+  const containerRight = containerX + containerWidth;
   const offsetXVal = tooltipEl.style.getPropertyValue(
     '--media-tooltip-offset-x'
   );
   const currOffsetX = offsetXVal ? parseFloat(offsetXVal.replace('px', '')) : 0;
 
-  // we might have already offset the tooltip previously so we take remove it's
+  // we might have already offset the tooltip previously so we remove it's
   // current offset from our calculations
-  const xDiff = tooltipX - containerX + currOffsetX;
+  const leftDiff = tooltipX - containerX + currOffsetX;
+  const rightDiff = tooltipRight - containerRight + currOffsetX;
 
-  // not spilling out left
-  if (xDiff > 0) {
-    tooltipEl.style.removeProperty('--media-tooltip-offset-x');
+  // out of left bounds
+  if (leftDiff < 0) {
+    tooltipEl.style.setProperty('--media-tooltip-offset-x', `${leftDiff}px`);
     return;
   }
 
-  tooltipEl.style.setProperty('--media-tooltip-offset-x', `${xDiff}px`);
+  // out of right bounds
+  if (rightDiff > 0) {
+    tooltipEl.style.setProperty('--media-tooltip-offset-x', `${rightDiff}px`);
+    return;
+  }
 
-  // right edge
-  // TODO: ...
+  // no spilling out
+  tooltipEl.style.removeProperty('--media-tooltip-offset-x');
 };
 
 const template = document.createElement('template');

--- a/src/js/media-chrome-button.ts
+++ b/src/js/media-chrome-button.ts
@@ -246,6 +246,16 @@ class MediaChromeButton extends globalThis.HTMLElement {
     ) {
       this.tooltipEl.placement = newValue;
     }
+
+    // The tooltips label, and subsequently it's size and position, are a function
+    // of the buttons state, so we greedily assume we need account for any form
+    // of state change by reacting to all attribute changes, even if sometimes the
+    // update might be redundant
+    if (this.tooltipEl) {
+      // conditional chaining accounts for scenarios where the tooltip element isn't
+      // yet defined
+      this.tooltipEl?.updateXOffset?.();
+    }
   }
 
   connectedCallback() {

--- a/src/js/media-chrome-button.ts
+++ b/src/js/media-chrome-button.ts
@@ -76,7 +76,8 @@ template.innerHTML = /*html*/ `
     transition: opacity .3s;
   }
 
-  :host(:hover) media-tooltip {
+  :host(:hover) media-tooltip,
+  :host(:focus-visible) media-tooltip {
     opacity: 1;
   }
 

--- a/src/js/media-chrome-button.ts
+++ b/src/js/media-chrome-button.ts
@@ -1,10 +1,17 @@
 import { MediaStateReceiverAttributes } from './constants.js';
 import MediaTooltip, { TooltipPosition } from './media-tooltip.js';
-import { getOrInsertCSSRule } from './utils/element-utils.js';
+import {
+  getOrInsertCSSRule,
+  getStringAttr,
+  setStringAttr,
+} from './utils/element-utils.js';
 import { globalThis, document } from './utils/server-safe-globals.js';
 
-const template = document.createElement('template');
+const Attributes = {
+  TOOLTIP_POSITION: 'tooltipposition',
+};
 
+const template = document.createElement('template');
 template.innerHTML = /*html*/ `
 <style>
   :host {
@@ -113,7 +120,7 @@ class MediaChromeButton extends globalThis.HTMLElement {
   static get observedAttributes() {
     return [
       'disabled',
-      'tooltipposition',
+      Attributes.TOOLTIP_POSITION,
       MediaStateReceiverAttributes.MEDIA_CONTROLLER,
     ];
   }
@@ -208,7 +215,10 @@ class MediaChromeButton extends globalThis.HTMLElement {
       } else {
         this.disable();
       }
-    } else if (attrName === 'tooltipposition' && newValue !== oldValue) {
+    } else if (
+      attrName === Attributes.TOOLTIP_POSITION &&
+      newValue !== oldValue
+    ) {
       // If the tooltip isn't defined, then we could accidentally overwrite
       // the '.position' property
       if (this.tooltip && globalThis.customElements.get('media-tooltip')) {
@@ -267,6 +277,17 @@ class MediaChromeButton extends globalThis.HTMLElement {
   }
 
   /**
+   * Get or set tooltip position
+   */
+  get tooltipPosition(): TooltipPosition | undefined {
+    return getStringAttr(this, Attributes.TOOLTIP_POSITION);
+  }
+
+  set tooltipPosition(value: TooltipPosition | undefined) {
+    setStringAttr(this, Attributes.TOOLTIP_POSITION, value);
+  }
+
+  /**
    * @abstract
    * @argument {Event} e
    */
@@ -281,9 +302,7 @@ class MediaChromeButton extends globalThis.HTMLElement {
       // measured position does not take into account the new tooltip content
       setTimeout(this.tooltip.updateXOffset, 0);
     });
-    const initialPosition = this.getAttribute(
-      'tooltipposition'
-    ) as TooltipPosition;
+    const initialPosition = this.tooltipPosition;
     if (initialPosition) this.tooltip.position = initialPosition;
   }
 }

--- a/src/js/media-chrome-button.ts
+++ b/src/js/media-chrome-button.ts
@@ -1,5 +1,5 @@
 import { MediaStateReceiverAttributes } from './constants.js';
-import MediaTooltip from './media-tooltip.js';
+import MediaTooltip, { TooltipPosition } from './media-tooltip.js';
 import { getOrInsertCSSRule } from './utils/element-utils.js';
 import { globalThis, document } from './utils/server-safe-globals.js';
 
@@ -278,7 +278,9 @@ class MediaChromeButton extends globalThis.HTMLElement {
       // measured position does not take into account the new tooltip content
       setTimeout(this.tooltip.updateXOffset, 0);
     });
-    const initialPosition = this.getAttribute('tooltipposition');
+    const initialPosition = this.getAttribute(
+      'tooltipposition'
+    ) as TooltipPosition;
     if (initialPosition) this.tooltip.position = initialPosition;
   }
 }

--- a/src/js/media-chrome-button.ts
+++ b/src/js/media-chrome-button.ts
@@ -221,13 +221,10 @@ class MediaChromeButton extends globalThis.HTMLElement {
       }
     } else if (
       attrName === Attributes.TOOLTIP_POSITION &&
+      this.tooltip &&
       newValue !== oldValue
     ) {
-      // If the tooltip isn't defined, then we could accidentally overwrite
-      // the '.position' property
-      if (this.tooltip && globalThis.customElements.get('media-tooltip')) {
-        this.tooltip.position = newValue;
-      }
+      this.tooltip.position = newValue;
     }
   }
 

--- a/src/js/media-chrome-button.ts
+++ b/src/js/media-chrome-button.ts
@@ -250,13 +250,9 @@ class MediaChromeButton extends globalThis.HTMLElement {
       this.#mediaController?.associateElement?.(this);
     }
 
-    if (window.customElements.get('media-tooltip')) {
-      this.setupTooltip();
-    } else {
-      globalThis.customElements
-        .whenDefined('media-tooltip')
-        .then(this.setupTooltip.bind(this));
-    }
+    globalThis.customElements
+      .whenDefined('media-tooltip')
+      .then(this.setupTooltip.bind(this));
   }
 
   disconnectedCallback() {

--- a/src/js/media-chrome-button.ts
+++ b/src/js/media-chrome-button.ts
@@ -69,7 +69,8 @@ template.innerHTML = /*html*/ `
     transition: opacity .3s;
   }
 
-  :host(:hover) media-tooltip {
+  :host(:hover) media-tooltip,
+  :host(:focus) media-tooltip {
     opacity: 1;
   }
 </style>
@@ -256,8 +257,10 @@ class MediaChromeButton extends globalThis.HTMLElement {
     this.#mediaController = null;
 
     this.removeEventListener('mouseenter', this.tooltip?.updateXOffset);
+    this.removeEventListener('focus', this.tooltip?.updateXOffset);
     // TODO: how to remove this correctly?
     // this.removeEventListener('click', this.tooltip?.updatePosition);
+    this.tooltip = null;
   }
 
   get keysUsed() {
@@ -273,6 +276,7 @@ class MediaChromeButton extends globalThis.HTMLElement {
   // Called when we know the tooltip is ready / defined
   setupTooltip() {
     this.addEventListener('mouseenter', this.tooltip.updateXOffset);
+    this.addEventListener('focus', this.tooltip.updateXOffset);
     this.addEventListener('click', () => {
       // Timeout needed to wait for a new "tick" of event loop otherwise
       // measured position does not take into account the new tooltip content

--- a/src/js/media-chrome-button.ts
+++ b/src/js/media-chrome-button.ts
@@ -98,6 +98,7 @@ template.innerHTML = /*html*/ `
  * @attr {boolean} disabled - The Boolean disabled attribute makes the element not mutable or focusable.
  * @attr {string} mediacontroller - The element `id` of the media controller to connect to (if not nested within).
  * @attr {('top'|'right'|'bottom'|'left'|'none')} tooltipplacement - The placement of the tooltip, defaults to "top"
+ * @attr {boolean} notooltip - Hides the tooltip if this attribute is present
  *
  * @cssproperty --media-primary-color - Default color of text and icon.
  * @cssproperty --media-secondary-color - Default color of button background.

--- a/src/js/media-chrome-button.ts
+++ b/src/js/media-chrome-button.ts
@@ -160,6 +160,10 @@ class MediaChromeButton extends globalThis.HTMLElement {
     if (!this.preventClick) {
       this.handleClick(e);
     }
+
+    // Timeout needed to wait for a new "tick" of event loop otherwise
+    // measured position does not take into account the new tooltip content
+    setTimeout(this.tooltip.updateXOffset, 0);
   };
 
   // NOTE: There are definitely some "false positive" cases with multi-key pressing,
@@ -263,8 +267,7 @@ class MediaChromeButton extends globalThis.HTMLElement {
 
     this.removeEventListener('mouseenter', this.tooltip?.updateXOffset);
     this.removeEventListener('focus', this.tooltip?.updateXOffset);
-    // TODO: how to remove this correctly?
-    // this.removeEventListener('click', this.tooltip?.updatePosition);
+    this.removeEventListener('click', this.#clickListener);
     this.tooltip = null;
   }
 
@@ -293,11 +296,7 @@ class MediaChromeButton extends globalThis.HTMLElement {
   setupTooltip() {
     this.addEventListener('mouseenter', this.tooltip.updateXOffset);
     this.addEventListener('focus', this.tooltip.updateXOffset);
-    this.addEventListener('click', () => {
-      // Timeout needed to wait for a new "tick" of event loop otherwise
-      // measured position does not take into account the new tooltip content
-      setTimeout(this.tooltip.updateXOffset, 0);
-    });
+    this.addEventListener('click', this.#clickListener);
     const initialPosition = this.tooltipPosition;
     if (initialPosition) this.tooltip.position = initialPosition;
   }

--- a/src/js/media-fullscreen-button.ts
+++ b/src/js/media-fullscreen-button.ts
@@ -16,6 +16,7 @@ import {
   setBooleanAttr,
   setStringAttr,
 } from './utils/element-utils.js';
+import { capitalize } from './utils/utils.js';
 
 const enterFullscreenIcon = `<svg aria-hidden="true" viewBox="0 0 26 24">
   <path d="M16 3v2.5h3.5V9H22V3h-6ZM4 9h2.5V5.5H10V3H4v6Zm15.5 9.5H16V21h6v-6h-2.5v3.5ZM6.5 15H4v6h6v-2.5H6.5V15Z"/>
@@ -56,8 +57,8 @@ slotTemplate.innerHTML = /*html*/ `
 `;
 
 const tooltipContent = /*html*/ `
-  <slot name="tooltip-enter">Enter fullscreen</slot>
-  <slot name="tooltip-exit">Exit fullscreen</slot>
+  <slot name="tooltip-enter">${capitalize(verbs.ENTER_FULLSCREEN())}</slot>
+  <slot name="tooltip-exit">${capitalize(verbs.EXIT_FULLSCREEN())}</slot>
 `;
 
 const updateAriaLabel = (el: MediaFullscreenButton) => {

--- a/src/js/media-fullscreen-button.ts
+++ b/src/js/media-fullscreen-button.ts
@@ -9,14 +9,13 @@
 import { MediaChromeButton } from './media-chrome-button.js';
 import { globalThis, document } from './utils/server-safe-globals.js';
 import { MediaUIEvents, MediaUIAttributes } from './constants.js';
-import { verbs } from './labels/labels.js';
+import { tooltipLabels, verbs } from './labels/labels.js';
 import {
   getBooleanAttr,
   getStringAttr,
   setBooleanAttr,
   setStringAttr,
 } from './utils/element-utils.js';
-import { capitalize } from './utils/utils.js';
 
 const enterFullscreenIcon = `<svg aria-hidden="true" viewBox="0 0 26 24">
   <path d="M16 3v2.5h3.5V9H22V3h-6ZM4 9h2.5V5.5H10V3H4v6Zm15.5 9.5H16V21h6v-6h-2.5v3.5ZM6.5 15H4v6h6v-2.5H6.5V15Z"/>
@@ -57,8 +56,8 @@ slotTemplate.innerHTML = /*html*/ `
 `;
 
 const tooltipContent = /*html*/ `
-  <slot name="tooltip-enter">${capitalize(verbs.ENTER_FULLSCREEN())}</slot>
-  <slot name="tooltip-exit">${capitalize(verbs.EXIT_FULLSCREEN())}</slot>
+  <slot name="tooltip-enter">${tooltipLabels.ENTER_FULLSCREEN}</slot>
+  <slot name="tooltip-exit">${tooltipLabels.EXIT_FULLSCREEN}</slot>
 `;
 
 const updateAriaLabel = (el: MediaFullscreenButton) => {

--- a/src/js/media-fullscreen-button.ts
+++ b/src/js/media-fullscreen-button.ts
@@ -28,24 +28,36 @@ const exitFullscreenIcon = `<svg aria-hidden="true" viewBox="0 0 26 24">
 const slotTemplate = document.createElement('template');
 slotTemplate.innerHTML = /*html*/ `
   <style>
-  :host([${
-    MediaUIAttributes.MEDIA_IS_FULLSCREEN
-  }]) slot:not([name=exit]):not([name=icon]) {
-    display: none !important;
-  }
+    :host([${
+      MediaUIAttributes.MEDIA_IS_FULLSCREEN
+    }]) slot[name=icon] slot:not([name=exit]) {
+      display: none !important;
+    }
 
-  ${/* Double negative, but safer if display doesn't equal 'block' */ ''}
-  :host(:not([${
-    MediaUIAttributes.MEDIA_IS_FULLSCREEN
-  }])) slot:not([name=enter]):not([name=icon]) {
-    display: none !important;
-  }
+    ${/* Double negative, but safer if display doesn't equal 'block' */ ''}
+    :host(:not([${
+      MediaUIAttributes.MEDIA_IS_FULLSCREEN
+    }])) slot[name=icon] slot:not([name=enter]) {
+      display: none !important;
+    }
+
+    :host([${MediaUIAttributes.MEDIA_IS_FULLSCREEN}]) slot[name=tooltip-enter],
+    :host(:not([${
+      MediaUIAttributes.MEDIA_IS_FULLSCREEN
+    }])) slot[name=tooltip-exit] {
+      display: none;
+    }
   </style>
 
   <slot name="icon">
     <slot name="enter">${enterFullscreenIcon}</slot>
     <slot name="exit">${exitFullscreenIcon}</slot>
   </slot>
+`;
+
+const tooltipContent = /*html*/ `
+  <slot name="tooltip-enter">Enter fullscreen</slot>
+  <slot name="tooltip-exit">Exit fullscreen</slot>
 `;
 
 const updateAriaLabel = (el: MediaFullscreenButton) => {
@@ -75,7 +87,7 @@ class MediaFullscreenButton extends MediaChromeButton {
   }
 
   constructor(options: object = {}) {
-    super({ slotTemplate, ...options });
+    super({ slotTemplate, tooltipContent, ...options });
   }
 
   connectedCallback(): void {

--- a/src/js/media-live-button.ts
+++ b/src/js/media-live-button.ts
@@ -13,7 +13,8 @@ const indicatorSVG =
 const slotTemplate = document.createElement('template');
 slotTemplate.innerHTML = /*html*/ `
   <style>
-
+  :host { --media-tooltip-display: none; }
+  
   slot[name=indicator] > *,
   :host ::slotted([slot=indicator]) {
     ${/* Override styles for icon-only buttons */ ''}

--- a/src/js/media-mute-button.ts
+++ b/src/js/media-mute-button.ts
@@ -1,9 +1,8 @@
 import { MediaChromeButton } from './media-chrome-button.js';
 import { globalThis, document } from './utils/server-safe-globals.js';
 import { MediaUIEvents, MediaUIAttributes } from './constants.js';
-import { verbs } from './labels/labels.js';
+import { tooltipLabels, verbs } from './labels/labels.js';
 import { getStringAttr, setStringAttr } from './utils/element-utils.js';
-import { capitalize } from './utils/utils.js';
 
 const { MEDIA_VOLUME_LEVEL } = MediaUIAttributes;
 
@@ -55,8 +54,8 @@ slotTemplate.innerHTML = /*html*/ `
 `;
 
 const tooltipContent = /*html*/ `
-  <slot name="tooltip-mute">${capitalize(verbs.MUTE())}</slot>
-  <slot name="tooltip-unmute">${capitalize(verbs.UNMUTE())}</slot>
+  <slot name="tooltip-mute">${tooltipLabels.MUTE}</slot>
+  <slot name="tooltip-unmute">${tooltipLabels.UNMUTE}</slot>
 `;
 
 const updateAriaLabel = (el: MediaMuteButton) => {

--- a/src/js/media-mute-button.ts
+++ b/src/js/media-mute-button.ts
@@ -3,6 +3,7 @@ import { globalThis, document } from './utils/server-safe-globals.js';
 import { MediaUIEvents, MediaUIAttributes } from './constants.js';
 import { verbs } from './labels/labels.js';
 import { getStringAttr, setStringAttr } from './utils/element-utils.js';
+import { capitalize } from './utils/utils.js';
 
 const { MEDIA_VOLUME_LEVEL } = MediaUIAttributes;
 
@@ -54,8 +55,8 @@ slotTemplate.innerHTML = /*html*/ `
 `;
 
 const tooltipContent = /*html*/ `
-  <slot name="tooltip-mute">Mute</slot>
-  <slot name="tooltip-unmute">Unmute</slot>
+  <slot name="tooltip-mute">${capitalize(verbs.MUTE())}</slot>
+  <slot name="tooltip-unmute">${capitalize(verbs.UNMUTE())}</slot>
 `;
 
 const updateAriaLabel = (el: MediaMuteButton) => {

--- a/src/js/media-mute-button.ts
+++ b/src/js/media-mute-button.ts
@@ -22,21 +22,26 @@ const slotTemplate = document.createElement('template');
 slotTemplate.innerHTML = /*html*/ `
   <style>
   ${/* Default to High slot/icon. */ ''}
-  :host(:not([${MEDIA_VOLUME_LEVEL}])) slot:not([name=high]):not([name=icon]), 
-  :host([${MEDIA_VOLUME_LEVEL}=high]) slot:not([name=high]):not([name=icon]) {
+  :host(:not([${MEDIA_VOLUME_LEVEL}])) slot[name=icon] slot:not([name=high]), 
+  :host([${MEDIA_VOLUME_LEVEL}=high]) slot[name=icon] slot:not([name=high]) {
     display: none !important;
   }
 
-  :host([${MEDIA_VOLUME_LEVEL}=off]) slot:not([name=off]):not([name=icon]) {
+  :host([${MEDIA_VOLUME_LEVEL}=off]) slot[name=icon] slot:not([name=off]) {
     display: none !important;
   }
 
-  :host([${MEDIA_VOLUME_LEVEL}=low]) slot:not([name=low]):not([name=icon]) {
+  :host([${MEDIA_VOLUME_LEVEL}=low]) slot[name=icon] slot:not([name=low]) {
     display: none !important;
   }
 
-  :host([${MEDIA_VOLUME_LEVEL}=medium]) slot:not([name=medium]):not([name=icon]) {
+  :host([${MEDIA_VOLUME_LEVEL}=medium]) slot[name=icon] slot:not([name=medium]) {
     display: none !important;
+  }
+
+  :host(:not([${MEDIA_VOLUME_LEVEL}=off])) slot[name=tooltip-unmute],
+  :host([${MEDIA_VOLUME_LEVEL}=off]) slot[name=tooltip-mute] {
+    display: none;
   }
   </style>
 
@@ -46,6 +51,11 @@ slotTemplate.innerHTML = /*html*/ `
     <slot name="medium">${lowIcon}</slot>
     <slot name="high">${highIcon}</slot>
   </slot>
+`;
+
+const tooltipContent = /*html*/ `
+  <slot name="tooltip-mute">Mute</slot>
+  <slot name="tooltip-unmute">Unmute</slot>
 `;
 
 const updateAriaLabel = (el: MediaMuteButton) => {
@@ -71,7 +81,7 @@ class MediaMuteButton extends MediaChromeButton {
   }
 
   constructor(options: object = {}) {
-    super({ slotTemplate, ...options });
+    super({ slotTemplate, tooltipContent, ...options });
   }
 
   connectedCallback(): void {

--- a/src/js/media-pip-button.ts
+++ b/src/js/media-pip-button.ts
@@ -18,15 +18,20 @@ slotTemplate.innerHTML = /*html*/ `
   <style>
   :host([${
     MediaUIAttributes.MEDIA_IS_PIP
-  }]) slot:not([name=exit]):not([name=icon]) {
+  }]) slot[name=icon] slot:not([name=exit]) {
     display: none !important;
   }
 
   ${/* Double negative, but safer if display doesn't equal 'block' */ ''}
   :host(:not([${
     MediaUIAttributes.MEDIA_IS_PIP
-  }])) slot:not([name=enter]):not([name=icon]) {
+  }])) slot[name=icon] slot:not([name=enter]) {
     display: none !important;
+  }
+
+  :host([${MediaUIAttributes.MEDIA_IS_PIP}]) slot[name=tooltip-enter],
+  :host(:not([${MediaUIAttributes.MEDIA_IS_PIP}])) slot[name=tooltip-exit] {
+    display: none;
   }
   </style>
 
@@ -34,6 +39,11 @@ slotTemplate.innerHTML = /*html*/ `
     <slot name="enter">${pipIcon}</slot>
     <slot name="exit">${pipIcon}</slot>
   </slot>
+`;
+
+const tooltipContent = /*html*/ `
+  <slot name="tooltip-enter">Enter picture in picture mode</slot>
+  <slot name="tooltip-exit">Exit picture in picture mode</slot>
 `;
 
 const updateAriaLabel = (el: MediaPipButton): void => {
@@ -61,7 +71,7 @@ class MediaPipButton extends MediaChromeButton {
   }
 
   constructor(options: object = {}) {
-    super({ slotTemplate, ...options });
+    super({ slotTemplate, tooltipContent, ...options });
   }
 
   connectedCallback(): void {

--- a/src/js/media-pip-button.ts
+++ b/src/js/media-pip-button.ts
@@ -8,6 +8,7 @@ import {
   setBooleanAttr,
   setStringAttr,
 } from './utils/element-utils.js';
+import { capitalize } from './utils/utils.js';
 
 const pipIcon = `<svg aria-hidden="true" viewBox="0 0 28 24">
   <path d="M24 3H4a1 1 0 0 0-1 1v16a1 1 0 0 0 1 1h20a1 1 0 0 0 1-1V4a1 1 0 0 0-1-1Zm-1 16H5V5h18v14Zm-3-8h-7v5h7v-5Z"/>
@@ -42,8 +43,8 @@ slotTemplate.innerHTML = /*html*/ `
 `;
 
 const tooltipContent = /*html*/ `
-  <slot name="tooltip-enter">Enter picture in picture mode</slot>
-  <slot name="tooltip-exit">Exit picture in picture mode</slot>
+  <slot name="tooltip-enter">${capitalize(verbs.ENTER_PIP())}</slot>
+  <slot name="tooltip-exit">${capitalize(verbs.EXIT_PIP())}</slot>
 `;
 
 const updateAriaLabel = (el: MediaPipButton): void => {

--- a/src/js/media-pip-button.ts
+++ b/src/js/media-pip-button.ts
@@ -1,14 +1,13 @@
 import { MediaChromeButton } from './media-chrome-button.js';
 import { globalThis, document } from './utils/server-safe-globals.js';
 import { MediaUIEvents, MediaUIAttributes } from './constants.js';
-import { verbs } from './labels/labels.js';
+import { tooltipLabels, verbs } from './labels/labels.js';
 import {
   getBooleanAttr,
   getStringAttr,
   setBooleanAttr,
   setStringAttr,
 } from './utils/element-utils.js';
-import { capitalize } from './utils/utils.js';
 
 const pipIcon = `<svg aria-hidden="true" viewBox="0 0 28 24">
   <path d="M24 3H4a1 1 0 0 0-1 1v16a1 1 0 0 0 1 1h20a1 1 0 0 0 1-1V4a1 1 0 0 0-1-1Zm-1 16H5V5h18v14Zm-3-8h-7v5h7v-5Z"/>
@@ -43,8 +42,8 @@ slotTemplate.innerHTML = /*html*/ `
 `;
 
 const tooltipContent = /*html*/ `
-  <slot name="tooltip-enter">${capitalize(verbs.ENTER_PIP())}</slot>
-  <slot name="tooltip-exit">${capitalize(verbs.EXIT_PIP())}</slot>
+  <slot name="tooltip-enter">${tooltipLabels.ENTER_PIP}</slot>
+  <slot name="tooltip-exit">${tooltipLabels.EXIT_PIP}</slot>
 `;
 
 const updateAriaLabel = (el: MediaPipButton): void => {

--- a/src/js/media-play-button.ts
+++ b/src/js/media-play-button.ts
@@ -28,6 +28,7 @@ slotTemplate.innerHTML = /*html*/ `
     <slot name="play">${playIcon}</slot>
     <slot name="pause">${pauseIcon}</slot>
   </slot>
+  <media-tooltip id="tooltip">Play</media-tooltip>
 `;
 
 const updateAriaLabel = (el: any): void => {

--- a/src/js/media-play-button.ts
+++ b/src/js/media-play-button.ts
@@ -3,6 +3,7 @@ import { globalThis, document } from './utils/server-safe-globals.js';
 import { MediaUIEvents, MediaUIAttributes } from './constants.js';
 import { verbs } from './labels/labels.js';
 import { getBooleanAttr, setBooleanAttr } from './utils/element-utils.js';
+import { capitalize } from './utils/utils.js';
 
 const playIcon = `<svg aria-hidden="true" viewBox="0 0 24 24">
   <path d="m6 21 15-9L6 3v18Z"/>
@@ -33,8 +34,8 @@ slotTemplate.innerHTML = /*html*/ `
 `;
 
 const tooltipContent = /*html*/ `
-  <slot name="tooltip-play">Play</slot>
-  <slot name="tooltip-pause">Pause</slot>
+  <slot name="tooltip-play">${capitalize(verbs.PLAY())}</slot>
+  <slot name="tooltip-pause">${capitalize(verbs.PAUSE())}</slot>
 `;
 
 const updateAriaLabel = (el: any): void => {

--- a/src/js/media-play-button.ts
+++ b/src/js/media-play-button.ts
@@ -15,12 +15,15 @@ const pauseIcon = `<svg aria-hidden="true" viewBox="0 0 24 24">
 const slotTemplate: HTMLTemplateElement = document.createElement('template');
 slotTemplate.innerHTML = /*html*/ `
   <style>
-  :host([${MediaUIAttributes.MEDIA_PAUSED}]) slot[name=pause],
-  :host(:not([${MediaUIAttributes.MEDIA_PAUSED}])) slot[name=play],
-  :host([${MediaUIAttributes.MEDIA_PAUSED}]) slot[name=tooltip-pause],
-  :host(:not([${MediaUIAttributes.MEDIA_PAUSED}])) slot[name=tooltip-play] {
-    display: none !important;
-  }
+    :host([${MediaUIAttributes.MEDIA_PAUSED}]) slot[name=pause],
+    :host(:not([${MediaUIAttributes.MEDIA_PAUSED}])) slot[name=play] {
+      display: none !important;
+    }
+
+    :host([${MediaUIAttributes.MEDIA_PAUSED}]) slot[name=tooltip-pause],
+    :host(:not([${MediaUIAttributes.MEDIA_PAUSED}])) slot[name=tooltip-play] {
+      display: none;
+    }
   </style>
 
   <slot name="icon">
@@ -28,7 +31,7 @@ slotTemplate.innerHTML = /*html*/ `
     <slot name="pause">${pauseIcon}</slot>
   </slot>
   <slot name="tooltip">
-    <media-tooltip container="media-control-bar">
+    <media-tooltip>
       <slot name="tooltip-play">Play</slot>
       <slot name="tooltip-pause">Pause</slot>
     </media-tooltip>

--- a/src/js/media-play-button.ts
+++ b/src/js/media-play-button.ts
@@ -27,10 +27,12 @@ slotTemplate.innerHTML = /*html*/ `
     <slot name="play">${playIcon}</slot>
     <slot name="pause">${pauseIcon}</slot>
   </slot>
-  <media-tooltip>
-    <slot name="tooltip-play">Play</slot>
-    <slot name="tooltip-pause">Pause</slot>
-  </media-tooltip>
+  <slot name="tooltip">
+    <media-tooltip>
+      <slot name="tooltip-play">Play</slot>
+      <slot name="tooltip-pause">Pause</slot>
+    </media-tooltip>
+  </slot>
 `;
 
 const updateAriaLabel = (el: any): void => {

--- a/src/js/media-play-button.ts
+++ b/src/js/media-play-button.ts
@@ -28,7 +28,9 @@ slotTemplate.innerHTML = /*html*/ `
     <slot name="play">${playIcon}</slot>
     <slot name="pause">${pauseIcon}</slot>
   </slot>
-  <media-tooltip id="tooltip">Play</media-tooltip>
+  <media-tooltip id="tooltip">
+    <slot name="tooltip">Play</slot>
+  </media-tooltip>
 `;
 
 const updateAriaLabel = (el: any): void => {

--- a/src/js/media-play-button.ts
+++ b/src/js/media-play-button.ts
@@ -30,12 +30,11 @@ slotTemplate.innerHTML = /*html*/ `
     <slot name="play">${playIcon}</slot>
     <slot name="pause">${pauseIcon}</slot>
   </slot>
-  <slot name="tooltip">
-    <media-tooltip>
-      <slot name="tooltip-play">Play</slot>
-      <slot name="tooltip-pause">Pause</slot>
-    </media-tooltip>
-  </slot>
+`;
+
+const tooltipContent = /*html*/ `
+  <slot name="tooltip-play">Play</slot>
+  <slot name="tooltip-pause">Pause</slot>
 `;
 
 const updateAriaLabel = (el: any): void => {
@@ -62,7 +61,7 @@ class MediaPlayButton extends MediaChromeButton {
   }
 
   constructor(options = {}) {
-    super({ slotTemplate, ...options });
+    super({ slotTemplate, tooltipContent, ...options });
   }
 
   connectedCallback(): void {

--- a/src/js/media-play-button.ts
+++ b/src/js/media-play-button.ts
@@ -15,11 +15,10 @@ const pauseIcon = `<svg aria-hidden="true" viewBox="0 0 24 24">
 const slotTemplate: HTMLTemplateElement = document.createElement('template');
 slotTemplate.innerHTML = /*html*/ `
   <style>
-  :host([${MediaUIAttributes.MEDIA_PAUSED}]) slot[name=pause] {
-    display: none !important;
-  }
-
-  :host(:not([${MediaUIAttributes.MEDIA_PAUSED}])) slot[name=play] {
+  :host([${MediaUIAttributes.MEDIA_PAUSED}]) slot[name=pause],
+  :host(:not([${MediaUIAttributes.MEDIA_PAUSED}])) slot[name=play],
+  :host([${MediaUIAttributes.MEDIA_PAUSED}]) slot[name=tooltip-pause],
+  :host(:not([${MediaUIAttributes.MEDIA_PAUSED}])) slot[name=tooltip-play] {
     display: none !important;
   }
   </style>
@@ -29,20 +28,14 @@ slotTemplate.innerHTML = /*html*/ `
     <slot name="pause">${pauseIcon}</slot>
   </slot>
   <media-tooltip id="tooltip">
-    <slot name="tooltip"></slot>
+    <slot name="tooltip-play">Play</slot>
+    <slot name="tooltip-pause">Pause</slot>
   </media-tooltip>
 `;
 
 const updateAriaLabel = (el: any): void => {
   const label = el.mediaPaused ? verbs.PLAY() : verbs.PAUSE();
   el.setAttribute('aria-label', label);
-};
-
-// TODO: should `verbs` be used here? they're not capitalised
-const updateTooltip = (el: any): void => {
-  const label = el.mediaPaused ? 'Play' : 'Pause';
-  const slot = el.shadowRoot.querySelector('slot[name=tooltip]');
-  if (slot) slot.textContent = label;
 };
 
 /**
@@ -69,7 +62,6 @@ class MediaPlayButton extends MediaChromeButton {
 
   connectedCallback(): void {
     updateAriaLabel(this);
-    updateTooltip(this);
     super.connectedCallback();
   }
 
@@ -80,7 +72,6 @@ class MediaPlayButton extends MediaChromeButton {
   ): void {
     if (attrName === MediaUIAttributes.MEDIA_PAUSED) {
       updateAriaLabel(this);
-      updateTooltip(this);
     }
     super.attributeChangedCallback(attrName, oldValue, newValue);
   }

--- a/src/js/media-play-button.ts
+++ b/src/js/media-play-button.ts
@@ -29,13 +29,20 @@ slotTemplate.innerHTML = /*html*/ `
     <slot name="pause">${pauseIcon}</slot>
   </slot>
   <media-tooltip id="tooltip">
-    <slot name="tooltip">Play</slot>
+    <slot name="tooltip"></slot>
   </media-tooltip>
 `;
 
 const updateAriaLabel = (el: any): void => {
   const label = el.mediaPaused ? verbs.PLAY() : verbs.PAUSE();
   el.setAttribute('aria-label', label);
+};
+
+// TODO: should `verbs` be used here? they're not capitalised
+const updateTooltip = (el: any): void => {
+  const label = el.mediaPaused ? 'Play' : 'Pause';
+  const slot = el.shadowRoot.querySelector('slot[name=tooltip]');
+  if (slot) slot.textContent = label;
 };
 
 /**
@@ -62,6 +69,7 @@ class MediaPlayButton extends MediaChromeButton {
 
   connectedCallback(): void {
     updateAriaLabel(this);
+    updateTooltip(this);
     super.connectedCallback();
   }
 
@@ -72,6 +80,7 @@ class MediaPlayButton extends MediaChromeButton {
   ): void {
     if (attrName === MediaUIAttributes.MEDIA_PAUSED) {
       updateAriaLabel(this);
+      updateTooltip(this);
     }
     super.attributeChangedCallback(attrName, oldValue, newValue);
   }

--- a/src/js/media-play-button.ts
+++ b/src/js/media-play-button.ts
@@ -53,11 +53,9 @@ const updateTooltipPosition = (
   const containingEl = closestComposedNode(tooltipEl, containingSelector);
   if (!containingEl) return;
 
-  const { x: cbX } = containingEl.getBoundingClientRect();
-  const { x: tpX } = tooltipEl.getBoundingClientRect();
-  const xDiff = tpX - cbX;
-
-  console.log(xDiff);
+  const { x: containerX } = containingEl.getBoundingClientRect();
+  const { x: tooltipX } = tooltipEl.getBoundingClientRect();
+  const xDiff = tooltipX - containerX;
 
   // not spilling out left
   if (xDiff > 0) {

--- a/src/js/media-play-button.ts
+++ b/src/js/media-play-button.ts
@@ -1,9 +1,8 @@
 import { MediaChromeButton } from './media-chrome-button.js';
 import { globalThis, document } from './utils/server-safe-globals.js';
 import { MediaUIEvents, MediaUIAttributes } from './constants.js';
-import { verbs } from './labels/labels.js';
+import { tooltipLabels, verbs } from './labels/labels.js';
 import { getBooleanAttr, setBooleanAttr } from './utils/element-utils.js';
-import { capitalize } from './utils/utils.js';
 
 const playIcon = `<svg aria-hidden="true" viewBox="0 0 24 24">
   <path d="m6 21 15-9L6 3v18Z"/>
@@ -34,8 +33,8 @@ slotTemplate.innerHTML = /*html*/ `
 `;
 
 const tooltipContent = /*html*/ `
-  <slot name="tooltip-play">${capitalize(verbs.PLAY())}</slot>
-  <slot name="tooltip-pause">${capitalize(verbs.PAUSE())}</slot>
+  <slot name="tooltip-play">${tooltipLabels.PLAY}</slot>
+  <slot name="tooltip-pause">${tooltipLabels.PAUSE}</slot>
 `;
 
 const updateAriaLabel = (el: any): void => {

--- a/src/js/media-play-button.ts
+++ b/src/js/media-play-button.ts
@@ -28,7 +28,7 @@ slotTemplate.innerHTML = /*html*/ `
     <slot name="pause">${pauseIcon}</slot>
   </slot>
   <slot name="tooltip">
-    <media-tooltip>
+    <media-tooltip container="media-control-bar">
       <slot name="tooltip-play">Play</slot>
       <slot name="tooltip-pause">Pause</slot>
     </media-tooltip>

--- a/src/js/media-playback-rate-button.ts
+++ b/src/js/media-playback-rate-button.ts
@@ -45,7 +45,7 @@ class MediaPlaybackRateButton extends MediaChromeButton {
   container: HTMLSlotElement;
 
   constructor(options = {}) {
-    super({ slotTemplate, ...options });
+    super({ slotTemplate, tooltipContent: 'Playback rate', ...options });
     this.container = this.shadowRoot.querySelector('slot[name="icon"]');
     this.container.innerHTML = `${DEFAULT_RATE}x`;
   }

--- a/src/js/media-playback-rate-button.ts
+++ b/src/js/media-playback-rate-button.ts
@@ -1,7 +1,7 @@
 import { MediaChromeButton } from './media-chrome-button.js';
 import { globalThis, document } from './utils/server-safe-globals.js';
 import { MediaUIEvents, MediaUIAttributes } from './constants.js';
-import { nouns } from './labels/labels.js';
+import { nouns, tooltipLabels } from './labels/labels.js';
 import { AttributeTokenList } from './utils/attribute-token-list.js';
 import { getNumericAttr, setNumericAttr } from './utils/element-utils.js';
 
@@ -45,7 +45,11 @@ class MediaPlaybackRateButton extends MediaChromeButton {
   container: HTMLSlotElement;
 
   constructor(options = {}) {
-    super({ slotTemplate, tooltipContent: 'Playback rate', ...options });
+    super({
+      slotTemplate,
+      tooltipContent: tooltipLabels.PLAYBACK_RATE,
+      ...options,
+    });
     this.container = this.shadowRoot.querySelector('slot[name="icon"]');
     this.container.innerHTML = `${DEFAULT_RATE}x`;
   }

--- a/src/js/media-playback-rate-menu-button.ts
+++ b/src/js/media-playback-rate-menu-button.ts
@@ -1,6 +1,6 @@
 import { globalThis, document } from './utils/server-safe-globals.js';
 import { MediaUIAttributes } from './constants.js';
-import { nouns } from './labels/labels.js';
+import { nouns, tooltipLabels } from './labels/labels.js';
 import { MediaChromeMenuButton } from './media-chrome-menu-button.js';
 import { AttributeTokenList } from './utils/attribute-token-list.js';
 import {
@@ -53,7 +53,11 @@ class MediaPlaybackRateMenuButton extends MediaChromeMenuButton {
   container: HTMLSlotElement;
 
   constructor(options = {}) {
-    super({ slotTemplate, tooltipContent: 'Playback rate', ...options });
+    super({
+      slotTemplate,
+      tooltipContent: tooltipLabels.PLAYBACK_RATE,
+      ...options,
+    });
     this.container = this.shadowRoot.querySelector('slot[name="icon"]');
     this.container.innerHTML = `${DEFAULT_RATE}x`;
   }

--- a/src/js/media-playback-rate-menu-button.ts
+++ b/src/js/media-playback-rate-menu-button.ts
@@ -23,6 +23,10 @@ slotTemplate.innerHTML = /*html*/ `
       min-width: 5ch;
       padding: var(--media-button-padding, var(--media-control-padding, 10px 5px));
     }
+    
+    :host([aria-expanded="true"]) slot[name=tooltip] {
+      display: none;
+    }
   </style>
   <slot name="icon"></slot>
 `;
@@ -49,7 +53,7 @@ class MediaPlaybackRateMenuButton extends MediaChromeMenuButton {
   container: HTMLSlotElement;
 
   constructor(options = {}) {
-    super({ slotTemplate, ...options });
+    super({ slotTemplate, tooltipContent: 'Playback rate', ...options });
     this.container = this.shadowRoot.querySelector('slot[name="icon"]');
     this.container.innerHTML = `${DEFAULT_RATE}x`;
   }

--- a/src/js/media-rendition-menu-button.ts
+++ b/src/js/media-rendition-menu-button.ts
@@ -14,6 +14,11 @@ const renditionIcon = /*html*/ `<svg aria-hidden="true" viewBox="0 0 24 24">
 
 const slotTemplate: HTMLTemplateElement = document.createElement('template');
 slotTemplate.innerHTML = /*html*/ `
+  <style>
+    :host([aria-expanded="true"]) slot[name=tooltip] {
+      display: none;
+    }
+  </style>
   <slot name="icon">${renditionIcon}</slot>
 `;
 
@@ -33,7 +38,7 @@ class MediaRenditionMenuButton extends MediaChromeMenuButton {
   }
 
   constructor() {
-    super({ slotTemplate });
+    super({ slotTemplate, tooltipContent: 'Quality' });
   }
 
   connectedCallback(): void {

--- a/src/js/media-rendition-menu-button.ts
+++ b/src/js/media-rendition-menu-button.ts
@@ -1,7 +1,7 @@
 import { MediaUIAttributes } from './constants.js';
 import { MediaChromeMenuButton } from './media-chrome-menu-button.js';
 import { globalThis, document } from './utils/server-safe-globals.js';
-import { nouns } from './labels/labels.js';
+import { nouns, tooltipLabels } from './labels/labels.js';
 import {
   getStringAttr,
   setStringAttr,
@@ -38,7 +38,7 @@ class MediaRenditionMenuButton extends MediaChromeMenuButton {
   }
 
   constructor() {
-    super({ slotTemplate, tooltipContent: 'Quality' });
+    super({ slotTemplate, tooltipContent: tooltipLabels.RENDITIONS });
   }
 
   connectedCallback(): void {

--- a/src/js/media-seek-backward-button.ts
+++ b/src/js/media-seek-backward-button.ts
@@ -38,7 +38,7 @@ class MediaSeekBackwardButton extends MediaChromeButton {
   }
 
   constructor(options = {}) {
-    super({ slotTemplate, ...options });
+    super({ slotTemplate, tooltipContent: 'Seek backward', ...options });
   }
 
   connectedCallback(): void {

--- a/src/js/media-seek-backward-button.ts
+++ b/src/js/media-seek-backward-button.ts
@@ -2,7 +2,7 @@ import { MediaChromeButton } from './media-chrome-button.js';
 import { globalThis, document } from './utils/server-safe-globals.js';
 import { MediaUIEvents, MediaUIAttributes } from './constants.js';
 import { getNumericAttr, setNumericAttr } from './utils/element-utils.js';
-import { verbs } from './labels/labels.js';
+import { tooltipLabels, verbs } from './labels/labels.js';
 import { getSlotted, updateIconText } from './utils/element-utils.js';
 
 export const Attributes = {
@@ -38,7 +38,11 @@ class MediaSeekBackwardButton extends MediaChromeButton {
   }
 
   constructor(options = {}) {
-    super({ slotTemplate, tooltipContent: 'Seek backward', ...options });
+    super({
+      slotTemplate,
+      tooltipContent: tooltipLabels.SEEK_BACKWARD,
+      ...options,
+    });
   }
 
   connectedCallback(): void {

--- a/src/js/media-seek-forward-button.ts
+++ b/src/js/media-seek-forward-button.ts
@@ -2,7 +2,7 @@ import { MediaChromeButton } from './media-chrome-button.js';
 import { globalThis, document } from './utils/server-safe-globals.js';
 import { MediaUIEvents, MediaUIAttributes } from './constants.js';
 import { getNumericAttr, setNumericAttr } from './utils/element-utils.js';
-import { verbs } from './labels/labels.js';
+import { tooltipLabels, verbs } from './labels/labels.js';
 import { getSlotted, updateIconText } from './utils/element-utils.js';
 
 export const Attributes = {
@@ -38,7 +38,11 @@ class MediaSeekForwardButton extends MediaChromeButton {
   }
 
   constructor(options = {}) {
-    super({ slotTemplate, tooltipContent: 'Seek forward', ...options });
+    super({
+      slotTemplate,
+      tooltipContent: tooltipLabels.SEEK_FORWARD,
+      ...options,
+    });
   }
 
   connectedCallback(): void {

--- a/src/js/media-seek-forward-button.ts
+++ b/src/js/media-seek-forward-button.ts
@@ -38,7 +38,7 @@ class MediaSeekForwardButton extends MediaChromeButton {
   }
 
   constructor(options = {}) {
-    super({ slotTemplate, ...options });
+    super({ slotTemplate, tooltipContent: 'Seek forward', ...options });
   }
 
   connectedCallback(): void {

--- a/src/js/media-settings-menu-button.ts
+++ b/src/js/media-settings-menu-button.ts
@@ -5,6 +5,11 @@ import { nouns } from './labels/labels.js';
 
 const slotTemplate: HTMLTemplateElement = document.createElement('template');
 slotTemplate.innerHTML = /*html*/ `
+  <style>
+    :host([aria-expanded="true"]) slot[name=tooltip] {
+      display: none;
+    }
+  </style>
   <slot name="icon">
     <svg aria-hidden="true" viewBox="0 0 24 24">
       <path d="M4.5 14.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Zm7.5 0a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Zm7.5 0a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Z"/>
@@ -21,7 +26,7 @@ class MediaSettingsMenuButton extends MediaChromeMenuButton {
   }
 
   constructor() {
-    super({ slotTemplate });
+    super({ slotTemplate, tooltipContent: 'Settings' });
   }
 
   connectedCallback(): void {

--- a/src/js/media-settings-menu-button.ts
+++ b/src/js/media-settings-menu-button.ts
@@ -1,7 +1,7 @@
 import { MediaChromeMenuButton } from './media-chrome-menu-button.js';
 import { globalThis, document } from './utils/server-safe-globals.js';
 import { getMediaController } from './utils/element-utils.js';
-import { nouns } from './labels/labels.js';
+import { nouns, tooltipLabels } from './labels/labels.js';
 
 const slotTemplate: HTMLTemplateElement = document.createElement('template');
 slotTemplate.innerHTML = /*html*/ `
@@ -26,7 +26,7 @@ class MediaSettingsMenuButton extends MediaChromeMenuButton {
   }
 
   constructor() {
-    super({ slotTemplate, tooltipContent: 'Settings' });
+    super({ slotTemplate, tooltipContent: tooltipLabels.SETTINGS });
   }
 
   connectedCallback(): void {

--- a/src/js/media-tooltip.ts
+++ b/src/js/media-tooltip.ts
@@ -16,29 +16,26 @@ const template: HTMLTemplateElement = document.createElement('template');
 
 template.innerHTML = /*html*/ `
   <style>
-    :host {
-      pointer-events: none;
-      z-index: 1;
-    }
-
     /* TODO: remove hardcoded values / replace with CSS vars where appro */
     :host {
+      --_tooltip-background: var(--media-tooltip-background, var(--media-secondary-color, rgb(20 20 30 / .7)));
       position: relative;
+      pointer-events: none;
       display: var(--media-tooltip-display, inline-flex);
       justify-content: center;
       align-items: center;
       box-sizing: border-box;
-      background: var(--media-tooltip-background, #fff);
-      color: #000;
-      font-weight: 400;
-      font-family: var(--media-font-family, helvetica neue, segoe ui, roboto, arial, sans-serif);
-      padding: .35em .7em;
-      font-size: 13px;
-      text-align: center;
-      border-radius: 5px;
-      pointer-events: none;
-      filter: drop-shadow(0 0 4px rgba(0, 0, 0, .2));
-      white-space: nowrap;
+      z-index: var(--media-tooltip-z-index, 1);
+      background: var(--_tooltip-background);
+      color: var(--media-primary-color, rgb(238 238 238));
+      font: var(--media-font,
+        var(--media-font-weight, 400)
+        var(--media-font-size, 13px)
+        var(--media-font-family, helvetica neue, segoe ui, roboto, arial, sans-serif));
+      padding: var(--media-tooltip-padding, .35em .7em);
+      border-radius: var(--media-tooltip-border-radius, 5px);
+      filter: var(--media-tooltip-shadow, drop-shadow(0 0 4px rgba(0, 0, 0, .2)));
+      white-space: var(--media-tooltip-white-space, nowrap);
     }
 
     img, svg {
@@ -65,7 +62,7 @@ template.innerHTML = /*html*/ `
       top: 100%;
       left: 50%;
       border-width: 5px 6px 0 6px;
-      border-color: var(--media-tooltip-background, #fff) transparent transparent transparent;
+      border-color: var(--_tooltip-background) transparent transparent transparent;
       transform: translate(calc(-50% + var(--media-tooltip-offset-x, 0px)), 0);
     }
 
@@ -79,7 +76,7 @@ template.innerHTML = /*html*/ `
       top: 50%;
       right: 100%;
       border-width: 6px 5px 6px 0;
-      border-color: transparent var(--media-tooltip-background, #fff) transparent transparent;
+      border-color: transparent var(--_tooltip-background) transparent transparent;
       transform: translate(0, -50%);
     }
 
@@ -93,7 +90,7 @@ template.innerHTML = /*html*/ `
       bottom: 100%;
       left: 50%;
       border-width: 0 6px 5px 6px;
-      border-color: transparent transparent var(--media-tooltip-background, #fff) transparent;
+      border-color: transparent transparent var(--_tooltip-background) transparent;
       transform: translate(calc(-50% + var(--media-tooltip-offset-x, 0px)), 0);
     }
 
@@ -107,7 +104,7 @@ template.innerHTML = /*html*/ `
       top: 50%;
       left: 100%;
       border-width: 6px 0 6px 5px;
-      border-color: transparent transparent transparent var(--media-tooltip-background, #fff);
+      border-color: transparent transparent transparent var(--_tooltip-background);
       transform: translate(0, -50%);
     }
     

--- a/src/js/media-tooltip.ts
+++ b/src/js/media-tooltip.ts
@@ -180,7 +180,7 @@ class MediaTooltip extends globalThis.HTMLElement {
     // defined / upgraded. Without this, placement might be permanently overriden
     // on the target element.
     // see: https://nolanlawson.com/2021/08/03/handling-properties-in-custom-element-upgrades/
-    if (this.hasOwnProperty('placement')) {
+    if (Object.prototype.hasOwnProperty.call(this, 'placement')) {
       const placement = this.placement;
       delete this.placement;
       this.placement = placement;

--- a/src/js/media-tooltip.ts
+++ b/src/js/media-tooltip.ts
@@ -27,7 +27,7 @@ template.innerHTML = /*html*/ `
       justify-content: center;
       align-items: center;
       box-sizing: border-box;
-      background: #fff;
+      background: var(--media-tooltip-background, #fff);
       color: #000;
       font-weight: 400;
       font-family: var(--media-font-family, helvetica neue, segoe ui, roboto, arial, sans-serif);
@@ -46,15 +46,10 @@ template.innerHTML = /*html*/ `
 
     #arrow {
       position: absolute;
-      top: 100%;
-      left: 50%;
       width: 0px;
       height: 0px;
       border-style: solid;
-      border-width: 5px 6px 0 6px;
-      border-color: #fff transparent transparent transparent;
-      transform: rotate(0deg);
-      transform: translate(calc(-50% + var(--media-tooltip-offset-x, 0px)), 0);
+      display: var(--media-tooltip-arrow-display, block);
     }
 
     :host(:not([position])),
@@ -64,28 +59,60 @@ template.innerHTML = /*html*/ `
       left: 50%;
       transform: translate(calc(-50% - var(--media-tooltip-offset-x, 0px)), 0);
     }
+    :host(:not([position])) #arrow,
+    :host([position="top"]) #arrow {
+      top: 100%;
+      left: 50%;
+      border-width: 5px 6px 0 6px;
+      border-color: var(--media-tooltip-background, #fff) transparent transparent transparent;
+      transform: translate(calc(-50% + var(--media-tooltip-offset-x, 0px)), 0);
+    }
+
     :host([position="right"]) {
       position: absolute;
       left: calc(100% + var(--media-tooltip-distance, 12px));
       top: 50%;
       transform: translate(0, -50%);
     }
+    :host([position="right"]) #arrow {
+      top: 50%;
+      right: 100%;
+      border-width: 6px 5px 6px 0;
+      border-color: transparent var(--media-tooltip-background, #fff) transparent transparent;
+      transform: translate(0, -50%);
+    }
+
     :host([position="bottom"]) {
       position: absolute;
       top: calc(100% + var(--media-tooltip-distance, 12px));
       left: 50%;
       transform: translate(-50%, 0);
     }
+    :host([position="bottom"]) #arrow {
+      bottom: 100%;
+      left: 50%;
+      border-width: 0 6px 5px 6px;
+      border-color: transparent transparent var(--media-tooltip-background, #fff) transparent;
+      transform: translate(calc(-50% + var(--media-tooltip-offset-x, 0px)), 0);
+    }
+
     :host([position="left"]) {
       position: absolute;
       right: calc(100% + var(--media-tooltip-distance, 12px));
       top: 50%;
       transform: translate(0, -50%);
     }
-    /*
-    * Because we default to "top" style if no attr is set we can
-    /* let it fall back to default style for "none"
-    /* :host([position="none"]) .container {} */
+    :host([position="left"]) #arrow {
+      top: 50%;
+      left: 100%;
+      border-width: 6px 0 6px 5px;
+      border-color: transparent transparent transparent var(--media-tooltip-background, #fff);
+      transform: translate(0, -50%);
+    }
+    
+    :host([position="none"]) #arrow {
+      display: none;
+    }
 
   </style>
   <slot></slot>

--- a/src/js/media-tooltip.ts
+++ b/src/js/media-tooltip.ts
@@ -30,6 +30,10 @@ template.innerHTML = /*html*/ `
       white-space: nowrap;
     }
 
+    #container img, #container svg {
+      display: inline-block;
+    }
+
     #container::after {
       content: '';
       width: 0px;

--- a/src/js/media-tooltip.ts
+++ b/src/js/media-tooltip.ts
@@ -13,7 +13,7 @@ template.innerHTML = /*html*/ `
     /* TODO: remove hardcoded values / replace with CSS vars where appro */
     #container {
       position: relative;
-      display: inline-flex;
+      display: var(--media-control-display, var(--media-tooltip-display, inline-flex));
       justify-content: center;
       align-items: center;
       box-sizing: border-box;

--- a/src/js/media-tooltip.ts
+++ b/src/js/media-tooltip.ts
@@ -1,6 +1,9 @@
+import { getNumericAttr, setNumericAttr } from './utils/element-utils.js';
 import { globalThis, document } from './utils/server-safe-globals.js';
 
-export const Attributes = {};
+export const Attributes = {
+  OFFSET_X: 'offsetx',
+};
 
 const template: HTMLTemplateElement = document.createElement('template');
 
@@ -34,29 +37,32 @@ template.innerHTML = /*html*/ `
       display: inline-block;
     }
 
-    #container::after {
-      content: '';
+    #arrow {
+      position: absolute;
+      top: 100%;
+      left: 50%;
       width: 0px;
       height: 0px;
       border-style: solid;
       border-width: 5px 6px 0 6px;
       border-color: #fff transparent transparent transparent;
       transform: rotate(0deg);
-      position: absolute;
-      top: 100%;
-      left: 50%;
       transform: translate(-50%, 0);
     }
   </style>
-  <div id="container" role="tooltip"><slot></slot></div>
+  <div id="container" role="tooltip">
+    <slot></slot>
+    <div id="arrow"></div>
+  </div>
 `;
 
 class MediaTooltip extends globalThis.HTMLElement {
   static get observedAttributes(): string[] {
-    return [];
+    return [Attributes.OFFSET_X];
   }
 
   containerEl: HTMLElement;
+  arrowEl: HTMLElement;
 
   constructor() {
     super();
@@ -68,6 +74,34 @@ class MediaTooltip extends globalThis.HTMLElement {
     }
 
     this.containerEl = this.shadowRoot.querySelector('#container');
+    this.arrowEl = this.shadowRoot.querySelector('#arrow');
+  }
+
+  attributeChangedCallback(
+    attrName: string,
+    oldValue: string | null,
+    newValue: string | null
+  ): void {
+    if (attrName === Attributes.OFFSET_X) {
+      if (newValue == null) {
+        this.containerEl.style.removeProperty('right');
+        this.arrowEl.style.removeProperty('left');
+      } else {
+        this.containerEl.style.right = `${newValue}px`;
+        this.arrowEl.style.left = `calc(50% + ${newValue}px)`;
+      }
+    }
+  }
+
+  /**
+   * Get or set offset X value
+   */
+  get offsetX(): number | undefined {
+    return getNumericAttr(this, Attributes.OFFSET_X);
+  }
+
+  set offsetX(value: number | undefined) {
+    setNumericAttr(this, Attributes.OFFSET_X, value);
   }
 }
 

--- a/src/js/media-tooltip.ts
+++ b/src/js/media-tooltip.ts
@@ -6,13 +6,13 @@ import {
 import { globalThis, document } from './utils/server-safe-globals.js';
 
 export const Attributes = {
-  POSITION: 'position',
+  PLACEMENT: 'placement',
   CONTAIN_WITHIN: 'containwithin',
 };
 
 const defaultContainerSelector = 'media-controller';
 
-export type TooltipPosition = 'top' | 'right' | 'bottom' | 'left' | 'none';
+export type TooltipPlacement = 'top' | 'right' | 'bottom' | 'left' | 'none';
 
 const template: HTMLTemplateElement = document.createElement('template');
 
@@ -57,15 +57,15 @@ template.innerHTML = /*html*/ `
       display: var(--media-tooltip-arrow-display, block);
     }
 
-    :host(:not([position])),
-    :host([position="top"]) {
+    :host(:not([placement])),
+    :host([placement="top"]) {
       position: absolute;
       bottom: calc(100% + var(--media-tooltip-distance, 12px));
       left: 50%;
       transform: translate(calc(-50% - var(--media-tooltip-offset-x, 0px)), 0);
     }
-    :host(:not([position])) #arrow,
-    :host([position="top"]) #arrow {
+    :host(:not([placement])) #arrow,
+    :host([placement="top"]) #arrow {
       top: 100%;
       left: 50%;
       border-width: var(--_tooltip-arrow-height) var(--_tooltip-arrow-half-width) 0 var(--_tooltip-arrow-half-width);
@@ -73,13 +73,13 @@ template.innerHTML = /*html*/ `
       transform: translate(calc(-50% + var(--media-tooltip-offset-x, 0px)), 0);
     }
 
-    :host([position="right"]) {
+    :host([placement="right"]) {
       position: absolute;
       left: calc(100% + var(--media-tooltip-distance, 12px));
       top: 50%;
       transform: translate(0, -50%);
     }
-    :host([position="right"]) #arrow {
+    :host([placement="right"]) #arrow {
       top: 50%;
       right: 100%;
       border-width: var(--_tooltip-arrow-half-width) var(--_tooltip-arrow-height) var(--_tooltip-arrow-half-width) 0;
@@ -87,13 +87,13 @@ template.innerHTML = /*html*/ `
       transform: translate(0, -50%);
     }
 
-    :host([position="bottom"]) {
+    :host([placement="bottom"]) {
       position: absolute;
       top: calc(100% + var(--media-tooltip-distance, 12px));
       left: 50%;
       transform: translate(calc(-50% - var(--media-tooltip-offset-x, 0px)), 0);
     }
-    :host([position="bottom"]) #arrow {
+    :host([placement="bottom"]) #arrow {
       bottom: 100%;
       left: 50%;
       border-width: 0 var(--_tooltip-arrow-half-width) var(--_tooltip-arrow-height) var(--_tooltip-arrow-half-width);
@@ -101,13 +101,13 @@ template.innerHTML = /*html*/ `
       transform: translate(calc(-50% + var(--media-tooltip-offset-x, 0px)), 0);
     }
 
-    :host([position="left"]) {
+    :host([placement="left"]) {
       position: absolute;
       right: calc(100% + var(--media-tooltip-distance, 12px));
       top: 50%;
       transform: translate(0, -50%);
     }
-    :host([position="left"]) #arrow {
+    :host([placement="left"]) #arrow {
       top: 50%;
       left: 100%;
       border-width: var(--_tooltip-arrow-half-width) 0 var(--_tooltip-arrow-half-width) var(--_tooltip-arrow-height);
@@ -115,7 +115,7 @@ template.innerHTML = /*html*/ `
       transform: translate(0, -50%);
     }
     
-    :host([position="none"]) #arrow {
+    :host([placement="none"]) #arrow {
       display: none;
     }
 
@@ -127,7 +127,7 @@ template.innerHTML = /*html*/ `
 /**
  * @extends {HTMLElement}
  *
- * @attr {('top'|'right'|'bottom'|'left'|'none')} position - The position of the tooltip, defaults to "top"
+ * @attr {('top'|'right'|'bottom'|'left'|'none')} placement - The placement of the tooltip, defaults to "top"
  * @attr {string} containWithin - CSS selector for the containing element (one of it's parents) that should constrain the tooltips horizontal position.
  *
  * @cssproperty --media-primary-color - Default color of text.
@@ -156,7 +156,7 @@ template.innerHTML = /*html*/ `
  */
 class MediaTooltip extends globalThis.HTMLElement {
   static get observedAttributes(): string[] {
-    return [Attributes.POSITION, Attributes.CONTAIN_WITHIN];
+    return [Attributes.PLACEMENT, Attributes.CONTAIN_WITHIN];
   }
 
   arrowEl: HTMLElement;
@@ -172,25 +172,25 @@ class MediaTooltip extends globalThis.HTMLElement {
 
     this.arrowEl = this.shadowRoot.querySelector('#arrow');
 
-    // Check if the position prop has been set before the element was
-    // defined / upgraded. Without this, position might be permanently overriden
+    // Check if the placement prop has been set before the element was
+    // defined / upgraded. Without this, placement might be permanently overriden
     // on the target element.
     // see: https://nolanlawson.com/2021/08/03/handling-properties-in-custom-element-upgrades/
-    if (this.hasOwnProperty('position')) {
-      const position = this.position;
-      delete this.position;
-      this.position = position;
+    if (this.hasOwnProperty('placement')) {
+      const placement = this.placement;
+      delete this.placement;
+      this.placement = placement;
     }
   }
 
   // Adjusts tooltip position relative to the closest specified container
   // such that it doesn't spill out of the left or right sides. Only applies
-  // to 'top' and 'bottom' positioned tooltips.
+  // to 'top' and 'bottom' placed tooltips.
   updateXOffset = () => {
-    const position = this.position;
+    const placement = this.placement;
 
     // we don't offset against tooltips coming out of left and right sides
-    if (position === 'left' || position === 'right') {
+    if (placement === 'left' || placement === 'right') {
       // could have been offset before switching to a new position
       this.style.removeProperty('--media-tooltip-offset-x');
       return;
@@ -248,14 +248,14 @@ class MediaTooltip extends globalThis.HTMLElement {
   };
 
   /**
-   * Get or set tooltip position
+   * Get or set tooltip placement
    */
-  get position(): TooltipPosition | undefined {
-    return getStringAttr(this, Attributes.POSITION);
+  get placement(): TooltipPlacement | undefined {
+    return getStringAttr(this, Attributes.PLACEMENT);
   }
 
-  set position(value: TooltipPosition | undefined) {
-    setStringAttr(this, Attributes.POSITION, value);
+  set placement(value: TooltipPlacement | undefined) {
+    setStringAttr(this, Attributes.PLACEMENT, value);
   }
 
   /**

--- a/src/js/media-tooltip.ts
+++ b/src/js/media-tooltip.ts
@@ -121,7 +121,7 @@ template.innerHTML = /*html*/ `
  * @extends {HTMLElement}
  *
  * @attr {('top'|'right'|'bottom'|'left'|'none')} position - The position of the tooltip, defaults to "top"
- * @attr {string} container - The containing element (one of it's parents) that should constrain the tooltips left and right position.
+ * @attr {string} container - CSS selector for the containing element (one of it's parents) that should constrain the tooltips horizontal position.
  *
  * @cssproperty --media-primary-color - Default color of text.
  * @cssproperty --media-secondary-color - Default color of tooltip background.
@@ -161,9 +161,9 @@ class MediaTooltip extends globalThis.HTMLElement {
     this.arrowEl = this.shadowRoot.querySelector('#arrow');
   }
 
-  // Adjust tooltip position relative to the closest containing element
+  // Adjusts tooltip position relative to the closest specified container
   // such that it doesn't spill out of the left or right sides. Only applies
-  // to top and bottom positioned tooltips.
+  // to 'top' and 'bottom' positioned tooltips.
   updateXOffset = () => {
     const position = this.position;
 

--- a/src/js/media-tooltip.ts
+++ b/src/js/media-tooltip.ts
@@ -1,5 +1,6 @@
 import {
   closestComposedNode,
+  getMediaController,
   getStringAttr,
   setStringAttr,
 } from './utils/element-utils.js';
@@ -7,10 +8,8 @@ import { globalThis, document } from './utils/server-safe-globals.js';
 
 export const Attributes = {
   PLACEMENT: 'placement',
-  CONTAIN_WITHIN: 'containwithin',
+  BOUNDS: 'bounds',
 };
-
-const defaultContainerSelector = 'media-controller';
 
 export type TooltipPlacement = 'top' | 'right' | 'bottom' | 'left' | 'none';
 
@@ -132,7 +131,7 @@ template.innerHTML = /*html*/ `
  * @extends {HTMLElement}
  *
  * @attr {('top'|'right'|'bottom'|'left'|'none')} placement - The placement of the tooltip, defaults to "top"
- * @attr {string} containWithin - CSS selector for the containing element (one of it's parents) that should constrain the tooltips horizontal position.
+ * @attr {string} bounds - ID for the containing element (one of it's parents) that should constrain the tooltips horizontal position.
  *
  * @cssproperty --media-primary-color - Default color of text.
  * @cssproperty --media-secondary-color - Default color of tooltip background.
@@ -160,7 +159,7 @@ template.innerHTML = /*html*/ `
  */
 class MediaTooltip extends globalThis.HTMLElement {
   static get observedAttributes(): string[] {
-    return [Attributes.PLACEMENT, Attributes.CONTAIN_WITHIN];
+    return [Attributes.PLACEMENT, Attributes.BOUNDS];
   }
 
   arrowEl: HTMLElement;
@@ -207,8 +206,8 @@ class MediaTooltip extends globalThis.HTMLElement {
     // + any extra margin specified to create some buffer space, so it looks better.
     // e.g. it's 20px out of bounds, we nudge it 20px back in + margin
     const tooltipStyle = getComputedStyle(this);
-    const containingSelector = this.containWithin ?? defaultContainerSelector;
-    const containingEl = closestComposedNode(this, containingSelector);
+    const containingEl =
+      closestComposedNode(this, '#' + this.bounds) ?? getMediaController(this);
     if (!containingEl) return;
     const { x: containerX, width: containerWidth } =
       containingEl.getBoundingClientRect();
@@ -263,15 +262,15 @@ class MediaTooltip extends globalThis.HTMLElement {
   }
 
   /**
-   * Get or set tooltip container selector that will constrain the tooltips horizontal
-   * position. A css selector that matches one of the tooltips parents.
+   * Get or set tooltip container ID selector that will constrain the tooltips
+   * horizontal position.
    */
-  get containWithin(): string | undefined {
-    return getStringAttr(this, Attributes.CONTAIN_WITHIN);
+  get bounds(): string | undefined {
+    return getStringAttr(this, Attributes.BOUNDS);
   }
 
-  set containWithin(value: string | undefined) {
-    setStringAttr(this, Attributes.CONTAIN_WITHIN, value);
+  set bounds(value: string | undefined) {
+    setStringAttr(this, Attributes.BOUNDS, value);
   }
 }
 

--- a/src/js/media-tooltip.ts
+++ b/src/js/media-tooltip.ts
@@ -21,7 +21,7 @@ template.innerHTML = /*html*/ `
       --_tooltip-background: var(--media-tooltip-background, var(--_tooltip-background-color));
       --_tooltip-arrow-half-width: calc(var(--media-tooltip-arrow-width, 12px) / 2);
       --_tooltip-arrow-height: var(--media-tooltip-arrow-height, 5px);
-      --_tooltip-arrow-background: var(--media-tooltip-arrow-background-color, var(--_tooltip-background-color));
+      --_tooltip-arrow-background: var(--media-tooltip-arrow-color, var(--_tooltip-background-color));
       position: relative;
       pointer-events: none;
       display: var(--media-tooltip-display, inline-flex);
@@ -150,7 +150,7 @@ template.innerHTML = /*html*/ `
  * @cssproperty --media-tooltip-arrow-display - `display` property of tooltip arrow
  * @cssproperty --media-tooltip-arrow-width - Arrow width
  * @cssproperty --media-tooltip-arrow-height - Arrow height
- * @cssproperty --media-tooltip-arrow-background-color - Arrow background color
+ * @cssproperty --media-tooltip-arrow-color - Arrow color
  */
 class MediaTooltip extends globalThis.HTMLElement {
   static get observedAttributes(): string[] {

--- a/src/js/media-tooltip.ts
+++ b/src/js/media-tooltip.ts
@@ -1,8 +1,14 @@
-import { getNumericAttr, setNumericAttr } from './utils/element-utils.js';
+import {
+  getNumericAttr,
+  getStringAttr,
+  setNumericAttr,
+  setStringAttr,
+} from './utils/element-utils.js';
 import { globalThis, document } from './utils/server-safe-globals.js';
 
 export const Attributes = {
   OFFSET_X: 'offsetx',
+  POSITION: 'position',
 };
 
 const template: HTMLTemplateElement = document.createElement('template');
@@ -11,12 +17,13 @@ template.innerHTML = /*html*/ `
   <style>
     :host {
       pointer-events: none;
+      z-index: 1;
     }
 
     /* TODO: remove hardcoded values / replace with CSS vars where appro */
-    #container {
+    :host {
       position: relative;
-      display: var(--media-control-display, var(--media-tooltip-display, inline-flex));
+      display: var(--media-tooltip-display, inline-flex);
       justify-content: center;
       align-items: center;
       box-sizing: border-box;
@@ -33,7 +40,7 @@ template.innerHTML = /*html*/ `
       white-space: nowrap;
     }
 
-    #container img, #container svg {
+    img, svg {
       display: inline-block;
     }
 
@@ -47,21 +54,49 @@ template.innerHTML = /*html*/ `
       border-width: 5px 6px 0 6px;
       border-color: #fff transparent transparent transparent;
       transform: rotate(0deg);
+      transform: translate(calc(-50% + var(--media-tooltip-offset-x, 0px)), 0);
+    }
+
+    :host(:not([position])),
+    :host([position="top"]) {
+      position: absolute;
+      bottom: calc(100% + var(--media-tooltip-distance, 12px));
+      left: 50%;
+      transform: translate(calc(-50% - var(--media-tooltip-offset-x, 0px)), 0);
+    }
+    :host([position="right"]) {
+      position: absolute;
+      left: calc(100% + var(--media-tooltip-distance, 12px));
+      top: 50%;
+      transform: translate(0, -50%);
+    }
+    :host([position="bottom"]) {
+      position: absolute;
+      top: calc(100% + var(--media-tooltip-distance, 12px));
+      left: 50%;
       transform: translate(-50%, 0);
     }
+    :host([position="left"]) {
+      position: absolute;
+      right: calc(100% + var(--media-tooltip-distance, 12px));
+      top: 50%;
+      transform: translate(0, -50%);
+    }
+    /*
+    * Because we default to "top" style if no attr is set we can
+    /* let it fall back to default style for "none"
+    /* :host([position="none"]) .container {} */
+
   </style>
-  <div id="container" role="tooltip">
-    <slot></slot>
-    <div id="arrow"></div>
-  </div>
+  <slot></slot>
+  <div id="arrow"></div>
 `;
 
 class MediaTooltip extends globalThis.HTMLElement {
   static get observedAttributes(): string[] {
-    return [Attributes.OFFSET_X];
+    return [Attributes.OFFSET_X, Attributes.POSITION];
   }
 
-  containerEl: HTMLElement;
   arrowEl: HTMLElement;
 
   constructor() {
@@ -73,7 +108,6 @@ class MediaTooltip extends globalThis.HTMLElement {
       this.shadowRoot.appendChild(template.content.cloneNode(true));
     }
 
-    this.containerEl = this.shadowRoot.querySelector('#container');
     this.arrowEl = this.shadowRoot.querySelector('#arrow');
   }
 
@@ -84,11 +118,11 @@ class MediaTooltip extends globalThis.HTMLElement {
   ): void {
     if (attrName === Attributes.OFFSET_X) {
       if (newValue == null) {
-        this.containerEl.style.removeProperty('right');
-        this.arrowEl.style.removeProperty('left');
+        // this.style.removeProperty('right');
+        // this.arrowEl.style.removeProperty('left');
       } else {
-        this.containerEl.style.right = `${newValue}px`;
-        this.arrowEl.style.left = `calc(50% + ${newValue}px)`;
+        // this.style.right = `${newValue}px`;
+        // this.arrowEl.style.left = `calc(50% + ${newValue}px)`;
       }
     }
   }
@@ -96,12 +130,23 @@ class MediaTooltip extends globalThis.HTMLElement {
   /**
    * Get or set offset X value
    */
-  get offsetX(): number | undefined {
-    return getNumericAttr(this, Attributes.OFFSET_X);
+  // get offsetX(): number | undefined {
+  //   return getNumericAttr(this, Attributes.OFFSET_X);
+  // }
+
+  // set offsetX(value: number | undefined) {
+  //   setNumericAttr(this, Attributes.OFFSET_X, value);
+  // }
+
+  /**
+   * Get or set tooltip position
+   */
+  get position(): string | undefined {
+    return getStringAttr(this, Attributes.POSITION);
   }
 
-  set offsetX(value: number | undefined) {
-    setNumericAttr(this, Attributes.OFFSET_X, value);
+  set position(value: string | undefined) {
+    setStringAttr(this, Attributes.POSITION, value);
   }
 }
 

--- a/src/js/media-tooltip.ts
+++ b/src/js/media-tooltip.ts
@@ -17,10 +17,11 @@ const template: HTMLTemplateElement = document.createElement('template');
 template.innerHTML = /*html*/ `
   <style>
     :host {
-      --_tooltip-background: var(--media-tooltip-background, var(--media-secondary-color, rgba(20, 20, 30, .7)));
+      --_tooltip-background-color: var(--media-tooltip-background-color, var(--media-secondary-color, rgba(20, 20, 30, .7)));
+      --_tooltip-background: var(--media-tooltip-background, var(--_tooltip-background-color));
       --_tooltip-arrow-half-width: calc(var(--media-tooltip-arrow-width, 12px) / 2);
       --_tooltip-arrow-height: var(--media-tooltip-arrow-height, 5px);
-      --_tooltip-arrow-background: var(--media-tooltip-arrow-background-color, var(--_tooltip-background));
+      --_tooltip-arrow-background: var(--media-tooltip-arrow-background-color, var(--_tooltip-background-color));
       position: relative;
       pointer-events: none;
       display: var(--media-tooltip-display, inline-flex);
@@ -36,6 +37,7 @@ template.innerHTML = /*html*/ `
         var(--media-text-content-height, var(--media-control-height, 18px))
         var(--media-font-family, helvetica neue, segoe ui, roboto, arial, sans-serif));
       padding: var(--media-tooltip-padding, .35em .7em);
+      border: var(--media-tooltip-border, none);
       border-radius: var(--media-tooltip-border-radius, 5px);
       filter: var(--media-tooltip-filter, drop-shadow(0 0 4px rgba(0, 0, 0, .2)));
       white-space: var(--media-tooltip-white-space, nowrap);
@@ -136,7 +138,9 @@ template.innerHTML = /*html*/ `
  * @cssproperty --media-font-size - `font-size` property.
  * @cssproperty --media-text-content-height - `line-height` of button text.
  *
- * @cssproperty --media-tooltip-background - `background` of tooltip
+ * @cssproperty --media-tooltip-border - 'border' of tooltip
+ * @cssproperty --media-tooltip-background-color - Background color of tooltip and arrow, unless individually overidden
+ * @cssproperty --media-tooltip-background - `background` of tooltip, ignoring the arrow
  * @cssproperty --media-tooltip-display - `display` of tooltip
  * @cssproperty --media-tooltip-z-index - `z-index` of tooltip
  * @cssproperty --media-tooltip-padding - `padding` of tooltip

--- a/src/js/media-tooltip.ts
+++ b/src/js/media-tooltip.ts
@@ -27,6 +27,7 @@ template.innerHTML = /*html*/ `
       border-radius: 5px;
       pointer-events: none;
       filter: drop-shadow(0 0 4px rgba(0, 0, 0, .2));
+      white-space: nowrap;
     }
 
     #container::after {

--- a/src/js/media-tooltip.ts
+++ b/src/js/media-tooltip.ts
@@ -45,6 +45,10 @@ template.innerHTML = /*html*/ `
       white-space: var(--media-tooltip-white-space, nowrap);
     }
 
+    :host([hidden]) {
+      display: none;
+    }
+
     img, svg {
       display: inline-block;
     }

--- a/src/js/media-tooltip.ts
+++ b/src/js/media-tooltip.ts
@@ -16,7 +16,6 @@ const template: HTMLTemplateElement = document.createElement('template');
 
 template.innerHTML = /*html*/ `
   <style>
-    /* TODO: remove hardcoded values / replace with CSS vars where appro */
     :host {
       --_tooltip-background: var(--media-tooltip-background, var(--media-secondary-color, rgb(20 20 30 / .7)));
       position: relative;
@@ -27,14 +26,15 @@ template.innerHTML = /*html*/ `
       box-sizing: border-box;
       z-index: var(--media-tooltip-z-index, 1);
       background: var(--_tooltip-background);
-      color: var(--media-primary-color, rgb(238 238 238));
+      color: var(--media-text-color, var(--media-primary-color, rgb(238 238 238)));
       font: var(--media-font,
         var(--media-font-weight, 400)
-        var(--media-font-size, 13px)
+        var(--media-font-size, 13px) /
+        var(--media-text-content-height, var(--media-control-height, 18px))
         var(--media-font-family, helvetica neue, segoe ui, roboto, arial, sans-serif));
       padding: var(--media-tooltip-padding, .35em .7em);
       border-radius: var(--media-tooltip-border-radius, 5px);
-      filter: var(--media-tooltip-shadow, drop-shadow(0 0 4px rgba(0, 0, 0, .2)));
+      filter: var(--media-tooltip-filter, drop-shadow(0 0 4px rgba(0, 0, 0, .2)));
       white-space: var(--media-tooltip-white-space, nowrap);
     }
 
@@ -122,6 +122,25 @@ template.innerHTML = /*html*/ `
  *
  * @attr {('top'|'right'|'bottom'|'left'|'none')} position - The position of the tooltip, defaults to "top"
  * @attr {string} container - The containing element (one of it's parents) that should constrain the tooltips left and right position.
+ *
+ * @cssproperty --media-primary-color - Default color of text.
+ * @cssproperty --media-secondary-color - Default color of tooltip background.
+ * @cssproperty --media-text-color - `color` of tooltip text.
+ *
+ * @cssproperty --media-font - `font` shorthand property.
+ * @cssproperty --media-font-weight - `font-weight` property.
+ * @cssproperty --media-font-family - `font-family` property.
+ * @cssproperty --media-font-size - `font-size` property.
+ * @cssproperty --media-text-content-height - `line-height` of button text.
+ *
+ * @cssproperty --media-tooltip-background - `background` color
+ * @cssproperty --media-tooltip-display - `display` of tooltip
+ * @cssproperty --media-tooltip-z-index - `z-index` of tooltip
+ * @cssproperty --media-tooltip-padding - `padding` of tooltip
+ * @cssproperty --media-tooltip-border-radius - `border-radius` of tooltip
+ * @cssproperty --media-tooltip-filter - `filter` property of tooltip, for drop-shadow
+ * @cssproperty --media-tooltip-white-space - `white-space` property of tooltip
+ * @cssproperty --media-tooltip-arrow-display - `display` property of tooltip arrow
  */
 class MediaTooltip extends globalThis.HTMLElement {
   static get observedAttributes(): string[] {

--- a/src/js/media-tooltip.ts
+++ b/src/js/media-tooltip.ts
@@ -17,7 +17,10 @@ const template: HTMLTemplateElement = document.createElement('template');
 template.innerHTML = /*html*/ `
   <style>
     :host {
-      --_tooltip-background: var(--media-tooltip-background, var(--media-secondary-color, rgb(20 20 30 / .7)));
+      --_tooltip-background: var(--media-tooltip-background, var(--media-secondary-color, rgba(20, 20, 30, .7)));
+      --_tooltip-arrow-half-width: calc(var(--media-tooltip-arrow-width, 12px) / 2);
+      --_tooltip-arrow-height: var(--media-tooltip-arrow-height, 5px);
+      --_tooltip-arrow-background: var(--media-tooltip-arrow-background-color, var(--_tooltip-background));
       position: relative;
       pointer-events: none;
       display: var(--media-tooltip-display, inline-flex);
@@ -61,8 +64,8 @@ template.innerHTML = /*html*/ `
     :host([position="top"]) #arrow {
       top: 100%;
       left: 50%;
-      border-width: 5px 6px 0 6px;
-      border-color: var(--_tooltip-background) transparent transparent transparent;
+      border-width: var(--_tooltip-arrow-height) var(--_tooltip-arrow-half-width) 0 var(--_tooltip-arrow-half-width);
+      border-color: var(--_tooltip-arrow-background) transparent transparent transparent;
       transform: translate(calc(-50% + var(--media-tooltip-offset-x, 0px)), 0);
     }
 
@@ -75,8 +78,8 @@ template.innerHTML = /*html*/ `
     :host([position="right"]) #arrow {
       top: 50%;
       right: 100%;
-      border-width: 6px 5px 6px 0;
-      border-color: transparent var(--_tooltip-background) transparent transparent;
+      border-width: var(--_tooltip-arrow-half-width) var(--_tooltip-arrow-height) var(--_tooltip-arrow-half-width) 0;
+      border-color: transparent var(--_tooltip-arrow-background) transparent transparent;
       transform: translate(0, -50%);
     }
 
@@ -89,8 +92,8 @@ template.innerHTML = /*html*/ `
     :host([position="bottom"]) #arrow {
       bottom: 100%;
       left: 50%;
-      border-width: 0 6px 5px 6px;
-      border-color: transparent transparent var(--_tooltip-background) transparent;
+      border-width: 0 var(--_tooltip-arrow-half-width) var(--_tooltip-arrow-height) var(--_tooltip-arrow-half-width);
+      border-color: transparent transparent var(--_tooltip-arrow-background) transparent;
       transform: translate(calc(-50% + var(--media-tooltip-offset-x, 0px)), 0);
     }
 
@@ -103,8 +106,8 @@ template.innerHTML = /*html*/ `
     :host([position="left"]) #arrow {
       top: 50%;
       left: 100%;
-      border-width: 6px 0 6px 5px;
-      border-color: transparent transparent transparent var(--_tooltip-background);
+      border-width: var(--_tooltip-arrow-half-width) 0 var(--_tooltip-arrow-half-width) var(--_tooltip-arrow-height);
+      border-color: transparent transparent transparent var(--_tooltip-arrow-background);
       transform: translate(0, -50%);
     }
     
@@ -133,7 +136,7 @@ template.innerHTML = /*html*/ `
  * @cssproperty --media-font-size - `font-size` property.
  * @cssproperty --media-text-content-height - `line-height` of button text.
  *
- * @cssproperty --media-tooltip-background - `background` color
+ * @cssproperty --media-tooltip-background - `background` of tooltip
  * @cssproperty --media-tooltip-display - `display` of tooltip
  * @cssproperty --media-tooltip-z-index - `z-index` of tooltip
  * @cssproperty --media-tooltip-padding - `padding` of tooltip
@@ -141,6 +144,9 @@ template.innerHTML = /*html*/ `
  * @cssproperty --media-tooltip-filter - `filter` property of tooltip, for drop-shadow
  * @cssproperty --media-tooltip-white-space - `white-space` property of tooltip
  * @cssproperty --media-tooltip-arrow-display - `display` property of tooltip arrow
+ * @cssproperty --media-tooltip-arrow-width - Arrow width
+ * @cssproperty --media-tooltip-arrow-height - Arrow height
+ * @cssproperty --media-tooltip-arrow-background-color - Arrow background color
  */
 class MediaTooltip extends globalThis.HTMLElement {
   static get observedAttributes(): string[] {

--- a/src/js/media-tooltip.ts
+++ b/src/js/media-tooltip.ts
@@ -171,6 +171,16 @@ class MediaTooltip extends globalThis.HTMLElement {
     }
 
     this.arrowEl = this.shadowRoot.querySelector('#arrow');
+
+    // Check if the position prop has been set before the element was
+    // defined / upgraded. Without this, position might be permanently overriden
+    // on the target element.
+    // see: https://nolanlawson.com/2021/08/03/handling-properties-in-custom-element-upgrades/
+    if (this.hasOwnProperty('position')) {
+      const position = this.position;
+      delete this.position;
+      this.position = position;
+    }
   }
 
   // Adjusts tooltip position relative to the closest specified container

--- a/src/js/media-tooltip.ts
+++ b/src/js/media-tooltip.ts
@@ -1,0 +1,73 @@
+import { globalThis, document } from './utils/server-safe-globals.js';
+
+export const Attributes = {};
+
+const template: HTMLTemplateElement = document.createElement('template');
+
+template.innerHTML = /*html*/ `
+  <style>
+    :host {
+      pointer-events: none;
+    }
+
+    /* TODO: remove hardcoded values / replace with CSS vars where appro */
+    #container {
+      position: relative;
+      display: inline-flex;
+      justify-content: center;
+      align-items: center;
+      box-sizing: border-box;
+      background: #fff;
+      color: #000;
+      font-weight: 400;
+      font-family: var(--media-font-family, helvetica neue, segoe ui, roboto, arial, sans-serif);
+      padding: .35em .7em;
+      font-size: 13px;
+      text-align: center;
+      border-radius: 5px;
+      pointer-events: none;
+      filter: drop-shadow(0 0 4px rgba(0, 0, 0, .2));
+    }
+
+    #container::after {
+      content: '';
+      width: 0px;
+      height: 0px;
+      border-style: solid;
+      border-width: 5px 6px 0 6px;
+      border-color: #fff transparent transparent transparent;
+      transform: rotate(0deg);
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translate(-50%, 0);
+    }
+  </style>
+  <div id="container" role="tooltip"><slot></slot></div>
+`;
+
+class MediaTooltip extends globalThis.HTMLElement {
+  static get observedAttributes(): string[] {
+    return [];
+  }
+
+  containerEl: HTMLElement;
+
+  constructor() {
+    super();
+
+    if (!this.shadowRoot) {
+      // Set up the Shadow DOM if not using Declarative Shadow DOM.
+      this.attachShadow({ mode: 'open' });
+      this.shadowRoot.appendChild(template.content.cloneNode(true));
+    }
+
+    this.containerEl = this.shadowRoot.querySelector('#container');
+  }
+}
+
+if (!globalThis.customElements.get('media-tooltip')) {
+  globalThis.customElements.define('media-tooltip', MediaTooltip);
+}
+
+export default MediaTooltip;

--- a/src/js/utils/utils.ts
+++ b/src/js/utils/utils.ts
@@ -97,3 +97,6 @@ export function isNumericString(str: any): boolean {
  */
 export const delay = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
+
+export const capitalize = (str: string) =>
+  str && str[0].toUpperCase() + str.slice(1);


### PR DESCRIPTION
Adds a new `media-tooltip` element and includes tooltips by default in anything that extends the `media-chrome-button` class. Tooltips can be placed either `top`, `right`, `bottom`, `left` or `none`.

fix #411