### PR TITLE
fix: Safari (webkit) style tag styles not applied

### DIFF
--- a/src/js/menu/media-chrome-menu.ts
+++ b/src/js/menu/media-chrome-menu.ts
@@ -641,7 +641,9 @@ class MediaChromeMenu extends globalThis.HTMLElement {
     const realBottom = isBottomCalc ? bottom : parseFloat(computedStyle.bottom);
     const maxHeight = boundsRect.height - realBottom - parseFloat(computedStyle.marginBottom);
 
-    style.setProperty('--_menu-max-height', `${maxHeight}px`);
+    // Safari required directly setting the element style property instead of
+    // updating the style node for the styles to be refreshed.
+    this.style.setProperty('--_menu-max-height', `${maxHeight}px`);
   }
 
   /**

--- a/src/js/utils/element-utils.ts
+++ b/src/js/utils/element-utils.ts
@@ -215,7 +215,7 @@ export function getCSSRule(
 ): CSSStyleRule | undefined {
   let style;
 
-  for (style of styleParent.querySelectorAll('style')) {
+  for (style of styleParent.querySelectorAll('style:not([media])') ?? []) {
     // Catch this error. e.g. browser extension adds style tags.
     //   Uncaught DOMException: CSSStyleSheet.cssRules getter:
     //   Not allowed to access cross-origin stylesheet
@@ -240,7 +240,7 @@ export function insertCSSRule(
   styleParent: Element | ShadowRoot,
   selectorText: string
 ): CSSStyleRule | undefined {
-  const styles = styleParent.querySelectorAll('style') ?? [];
+  const styles = styleParent.querySelectorAll('style:not([media])') ?? [];
   const style = styles?.[styles.length - 1];
 
   // If there is no style sheet return an empty style rule.


### PR DESCRIPTION
regression in the previous fix. 

Safari!!!! 

![SCR-20240924-mgkd](https://github.com/user-attachments/assets/52bc75bb-c484-4425-aad5-4fe542cff457)
