### PR TITLE
fix: hide error dialog on playback recovery

### DIFF
--- a/examples/vanilla/control-elements/media-error-dialog.html
+++ b/examples/vanilla/control-elements/media-error-dialog.html
@@ -69,6 +69,47 @@
       </media-control-bar>
     </media-controller>
 
+    <h2>Hide error on recovery</h2>
+
+    <media-controller defaultsubtitles>
+      <custom-video
+        id="recoverable-video"
+        slot="media"
+        src="https://stream.mux.com/Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008/low.mp4"
+        muted
+        crossorigin
+      ></custom-video>
+      <img slot="poster" src="https://image.mux.com/Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008/thumbnail.webp?time=13" />
+      <media-loading-indicator slot="centered-chrome" noautohide></media-loading-indicator>
+      <media-error-dialog slot="dialog"></media-error-dialog>
+      <media-control-bar>
+        <media-play-button></media-play-button>
+        <media-mute-button></media-mute-button>
+        <media-time-range></media-time-range>
+        <media-time-display></media-time-display>
+        <media-fullscreen-button></media-fullscreen-button>
+      </media-control-bar>
+    </media-controller>
+    <br>
+    <button onclick="recoverAndPlay()">Play</button>
+
+    <script>
+      function setError() {
+        const video = document.querySelector('#recoverable-video');
+        const customError = new Error('');
+        customError.code = 2;
+        video.error = customError;
+        video.dispatchEvent(new Event('error'));
+      }
+
+      setError();
+
+      function recoverAndPlay() {
+        const video = document.querySelector('#recoverable-video');
+        video.play();
+      }
+    </script>
+
     <h2>Custom error code for custom media elements</h2>
     <script>
       function setError() {

--- a/src/js/media-store/state-mediator.ts
+++ b/src/js/media-store/state-mediator.ts
@@ -18,6 +18,7 @@ import {
 import {
   getShowingSubtitleTracks,
   getSubtitleTracks,
+  isMediaPlaying,
   toggleSubtitleTracks,
 } from './util.js';
 import { getTextTracksList } from '../utils/captions.js';
@@ -288,27 +289,30 @@ export const prepareStateOwners = async (
 
 export const stateMediator: StateMediator = {
   mediaError: {
-    get(stateOwners) {
+    get(stateOwners, event) {
       const { media } = stateOwners;
+      if (event?.type === 'playing' && isMediaPlaying(media)) return;
       // Add additional error info via the `mediaError` element property only.
       // This can be used in the MediaErrorDialog.formatErrorMessage() method.
       return media?.error;
     },
-    mediaEvents: ['emptied', 'error'],
+    mediaEvents: ['emptied', 'error', 'playing'],
   },
   mediaErrorCode: {
-    get(stateOwners) {
+    get(stateOwners, event) {
       const { media } = stateOwners;
+      if (event?.type === 'playing' && isMediaPlaying(media)) return;
       return media?.error?.code;
     },
-    mediaEvents: ['emptied', 'error'],
+    mediaEvents: ['emptied', 'error', 'playing'],
   },
   mediaErrorMessage: {
-    get(stateOwners) {
+    get(stateOwners, event) {
       const { media } = stateOwners;
+      if (event?.type === 'playing' && isMediaPlaying(media)) return;
       return media?.error?.message ?? '';
     },
-    mediaEvents: ['emptied', 'error'],
+    mediaEvents: ['emptied', 'error', 'playing'],
   },
   mediaWidth: {
     get(stateOwners) {

--- a/src/js/media-store/state-mediator.ts
+++ b/src/js/media-store/state-mediator.ts
@@ -18,7 +18,6 @@ import {
 import {
   getShowingSubtitleTracks,
   getSubtitleTracks,
-  isMediaPlaying,
   toggleSubtitleTracks,
 } from './util.js';
 import { getTextTracksList } from '../utils/captions.js';
@@ -291,7 +290,7 @@ export const stateMediator: StateMediator = {
   mediaError: {
     get(stateOwners, event) {
       const { media } = stateOwners;
-      if (event?.type === 'playing' && isMediaPlaying(media)) return;
+      if (event?.type === 'playing') return;
       // Add additional error info via the `mediaError` element property only.
       // This can be used in the MediaErrorDialog.formatErrorMessage() method.
       return media?.error;
@@ -301,7 +300,7 @@ export const stateMediator: StateMediator = {
   mediaErrorCode: {
     get(stateOwners, event) {
       const { media } = stateOwners;
-      if (event?.type === 'playing' && isMediaPlaying(media)) return;
+      if (event?.type === 'playing') return;
       return media?.error?.code;
     },
     mediaEvents: ['emptied', 'error', 'playing'],
@@ -309,7 +308,7 @@ export const stateMediator: StateMediator = {
   mediaErrorMessage: {
     get(stateOwners, event) {
       const { media } = stateOwners;
-      if (event?.type === 'playing' && isMediaPlaying(media)) return;
+      if (event?.type === 'playing') return;
       return media?.error?.message ?? '';
     },
     mediaEvents: ['emptied', 'error', 'playing'],

--- a/src/js/media-store/util.ts
+++ b/src/js/media-store/util.ts
@@ -2,10 +2,6 @@ import { TextTrackKinds, TextTrackModes } from '../constants.js';
 import { getTextTracksList, updateTracksModeTo } from '../utils/captions.js';
 import { TextTrackLike } from '../utils/TextTrackLike.js';
 
-export const isMediaPlaying = (media) => {
-  return !media.paused && !media.ended && media.readyState > 2;
-}
-
 export const getSubtitleTracks = (stateOwners): TextTrackLike[] => {
   return getTextTracksList(stateOwners.media, (textTrack) => {
     return [TextTrackKinds.SUBTITLES, TextTrackKinds.CAPTIONS].includes(

--- a/src/js/media-store/util.ts
+++ b/src/js/media-store/util.ts
@@ -2,6 +2,10 @@ import { TextTrackKinds, TextTrackModes } from '../constants.js';
 import { getTextTracksList, updateTracksModeTo } from '../utils/captions.js';
 import { TextTrackLike } from '../utils/TextTrackLike.js';
 
+export const isMediaPlaying = (media) => {
+  return !media.paused && !media.ended && media.readyState > 2;
+}
+
 export const getSubtitleTracks = (stateOwners): TextTrackLike[] => {
   return getTextTracksList(stateOwners.media, (textTrack) => {
     return [TextTrackKinds.SUBTITLES, TextTrackKinds.CAPTIONS].includes(


### PR DESCRIPTION
this change hides the error dialog when playback recovers (playing event fires and media state indicates playing).