### PR TITLE
feat: add CSS variable to customize the <media-controller> hide transition

### DIFF
--- a/examples/vanilla/basic-video.html
+++ b/examples/vanilla/basic-video.html
@@ -19,6 +19,11 @@
       .examples {
         margin-top: 20px;
       }
+
+      /** (optional) add style to change default behavior when hiding controls */
+      media-controller {
+        --media-hide-transition: opacity 0.125s ease-in-out;
+      }
     </style>
   </head>
   <body>

--- a/examples/vanilla/basic-video.html
+++ b/examples/vanilla/basic-video.html
@@ -22,7 +22,7 @@
 
       /** (optional) add style to change default behavior when hiding controls */
       media-controller {
-        --media-hide-transition: opacity 0.125s ease-in-out;
+        --media-control-transition-out: opacity 0.125s ease-in-out;
       }
     </style>
   </head>

--- a/examples/vanilla/basic-video.html
+++ b/examples/vanilla/basic-video.html
@@ -20,9 +20,10 @@
         margin-top: 20px;
       }
 
-      /** (optional) add style to change default behavior when hiding controls */
+      /** (optional) add style to change default behavior when showing/hiding controls */
       media-controller {
         --media-control-transition-out: opacity 0.125s ease-in-out;
+        --media-control-transition-in: opacity 0.2s ease-in-out;
       }
     </style>
   </head>

--- a/src/js/media-container.ts
+++ b/src/js/media-container.ts
@@ -153,7 +153,7 @@ template.innerHTML = /*html*/ `
       Attributes.NO_AUTOHIDE
     }]):not([hidden]):not([role=dialog])) {
       opacity: 1;
-      transition: opacity 0.25s;
+      transition: var(--media-control-transition-in, opacity 0.25s);
     }
 
     ${
@@ -286,6 +286,7 @@ function getBreakpoints(breakpoints: Record<string, string>, width: number) {
  * @cssprop --media-background-color - `background-color` of container.
  * @cssprop --media-slot-display - `display` of the media slot (default none for [audio] usage).
  * @cssprop --media-control-transition-out - `transition` used to define the animation effect when hiding the container.
+ * @cssprop --media-control-transition-in - `transition` used to define the animation effect when showing the container.
  */
 class MediaContainer extends globalThis.HTMLElement {
   static get observedAttributes(): string[] {

--- a/src/js/media-container.ts
+++ b/src/js/media-container.ts
@@ -169,7 +169,7 @@ template.innerHTML = /*html*/ `
       Attributes.NO_AUTOHIDE
     }]):not([role=dialog])) {
       opacity: 0;
-      transition: var(--media-hide-transition, opacity 1s);
+      transition: var(--media-control-transition-out, opacity 1s);
     }
 
     :host([${Attributes.USER_INACTIVE}]:not([${
@@ -285,7 +285,7 @@ function getBreakpoints(breakpoints: Record<string, string>, width: number) {
  *
  * @cssprop --media-background-color - `background-color` of container.
  * @cssprop --media-slot-display - `display` of the media slot (default none for [audio] usage).
- * @cssprop --media-hide-transition - `transition` used to define the animation effect when hiding the container.
+ * @cssprop --media-control-transition-out - `transition` used to define the animation effect when hiding the container.
  */
 class MediaContainer extends globalThis.HTMLElement {
   static get observedAttributes(): string[] {

--- a/src/js/media-container.ts
+++ b/src/js/media-container.ts
@@ -169,7 +169,7 @@ template.innerHTML = /*html*/ `
       Attributes.NO_AUTOHIDE
     }]):not([role=dialog])) {
       opacity: 0;
-      transition: opacity 1s;
+      transition: var(--media-hide-transition, opacity 1s);
     }
 
     :host([${Attributes.USER_INACTIVE}]:not([${
@@ -285,6 +285,7 @@ function getBreakpoints(breakpoints: Record<string, string>, width: number) {
  *
  * @cssprop --media-background-color - `background-color` of container.
  * @cssprop --media-slot-display - `display` of the media slot (default none for [audio] usage).
+ * @cssprop --media-hide-transition - `transition` used to define the animation effect when hiding the container.
  */
 class MediaContainer extends globalThis.HTMLElement {
   static get observedAttributes(): string[] {


### PR DESCRIPTION
Related to #874
- Added `--media-control-transition-out` CSS variable to optionally change the transition effect when hiding the `<media-controller>` component.
- Added `--media-control-transition-in` CSS variable to optionally change the transition effect when showing the `<media-controller>` component.
- Added example of use in `basic-video.html`