### PR TITLE
fix: Use overflow clip in tooltip button to prevent scrollbar

### DIFF
--- a/src/js/media-chrome-button.ts
+++ b/src/js/media-chrome-button.ts
@@ -74,7 +74,7 @@ template.innerHTML = /*html*/ `
   media-tooltip {
     ${/** Make sure unpositioned tooltip doesn't cause page overflow (scroll). */ ''}
     max-width: 0;
-    overflow-x: hidden;
+    overflow-x: clip;
     opacity: 0;
     transition: opacity .3s, max-width 0s 9s;
   }


### PR DESCRIPTION
In #994 `overflow-x: hidden` was added to the tooltips to prevent unwanted overflows. `hidden` on a single axis does however introduce scrollbars on Windows devices and Mac's who enabled scrollbars to show always (this is great to emulate how a big part of users see your website, which is why I have it enabled). 

Changing the overflow to `overflow-x: clip` will achieve the same result, but won't show a scrollbar. Which is what I added in this PR. See video below showcasing the issue and fix. Let me know your thoughts.

cc @luwes 

Fixes #1000 

https://github.com/user-attachments/assets/67509a11-099f-4b02-ba35-1e0acc46d003

