### PR TITLE
fix: floating time display position

### DIFF
--- a/src/js/media-time-range.ts
+++ b/src/js/media-time-range.ts
@@ -245,7 +245,6 @@ template.innerHTML = /*html*/ `
       border-radius: var(--media-preview-time-border-radius,
         0 0 var(--media-preview-border-radius) var(--media-preview-border-radius));
       min-width: 100%;
-      transform: translateX(0);
     }
 
     :host([${MediaUIAttributes.MEDIA_PREVIEW_TIME}]:hover) {


### PR DESCRIPTION
found a bug when the preview thumbnail is sufficiently big, the time display will stay centered and the arrow underneath will stay positioned anchored to the cursor.

this change makes it so the time display will float together with the arrow until it reaches the limit of the bounding box.