### PR TITLE
fix: seeking when preload is none

### DIFF
--- a/examples/vanilla/mobile.html
+++ b/examples/vanilla/mobile.html
@@ -84,7 +84,7 @@
   <body>
     <main>
       <h1>Media Chrome Standard Mobile Video Usage Example</h1>
-      <media-controller autohide="2">
+      <media-controller autohide="2" defaultduration="134">
         <video
           slot="media"
           src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/high.mp4"

--- a/src/js/media-store/state-mediator.ts
+++ b/src/js/media-store/state-mediator.ts
@@ -21,6 +21,7 @@ import {
   toggleSubtitleTracks,
 } from './util.js';
 import { getTextTracksList } from '../utils/captions.js';
+import { isValidNumber } from '../utils/utils.js';
 
 export type Rendition = {
   src?: string;
@@ -432,8 +433,7 @@ export const stateMediator: StateMediator = {
     },
     set(value, stateOwners) {
       const { media } = stateOwners;
-      // If the media supports readyState and it's not ready, don't set currentTime
-      if (!media || media.readyState === 0) return;
+      if (!media || !isValidNumber(value)) return;
       media.currentTime = value;
     },
     mediaEvents: ['timeupdate', 'loadedmetadata'],


### PR DESCRIPTION
related #910

this fixes an issue where when you seek before the video is loaded we don't set the video.currentTime.

it's fine to set the currentTime anytime. it doesn't throw for a valid number value. 
but users have to set the `defaultduration` in some cases. not sure with iOS and native HLS.