### PR TITLE
feat: add range `thumb` slot

### DIFF
--- a/docs/src/pages/docs/en/components/media-time-range.mdx
+++ b/docs/src/pages/docs/en/components/media-time-range.mdx
@@ -131,6 +131,25 @@ Set the `preview` slot to an empty element to remove the default preview element
 </media-controller>`}
 />
 
+## Thumb slot
+
+<SandpackContainer
+  editorHeight={330}
+  html={`<media-controller>
+  <video 
+    playsinline muted crossorigin
+    slot="media"
+    src="https://stream.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/low.mp4"
+  ></video>
+  <media-control-bar>
+    <media-time-range>
+      <svg slot="thumb" style="width: 20px; height: 20px; background: none;">
+        <circle fill="#df2c2c" cx="10" cy="10" r="10"/>
+      </svg>
+    </media-time-range>
+  </media-control-bar>
+</media-controller>`}
+/>
 
 
 ## Styling

--- a/docs/src/pages/docs/en/components/media-time-range.mdx
+++ b/docs/src/pages/docs/en/components/media-time-range.mdx
@@ -143,8 +143,8 @@ Set the `preview` slot to an empty element to remove the default preview element
   ></video>
   <media-control-bar>
     <media-time-range>
-      <svg slot="thumb" style="width: 20px; height: 20px; background: none;">
-        <circle fill="#df2c2c" cx="10" cy="10" r="10"/>
+      <svg slot="thumb">
+        <circle fill="#df2c2c" cx="5" cy="5" r="5"/>
       </svg>
     </media-time-range>
   </media-control-bar>

--- a/src/js/media-chrome-range.ts
+++ b/src/js/media-chrome-range.ts
@@ -177,16 +177,19 @@ template.innerHTML = /*html*/ `
       width: var(--media-range-thumb-width, 10px);
       height: var(--media-range-thumb-height, 10px);
       margin-left: calc(var(--media-range-thumb-width, 10px) / -2);
-      border: var(--media-range-thumb-border, none);
-      border-radius: var(--media-range-thumb-border-radius, 10px);
-      background: var(--media-range-thumb-background, var(--media-primary-color, rgb(238 238 238)));
-      box-shadow: var(--media-range-thumb-box-shadow, 1px 1px 1px transparent);
       transition: var(--media-range-thumb-transition);
       transform: var(--media-range-thumb-transform, none);
       opacity: var(--media-range-thumb-opacity, 1);
       position: absolute;
       left: 0;
       cursor: pointer;
+    }
+
+    #thumb {
+      border-radius: var(--media-range-thumb-border-radius, 10px);
+      background: var(--media-range-thumb-background, var(--media-primary-color, rgb(238 238 238)));
+      box-shadow: var(--media-range-thumb-box-shadow, 1px 1px 1px transparent);
+      border: var(--media-range-thumb-border, none);
     }
 
     :host([disabled]) #thumb {

--- a/src/js/media-chrome-range.ts
+++ b/src/js/media-chrome-range.ts
@@ -172,7 +172,8 @@ template.innerHTML = /*html*/ `
       }
     }
 
-    #thumb {
+    #thumb,
+    ::slotted([slot=thumb]) {
       width: var(--media-range-thumb-width, 10px);
       height: var(--media-range-thumb-height, 10px);
       margin-left: calc(var(--media-range-thumb-width, 10px) / -2);
@@ -232,7 +233,9 @@ template.innerHTML = /*html*/ `
         <div id="pointer"></div>
         <div id="progress" part="progress"></div>
       </div>
-      <div id="thumb" part="thumb"></div>
+      <slot name="thumb">
+        <div id="thumb" part="thumb"></div>
+      </slot>
       <svg id="segments"><clipPath id="segments-clipping"></clipPath></svg>
     </div>
     <input id="range" type="range" min="0" max="1" step="any" value="0">
@@ -242,6 +245,8 @@ template.innerHTML = /*html*/ `
 
 /**
  * @extends {HTMLElement}
+ *
+ * @slot thumb - The thumb element to use for the range.
  *
  * @attr {boolean} disabled - The Boolean disabled attribute makes the element not mutable or focusable.
  * @attr {string} mediacontroller - The element `id` of the media controller to connect to (if not nested within).
@@ -386,7 +391,7 @@ class MediaChromeRange extends globalThis.HTMLElement {
 
     this.#cssRules.pointer = getOrInsertCSSRule(this.shadowRoot, '#pointer');
     this.#cssRules.progress = getOrInsertCSSRule(this.shadowRoot, '#progress');
-    this.#cssRules.thumb = getOrInsertCSSRule(this.shadowRoot, '#thumb');
+    this.#cssRules.thumb = getOrInsertCSSRule(this.shadowRoot, '#thumb, ::slotted([slot="thumb"])');
     this.#cssRules.activeSegment = getOrInsertCSSRule(
       this.shadowRoot,
       '#segments-clipping rect:nth-child(0)'

--- a/src/js/media-chrome-range.ts
+++ b/src/js/media-chrome-range.ts
@@ -176,10 +176,10 @@ template.innerHTML = /*html*/ `
     ::slotted([slot=thumb]) {
       width: var(--media-range-thumb-width, 10px);
       height: var(--media-range-thumb-height, 10px);
-      margin-left: calc(var(--media-range-thumb-width, 10px) / -2);
       transition: var(--media-range-thumb-transition);
       transform: var(--media-range-thumb-transform, none);
       opacity: var(--media-range-thumb-opacity, 1);
+      translate: -50%;
       position: absolute;
       left: 0;
       cursor: pointer;


### PR DESCRIPTION
adds a `thumb` slot for range elements. 

this is required for some CSS features like animations because the declared keyframes have to be in the same scope as the element to which they are applied.