### PR TITLE
fix: for audio don't set media-controller bg color

### DIFF
--- a/src/js/media-container.ts
+++ b/src/js/media-container.ts
@@ -44,6 +44,9 @@ template.innerHTML = /*html*/ `
       position: relative;
       display: inline-block;
       line-height: 0;
+    }
+
+    :host(:not([${Attributes.AUDIO}])) {
       background-color: var(--media-background-color, #000);
     }
 


### PR DESCRIPTION
fix #939

small change to not set a media container background color when the audio attribute is set.
I'm not fully convinced it's better. open to suggestions.