### PR TITLE
fix: make tooltip not focusable to fix a11y

### DIFF
--- a/src/js/media-chrome-button.ts
+++ b/src/js/media-chrome-button.ts
@@ -92,7 +92,7 @@ template.innerHTML = /*html*/ `
 </style>
 
 <slot name="tooltip">
-  <media-tooltip part="tooltip">
+  <media-tooltip part="tooltip" aria-hidden="true">
     <slot name="tooltip-content"></slot>
   </media-tooltip>
 </slot>


### PR DESCRIPTION
This fixes an a11y test for media-tooltip not being focusable.