### PR TITLE
fix: remove media container observers on disconnect

### DIFF
--- a/src/js/media-container.ts
+++ b/src/js/media-container.ts
@@ -10,7 +10,7 @@
 import { globalThis, document } from './utils/server-safe-globals.js';
 import { MediaUIAttributes, MediaStateChangeEvents } from './constants.js';
 import { nouns } from './labels/labels.js';
-import { observeResize } from './utils/resize-observer.js';
+import { observeResize, unobserveResize } from './utils/resize-observer.js';
 // Guarantee that `<media-gesture-receiver/>` is available for use in the template
 import './media-gesture-receiver.js';
 
@@ -89,11 +89,11 @@ template.innerHTML = /*html*/ `
        */ ''
     }
     :host(:not([${Attributes.AUDIO}])[${
-      Attributes.GESTURES_DISABLED
-    }]) ::slotted([slot=gestures-chrome]),
+  Attributes.GESTURES_DISABLED
+}]) ::slotted([slot=gestures-chrome]),
     :host(:not([${Attributes.AUDIO}])[${
-      Attributes.GESTURES_DISABLED
-    }]) media-gesture-receiver[slot=gestures-chrome] {
+  Attributes.GESTURES_DISABLED
+}]) media-gesture-receiver[slot=gestures-chrome] {
       display: none;
     }
 
@@ -160,23 +160,23 @@ template.innerHTML = /*html*/ `
       /* Hide controls when inactive, not paused, not audio and auto hide not disabled */ ''
     }
     :host([${Attributes.USER_INACTIVE}]:not([${
-      MediaUIAttributes.MEDIA_PAUSED
-    }]):not([${MediaUIAttributes.MEDIA_IS_AIRPLAYING}]):not([${
-      MediaUIAttributes.MEDIA_IS_CASTING
-    }]):not([${
-      Attributes.AUDIO
-    }])) ::slotted(:not([slot=media]):not([slot=poster]):not([${
-      Attributes.NO_AUTOHIDE
-    }]):not([role=dialog])) {
+  MediaUIAttributes.MEDIA_PAUSED
+}]):not([${MediaUIAttributes.MEDIA_IS_AIRPLAYING}]):not([${
+  MediaUIAttributes.MEDIA_IS_CASTING
+}]):not([${
+  Attributes.AUDIO
+}])) ::slotted(:not([slot=media]):not([slot=poster]):not([${
+  Attributes.NO_AUTOHIDE
+}]):not([role=dialog])) {
       opacity: 0;
       transition: opacity 1s;
     }
 
     :host([${Attributes.USER_INACTIVE}]:not([${
-      MediaUIAttributes.MEDIA_PAUSED
-    }]):not([${MediaUIAttributes.MEDIA_IS_CASTING}]):not([${
-      Attributes.AUDIO
-    }])) ::slotted([slot=media]) {
+  MediaUIAttributes.MEDIA_PAUSED
+}]):not([${MediaUIAttributes.MEDIA_IS_CASTING}]):not([${
+  Attributes.AUDIO
+}])) ::slotted([slot=media]) {
       cursor: none;
     }
 
