### PR TITLE
docs: Added reminder for menu import to rendition menu docs

### DIFF
--- a/docs/src/pages/docs/en/components/media-rendition-menu.mdx
+++ b/docs/src/pages/docs/en/components/media-rendition-menu.mdx
@@ -9,6 +9,13 @@ import SandpackContainer from "../../../../components/SandpackContainer.astro";
 
 A menu for video renditions (qualities).
 
+> Remember to add the seperate menu module for the menu components.
+
+```js
+import "media-chrome";
+import "media-chrome/menu";
+```
+
 ### Default usage
 
 <SandpackContainer


### PR DESCRIPTION
I did not just lose 4 hours of my life trying to find out why the rendition menu wasn't working 🥲 

To prevent someone else from making the same mistake, I added this warning. Copied it from other menu pages that already included this warning, which I only encountered after reverse engineering how the menu works myself 😅 

Hope it's helpful to at least one person out there! 