### PR TITLE
fix: chapters event w/ preload none

### DIFF
--- a/src/js/media-store/state-mediator.ts
+++ b/src/js/media-store/state-mediator.ts
@@ -685,12 +685,21 @@ export const stateMediator: StateMediator = {
           'track[kind="chapters"][default][src]'
         );
 
+        /* If `media` is a custom media element search in its shadow DOM. */
+        const shadowChaptersTrack = media.shadowRoot?.querySelector(
+          ':is(video,audio) > track[kind="chapters"][default][src]'
+        );
+
         /** @ts-ignore */
         chaptersTrack?.addEventListener('load', handler);
+        /** @ts-ignore */
+        shadowChaptersTrack?.addEventListener('load', handler);
 
         return () => {
           /** @ts-ignore */
           chaptersTrack?.removeEventListener('load', handler);
+          /** @ts-ignore */
+          shadowChaptersTrack?.removeEventListener('load', handler);
         };
       },
     ],


### PR DESCRIPTION
this fixes an issue where the chapters were not being loaded in the UI because the track event was not fired.