@@ -188,8 +188,8 @@ template.innerHTML = /*html*/ `
       /* ::slotted([slot=poster]) doesn't work for slot fallback content so hide parent slot instead */ ''
     }
     :host(:not([${Attributes.AUDIO}])[${
-      MediaUIAttributes.MEDIA_HAS_PLAYED
-    }]) slot[name=poster] {
+  MediaUIAttributes.MEDIA_HAS_PLAYED
+}]) slot[name=poster] {
       display: none;
     }
 
@@ -323,84 +323,6 @@ class MediaContainer extends globalThis.HTMLElement {
       this.shadowRoot.appendChild(template.content.cloneNode(true));
     }
 
-    // Watch for child adds/removes and update the media element if necessary
-    const mutationCallback = (mutationsList: MutationRecord[]) => {
-      const media = this.media;
-
-      for (const mutation of mutationsList) {
-        if (mutation.type === 'childList') {
-          // Media element being removed
-          mutation.removedNodes.forEach((node: Element) => {
-            // Is this a direct child media element of media-controller?
-            // TODO: This accuracy doesn't matter after moving away from media attrs.
-            // Could refactor so we can always just call 'dispose' on any removed media el.
-            if (node.slot == 'media' && mutation.target == this) {
-              // Check if this was the current media by if it was the first
-              // el with slot=media in the child list. There could be multiple.
-              let previousSibling =
-                mutation.previousSibling &&
-                (mutation.previousSibling as Element).previousElementSibling;
-
-              // Must have been first if no prev sibling or new media
-              if (!previousSibling || !media) {
-                this.mediaUnsetCallback(node as HTMLMediaElement);
-              } else {
-                // Check if any prev siblings had a slot=media
-                // Should remain true otherwise
-                let wasFirst = previousSibling.slot !== 'media';
-                while (
-                  (previousSibling =
-                    previousSibling.previousSibling as Element) !== null
-                ) {
-                  if (previousSibling.slot == 'media') wasFirst = false;
-                }
-                if (wasFirst) this.mediaUnsetCallback(node as HTMLMediaElement);
-              }
-            }
-          });
-
-          // Controls or media element being added
-          // No need to inject anything if media=null
-          if (media) {
-            mutation.addedNodes.forEach((node) => {
-              if (node === media) {
-                // Update all controls with new media if this is the new media
-                this.handleMediaUpdated(media);
-              }
-            });
-          }
-        }
-      }
-    };
-
-    const mutationObserver = new MutationObserver(mutationCallback);
-    mutationObserver.observe(this, { childList: true, subtree: true });
-
-    let pendingResizeCb = false;
-    const deferResizeCallback = (entry: ResizeObserverEntry) => {
-      // Already have a pending async breakpoint computation, so go ahead and bail
-      if (pendingResizeCb) return;
-      // Just in case it takes too long (which will cause an error to throw),
-      // do the breakpoint computation asynchronously
-      setTimeout(() => {
-        resizeCallback(entry);
-        // Once we've completed, reset the pending cb flag to false
-        pendingResizeCb = false;
-
-        if (!this.breakpointsComputed) {
-          this.breakpointsComputed = true;
-          this.dispatchEvent(
-            new CustomEvent(MediaStateChangeEvents.BREAKPOINTS_COMPUTED, {
-              bubbles: true,
-              composed: true,
-            })
-          );
-        }
-      }, 0);
-      pendingResizeCb = true;
-    };
-    observeResize(this, deferResizeCallback);
-
     // Handles the case when the slotted media element is a slot element itself.
     // e.g. chaining media slots for media themes.
     const chainedSlot = this.querySelector(
@@ -462,6 +384,10 @@ class MediaContainer extends globalThis.HTMLElement {
   }
 
   connectedCallback(): void {
+    // Watch for child adds/removes and update the media element if necessary
+    this.#mutationObserver.observe(this, { childList: true, subtree: true });
+    observeResize(this, this.#handleResize);
+
     const isAudioChrome = this.getAttribute(Attributes.AUDIO) != null;
     const label = isAudioChrome ? nouns.AUDIO_PLAYER() : nouns.VIDEO_PLAYER();
     this.setAttribute('role', 'region');
@@ -483,6 +409,9 @@ class MediaContainer extends globalThis.HTMLElement {
   }
 
   disconnectedCallback(): void {
+    this.#mutationObserver.disconnect();
+    unobserveResize(this, this.#handleResize);
+
     // When disconnected from the DOM, remove root node and media event listeners
     // to prevent memory leaks and unneeded invisble UI updates.
     if (this.media) {
@@ -527,6 +456,85 @@ class MediaContainer extends globalThis.HTMLElement {
         break;
     }
   }
+
+  #mutationObserver = new MutationObserver(this.#handleMutation.bind(this));
+  #handleMutation(mutationsList: MutationRecord[]) {
+    const media = this.media;
+
+    for (const mutation of mutationsList) {
+      if (mutation.type !== 'childList') continue;
+
+      const removedNodes = mutation.removedNodes as NodeListOf<Element>;
+
+      // Media element being removed
+      for (const node of removedNodes) {
+        // Is this a direct child media element of media-controller?
+        // TODO: This accuracy doesn't matter after moving away from media attrs.
+        // Could refactor so we can always just call 'dispose' on any removed media el.
+        if (node.slot != 'media' || mutation.target != this) continue;
+
+        // Check if this was the current media by if it was the first
+        // el with slot=media in the child list. There could be multiple.
+        let previousSibling =
+          mutation.previousSibling &&
+          (mutation.previousSibling as Element).previousElementSibling;
+
+        // Must have been first if no prev sibling or new media
+        if (!previousSibling || !media) {
+          this.mediaUnsetCallback(node as HTMLMediaElement);
+        } else {
+          // Check if any prev siblings had a slot=media
+          // Should remain true otherwise
+          let wasFirst = previousSibling.slot !== 'media';
+
+          while (
+            (previousSibling = previousSibling.previousSibling as Element) !==
+            null
+          ) {
+            if (previousSibling.slot == 'media') wasFirst = false;
+          }
+
+          if (wasFirst) this.mediaUnsetCallback(node as HTMLMediaElement);
+        }
+      }
+
+      // Controls or media element being added
+      // No need to inject anything if media=null
+      if (media) {
+        for (const node of mutation.addedNodes) {
+          // Update all controls with new media if this is the new media
+          if (node === media) this.handleMediaUpdated(media);
+        }
+      }
+    }
+  }
+
+  #isResizePending = false;
+  #handleResize = (entry: ResizeObserverEntry) => {
+    // Already have a pending async breakpoint computation, so go ahead and bail
+    if (this.#isResizePending) return;
+
+    // Just in case it takes too long (which will cause an error to throw),
+    // do the breakpoint computation asynchronously
+    setTimeout(() => {
+      resizeCallback(entry);
+
+      // Once we've completed, reset the pending cb flag to false
+      this.#isResizePending = false;
+
+      if (!this.breakpointsComputed) {
+        this.breakpointsComputed = true;
+        this.dispatchEvent(
+          new CustomEvent(MediaStateChangeEvents.BREAKPOINTS_COMPUTED, {
+            bubbles: true,
+            composed: true,
+          })
+        );
+      }
+    }, 0);
+
+    this.#isResizePending = true;
+  };
 
   #handlePointerMove(event: PointerEvent) {
     if (event.pointerType !== 'mouse') {


### PR DESCRIPTION
As discussed in https://github.com/muxinc/media-chrome/pull/1057.

Apologies, not sure why it's auto-formatting the innerHTML template string, am I missing an extension or something?

To answer a few questions from the other PR:

> valid points though the constructor is called on an upgrade and most of the time that is on connected.

Generally true, but not when the element is created in-memory (`document.createElement` or via template) and not yet attached to the DOM. Quite common practice in modern frameworks (e.g., Vue/Solid/Svelte).

> I believe we put it there because it is just setup once but it could be an oversight. it doesn't cause any serious issues but a new PR putting it in connectedCallback seems good to me. last I checked the cleanup logic is not absolutely required because the browser cleans that up automatically when the element is garbage collected.

That is true but it's still best practice to clean up on disconnect. Element may be held in memory as it's being moved in the DOM, might be offloaded in a scroll container as it goes out of view, detached by a framework as a performance optimization, and many other reasons.