### PR TITLE
show Auto(mediaHeight) in rendition menu

### DIFF
--- a/src/js/menu/media-rendition-menu.ts
+++ b/src/js/menu/media-rendition-menu.ts
@@ -17,7 +17,7 @@ import { Rendition } from '../media-store/state-mediator.js';
 
 /**
  * @extends {MediaChromeMenu}
- * 
+ *
  * @slot - Default slotted elements.
  * @slot header - An element shown at the top of the menu.
  * @slot checked-indicator - An icon element indicating a checked menu-item.
@@ -153,9 +153,13 @@ class MediaRenditionMenu extends MediaChromeMenu {
       this.defaultSlot.append(item);
     }
 
+    const text = isAuto
+      ? this.formatMenuItemText(`Auto (${this.mediaHeight}p)`)
+      : this.formatMenuItemText('Auto');
+
     const item = createMenuItem({
       type: 'radio',
-      text: this.formatMenuItemText('Auto'),
+      text,
       value: 'auto',
       checked: isAuto,
     });
@@ -168,6 +172,15 @@ class MediaRenditionMenu extends MediaChromeMenu {
   }
 
   #onChange(): void {
+    const autoOption = this.defaultSlot.querySelector('[value="auto"]');
+    const isAuto = autoOption.part.contains('checked');
+
+    if (isAuto) {
+      autoOption.textContent = `Auto (${this.mediaHeight}p)`;
+    } else {
+      autoOption.textContent = 'Auto';
+    }
+
     if (this.value == null) return;
 
     const event = new globalThis.CustomEvent(

--- a/src/js/menu/media-rendition-menu.ts
+++ b/src/js/menu/media-rendition-menu.ts
@@ -174,13 +174,8 @@ class MediaRenditionMenu extends MediaChromeMenu {
   #onChange(): void {
     const autoOption = this.defaultSlot.querySelector('[value="auto"]');
     const isAuto = autoOption.part.contains('checked');
-
-    if (isAuto) {
-      autoOption.textContent = `Auto (${this.mediaHeight}p)`;
-    } else {
-      autoOption.textContent = 'Auto';
-    }
-
+    autoOption.textContent = isAuto ? `Auto (${this.mediaHeight}p)` : 'Auto';
+    
     if (this.value == null) return;
 
     const event = new globalThis.CustomEvent(

--- a/src/js/menu/media-rendition-menu.ts
+++ b/src/js/menu/media-rendition-menu.ts
@@ -51,6 +51,7 @@ class MediaRenditionMenu extends MediaChromeMenu {
       oldValue !== newValue
     ) {
       this.value = newValue ?? 'auto';
+      this.#render();
     } else if (
       attrName === MediaUIAttributes.MEDIA_RENDITION_LIST &&
       oldValue !== newValue
@@ -172,10 +173,6 @@ class MediaRenditionMenu extends MediaChromeMenu {
   }
 
   #onChange(): void {
-    const autoOption = this.defaultSlot.querySelector('[value="auto"]');
-    const isAuto = autoOption.part.contains('checked');
-    autoOption.textContent = isAuto ? `Auto (${this.mediaHeight}p)` : 'Auto';
-    
     if (this.value == null) return;
 
     const event = new globalThis.CustomEvent(


### PR DESCRIPTION
Resolves #1052

## Changes
I added conditions to check if the `Auto` option is selected when the menu is rendered and when it detects a change. If `Auto` is selected, the `mediaHeight` will be shown in the option.
## Example video
https://github.com/user-attachments/assets/2e8513f1-8c16-420d-a60b-94722f79999e

