### PR TITLE
Fix/firefox pip button activates when clicked through on settings menu

### DIFF
--- a/src/js/menu/media-chrome-menu.ts
+++ b/src/js/menu/media-chrome-menu.ts
@@ -103,6 +103,19 @@ template.innerHTML = /*html*/ `
       position: relative;
       bottom: var(--_menu-bottom);
       box-sizing: border-box;
+    } 
+
+    @-moz-document url-prefix() {
+      :host::after{
+        content: "";
+        position: absolute;
+        top: 0; left: 0; right: 0; bottom: 0;
+        background: var(--media-settings-menu-background,
+        var(--media-menu-background,
+        var(--media-control-background,
+        var(--media-secondary-color, rgb(20 20 30)))));
+        z-index: -1;
+      }
     }
 
     :host([hidden]) {
@@ -463,7 +476,10 @@ class MediaChromeMenu extends globalThis.HTMLElement {
   }
 
   formatMenuItemText(text: string, data?: any) {
-    return (this.constructor as typeof MediaChromeMenu).formatMenuItemText(text, data);
+    return (this.constructor as typeof MediaChromeMenu).formatMenuItemText(
+      text,
+      data
+    );
   }
 
   get anchor() {
@@ -479,7 +495,9 @@ class MediaChromeMenu extends globalThis.HTMLElement {
    */
   get anchorElement() {
     if (this.anchor) {
-      return getDocumentOrShadowRoot(this)?.querySelector<HTMLElement>(`#${this.anchor}`);
+      return getDocumentOrShadowRoot(this)?.querySelector<HTMLElement>(
+        `#${this.anchor}`
+      );
     }
     return null;
   }
@@ -640,9 +658,11 @@ class MediaChromeMenu extends globalThis.HTMLElement {
     // Determine the real bottom value that is used for the max-height calculation.
     // `bottom` could have been overridden externally.
     const computedStyle = getComputedStyle(this);
-    const isBottomCalc = style.getPropertyValue('--_menu-bottom') === computedStyle.bottom;
+    const isBottomCalc =
+      style.getPropertyValue('--_menu-bottom') === computedStyle.bottom;
     const realBottom = isBottomCalc ? bottom : parseFloat(computedStyle.bottom);
-    const maxHeight = boundsRect.height - realBottom - parseFloat(computedStyle.marginBottom);
+    const maxHeight =
+      boundsRect.height - realBottom - parseFloat(computedStyle.marginBottom);
 
     // Safari required directly setting the element style property instead of
     // updating the style node for the styles to be refreshed.
@@ -731,9 +751,7 @@ class MediaChromeMenu extends globalThis.HTMLElement {
     ) as HTMLSlotElement;
     return headerSlot
       .assignedElements({ flatten: true })
-      ?.find(
-        (el) => el.matches('button[part~="back"]')
-      ) as HTMLElement;
+      ?.find((el) => el.matches('button[part~="back"]')) as HTMLElement;
   }
 
   handleSelect(event: MouseEvent | KeyboardEvent): void {

--- a/src/js/menu/media-chrome-menu.ts
+++ b/src/js/menu/media-chrome-menu.ts
@@ -106,15 +106,8 @@ template.innerHTML = /*html*/ `
     } 
 
     @-moz-document url-prefix() {
-      :host::after{
-        content: "";
-        position: absolute;
-        top: 0; left: 0; right: 0; bottom: 0;
-        background: var(--media-settings-menu-background,
-        var(--media-menu-background,
-        var(--media-control-background,
-        var(--media-secondary-color, rgb(20 20 30)))));
-        z-index: -1;
+      :host{
+        background: rgb(20 20 30);
       }
     }
 

--- a/src/js/menu/media-settings-menu.ts
+++ b/src/js/menu/media-settings-menu.ts
@@ -16,6 +16,19 @@ template.innerHTML = MediaChromeMenu.template.innerHTML + /*html*/`
       overflow: hidden;
     }
 
+     @-moz-document url-prefix() {
+      :host::after{
+        content: "";
+        position: absolute;
+        top: 0; left: 0; right: 0; bottom: 0;
+        background: var(--media-settings-menu-background,
+        var(--media-menu-background,
+        var(--media-control-background,
+        var(--media-secondary-color, rgb(20 20 30)))));
+        z-index: -1;
+      }
+    }
+
     :host([role="menu"]) {
       ${/* Bottom fix setting menu items for animation when the height expands. */ ''}
       justify-content: end;
@@ -46,7 +59,9 @@ class MediaSettingsMenu extends MediaChromeMenu {
    */
   get anchorElement() {
     if (this.anchor !== 'auto') return super.anchorElement;
-    return getMediaController(this).querySelector<HTMLElement>('media-settings-menu-button');
+    return getMediaController(this).querySelector<HTMLElement>(
+      'media-settings-menu-button'
+    );
   }
 }
 

--- a/src/js/menu/media-settings-menu.ts
+++ b/src/js/menu/media-settings-menu.ts
@@ -6,8 +6,7 @@ const template: HTMLTemplateElement = document.createElement('template');
 // prettier-ignore
 template.innerHTML = MediaChromeMenu.template.innerHTML + /*html*/`
   <style>
-    :host {
-      background: var(--media-settings-menu-background,
+    :host {     background: var(--media-settings-menu-background,
         var(--media-menu-background,
         var(--media-control-background,
         var(--media-secondary-color, rgb(20 20 30 / .8)))));
@@ -16,16 +15,9 @@ template.innerHTML = MediaChromeMenu.template.innerHTML + /*html*/`
       overflow: hidden;
     }
 
-     @-moz-document url-prefix() {
-      :host::after{
-        content: "";
-        position: absolute;
-        top: 0; left: 0; right: 0; bottom: 0;
-        background: var(--media-settings-menu-background,
-        var(--media-menu-background,
-        var(--media-control-background,
-        var(--media-secondary-color, rgb(20 20 30)))));
-        z-index: -1;
+      @-moz-document url-prefix() {
+      :host{
+        background: rgb(20 20 30);
       }
     }
 


### PR DESCRIPTION
Fix to this [issue ](https://github.com/muxinc/media-chrome/issues/1069) After a research we discover that Firefox uses their own PiP system adding a toggle overlaying videos which identify if the element hovering it has opacity 100% or not and if it doesnt the click event will trigger the toggle instead out menu.

For now this can be partially solved adding a css class for background that only applies into firefox and we created this [ticket](https://bugzilla.mozilla.org/show_bug.cgi?id=1947825) for get a better solution for them since we also discover Youtube had the same problem but tey created an exception for transparencies from 0.7 or higher for them identifying youtube by the domain. 

![Screenshot 2025-02-12 at 4 26 29 PM](https://github.com/user-attachments/assets/8d13fb64-dbd2-4f90-a61d-6e6ef1796a6d)


