### PR TITLE
Made createMediaStore a named import

### DIFF
--- a/src/js/media-controller.ts
+++ b/src/js/media-controller.ts
@@ -28,7 +28,7 @@ import {
   setNumericAttr,
   setStringAttr,
 } from './utils/element-utils.js';
-import createMediaStore, { MediaStore } from './media-store/media-store.js';
+import { createMediaStore, MediaStore } from './media-store/media-store.js';
 import { CustomElement } from './utils/CustomElement.js';
 
 const ButtonPressedKeys = [

--- a/src/js/media-store/media-store.ts
+++ b/src/js/media-store/media-store.ts
@@ -556,3 +556,5 @@ export const createMediaStore = ({
     },
   };
 };
+
+export default createMediaStore;

--- a/src/js/media-store/media-store.ts
+++ b/src/js/media-store/media-store.ts
@@ -116,7 +116,7 @@ type MediaStoreConfig = {
  * A factory for creating a `MediaStore` instance.
  * @param mediaStoreConfig - Configuration object for the `MediaStore`.
  */
-const createMediaStore = ({
+export const createMediaStore = ({
   media,
   fullscreenElement,
   documentElement,
@@ -556,5 +556,3 @@ const createMediaStore = ({
     },
   };
 };
-
-export default createMediaStore;

--- a/src/js/react/media-store.tsx
+++ b/src/js/react/media-store.tsx
@@ -7,7 +7,8 @@ import {
   StreamTypes,
   VolumeLevels,
 } from '../constants.js';
-import createMediaStore, {
+import {
+  createMediaStore,
   type MediaState,
   type MediaStore,
 } from '../media-store/media-store.js';


### PR DESCRIPTION
I'm having the same problem, as the described in [this](https://github.com/muxinc/media-chrome/issues/886) issue.

The error I receive:
```
media-controller.js:440 Uncaught TypeError: (0 , import_media_store.default) is not a function
    at MediaController.setupDefaultStore_fn (media-controller.js:440:1)
    at MediaController.connectedCallback (media-controller.js:219:1)
```

Which shows me, that the problem is here:
`var import_media_store = __toESM(require("./media-store/media-store.js"), 1);`

By making **createMediaStore** a named export, and using that, this problem disappears, and the video player works perfectly.