### PR TITLE
feat: persist mute state

### DIFF
--- a/src/js/media-store/request-map.ts
+++ b/src/js/media-store/request-map.ts
@@ -15,7 +15,7 @@ import { StateMediator, StateOwners } from './state-mediator.js';
 import { MediaState } from './media-store.js';
 
 export type MediaUIEventsType =
-typeof MediaUIEvents[keyof typeof MediaUIEvents];
+  typeof MediaUIEvents[keyof typeof MediaUIEvents];
 export type MediaRequestTypes = Exclude<
   MediaUIEventsType,
   | 'registermediastatereceiver'

--- a/src/js/media-store/request-map.ts
+++ b/src/js/media-store/request-map.ts
@@ -161,15 +161,13 @@ export const requestMap: RequestMap = {
   [MediaUIEvents.MEDIA_UNMUTE_REQUEST](stateMediator, stateOwners) {
     const key = 'mediaMuted';
     const value = false;
-    const preferredVolume =
+    const volumePref =
       +globalThis.localStorage.getItem('media-chrome-pref-volume') || +'0.25';
     // If we've unmuted but the current volume is 0, restore the preferred volume or set it to some low volume
-    if (!stateMediator.mediaVolume.get(stateOwners)) {
-      stateMediator.mediaVolume.set(
-        preferredVolume > 0.25 ? preferredVolume : 0.25,
-        stateOwners
-      );
-    }
+    stateMediator.mediaVolume.set(
+      volumePref > 0.25 ? volumePref : 0.25,
+      stateOwners
+    );
     stateMediator[key].set(value, stateOwners);
   },
   [MediaUIEvents.MEDIA_VOLUME_REQUEST](stateMediator, stateOwners, { detail }) {

--- a/src/js/media-store/request-map.ts
+++ b/src/js/media-store/request-map.ts
@@ -178,10 +178,6 @@ export const requestMap: RequestMap = {
     if (value && stateMediator.mediaMuted.get(stateOwners)) {
       stateMediator.mediaMuted.set(false, stateOwners);
     }
-    // If we've adjusted the volume to 0 and are unmuted, automatically mute.
-    if(value === '0' && !stateMediator.mediaMuted.get(stateOwners)){
-      stateMediator.mediaMuted.set(true, stateOwners);
-    }
     stateMediator[key].set(value, stateOwners);
   },
   [MediaUIEvents.MEDIA_SEEK_REQUEST](stateMediator, stateOwners, { detail }) {

--- a/src/js/media-store/request-map.ts
+++ b/src/js/media-store/request-map.ts
@@ -161,13 +161,10 @@ export const requestMap: RequestMap = {
   [MediaUIEvents.MEDIA_UNMUTE_REQUEST](stateMediator, stateOwners) {
     const key = 'mediaMuted';
     const value = false;
-    const volumePref =
-      +globalThis.localStorage.getItem('media-chrome-pref-volume');
-    // If we've unmuted but the current volume is 0, restore the preferred volume or set it to some low volume
-    stateMediator.mediaVolume.set(
-      volumePref > 0.25 ? volumePref : 0.25,
-      stateOwners
-    );
+    // If we've unmuted but our volume is currently 0, automatically set it to some low volume
+    if (!stateMediator.mediaVolume.get(stateOwners)) {
+      stateMediator.mediaVolume.set(0.25, stateOwners);
+    }
     stateMediator[key].set(value, stateOwners);
   },
   [MediaUIEvents.MEDIA_VOLUME_REQUEST](stateMediator, stateOwners, { detail }) {

--- a/src/js/media-store/request-map.ts
+++ b/src/js/media-store/request-map.ts
@@ -161,10 +161,6 @@ export const requestMap: RequestMap = {
   [MediaUIEvents.MEDIA_UNMUTE_REQUEST](stateMediator, stateOwners) {
     const key = 'mediaMuted';
     const value = false;
-    // If we've unmuted but our volume is currently 0, automatically set it to some low volume
-    if (!stateMediator.mediaVolume.get(stateOwners)) {
-      stateMediator.mediaVolume.set(0.25, stateOwners);
-    }
     stateMediator[key].set(value, stateOwners);
   },
   [MediaUIEvents.MEDIA_VOLUME_REQUEST](stateMediator, stateOwners, { detail }) {

--- a/src/js/media-store/request-map.ts
+++ b/src/js/media-store/request-map.ts
@@ -162,7 +162,7 @@ export const requestMap: RequestMap = {
     const key = 'mediaMuted';
     const value = false;
     const volumePref =
-      +globalThis.localStorage.getItem('media-chrome-pref-volume') || +'0.25';
+      +globalThis.localStorage.getItem('media-chrome-pref-volume');
     // If we've unmuted but the current volume is 0, restore the preferred volume or set it to some low volume
     stateMediator.mediaVolume.set(
       volumePref > 0.25 ? volumePref : 0.25,

--- a/src/js/media-store/request-map.ts
+++ b/src/js/media-store/request-map.ts
@@ -15,7 +15,7 @@ import { StateMediator, StateOwners } from './state-mediator.js';
 import { MediaState } from './media-store.js';
 
 export type MediaUIEventsType =
-  typeof MediaUIEvents[keyof typeof MediaUIEvents];
+typeof MediaUIEvents[keyof typeof MediaUIEvents];
 export type MediaRequestTypes = Exclude<
   MediaUIEventsType,
   | 'registermediastatereceiver'
@@ -161,6 +161,15 @@ export const requestMap: RequestMap = {
   [MediaUIEvents.MEDIA_UNMUTE_REQUEST](stateMediator, stateOwners) {
     const key = 'mediaMuted';
     const value = false;
+    const preferredVolume =
+      +globalThis.localStorage.getItem('media-chrome-pref-volume') || +'0.25';
+    // If we've unmuted but the current volume is 0, restore the preferred volume or set it to some low volume
+    if (!stateMediator.mediaVolume.get(stateOwners)) {
+      stateMediator.mediaVolume.set(
+        preferredVolume > 0.25 ? preferredVolume : 0.25,
+        stateOwners
+      );
+    }
     stateMediator[key].set(value, stateOwners);
   },
   [MediaUIEvents.MEDIA_VOLUME_REQUEST](stateMediator, stateOwners, { detail }) {

--- a/src/js/media-store/request-map.ts
+++ b/src/js/media-store/request-map.ts
@@ -178,6 +178,10 @@ export const requestMap: RequestMap = {
     if (value && stateMediator.mediaMuted.get(stateOwners)) {
       stateMediator.mediaMuted.set(false, stateOwners);
     }
+    // If we've adjusted the volume to 0 and are unmuted, automatically mute.
+    if(value === '0' && !stateMediator.mediaMuted.get(stateOwners)){
+      stateMediator.mediaMuted.set(true, stateOwners);
+    }
     stateMediator[key].set(value, stateOwners);
   },
   [MediaUIEvents.MEDIA_SEEK_REQUEST](stateMediator, stateOwners, { detail }) {

--- a/src/js/media-store/state-mediator.ts
+++ b/src/js/media-store/state-mediator.ts
@@ -446,14 +446,14 @@ export const stateMediator: StateMediator = {
           );
           const mutedPref =
             globalThis.localStorage.getItem('media-chrome-pref-muted') ===
-            'true';            
+            'true';
 
           if (volumePref == null) return;
           stateMediator.mediaVolume.set(+volumePref, stateOwners);
           stateMediator.mediaMuted.set(mutedPref, stateOwners);
           handler(+volumePref);
         } catch (e) {
-          console.debug('Error getting muted state or volume pref', e);
+          console.debug('Error getting muted or volume pref', e);
         }
       },
     ],

--- a/src/js/media-store/state-mediator.ts
+++ b/src/js/media-store/state-mediator.ts
@@ -86,6 +86,7 @@ export type StateOption = {
   defaultDuration?: number;
   liveEdgeOffset?: number;
   noVolumePref?: boolean;
+  noMutedPref?: boolean;
   noSubtitlesLangPref?: boolean;
 };
 
@@ -404,6 +405,10 @@ export const stateMediator: StateMediator = {
     mediaEvents: ['volumechange'],
     stateOwnersUpdateHandlers: [
       (handler, stateOwners) => {
+        const {
+          options: { noMutedPref },
+        } = stateOwners;
+        if (noMutedPref) return;
         try {
           const mutedPref =
             globalThis.localStorage.getItem('media-chrome-pref-muted') ===

--- a/src/js/media-store/state-mediator.ts
+++ b/src/js/media-store/state-mediator.ts
@@ -446,15 +446,11 @@ export const stateMediator: StateMediator = {
           );
           const mutedPref =
             globalThis.localStorage.getItem('media-chrome-pref-muted') ===
-            'true';
-
-          media.muted = mutedPref;
-          if (!mutedPref && volumePref !== null) {
-            media.volume = +volumePref;
-          }
+            'true';            
 
           if (volumePref == null) return;
           stateMediator.mediaVolume.set(+volumePref, stateOwners);
+          stateMediator.mediaMuted.set(mutedPref, stateOwners);
           handler(+volumePref);
         } catch (e) {
           console.debug('Error getting muted state or volume pref', e);

--- a/src/js/media-store/state-mediator.ts
+++ b/src/js/media-store/state-mediator.ts
@@ -402,6 +402,20 @@ export const stateMediator: StateMediator = {
       media.muted = value;
     },
     mediaEvents: ['volumechange'],
+    stateOwnersUpdateHandlers: [
+      (handler, stateOwners) => {
+        try {
+          const mutedPref =
+            globalThis.localStorage.getItem('media-chrome-pref-muted') ===
+            'true';
+
+          stateMediator.mediaMuted.set(mutedPref, stateOwners);
+          handler(mutedPref);
+        } catch (e) {
+          console.debug('Error getting muted pref', e);
+        }
+      },
+    ],
   },
   mediaVolume: {
     get(stateOwners) {
@@ -444,16 +458,12 @@ export const stateMediator: StateMediator = {
           const volumePref = globalThis.localStorage.getItem(
             'media-chrome-pref-volume'
           );
-          const mutedPref =
-            globalThis.localStorage.getItem('media-chrome-pref-muted') ===
-            'true';
 
           if (volumePref == null) return;
           stateMediator.mediaVolume.set(+volumePref, stateOwners);
-          stateMediator.mediaMuted.set(mutedPref, stateOwners);
           handler(+volumePref);
         } catch (e) {
-          console.debug('Error getting muted or volume pref', e);
+          console.debug('Error getting volume pref', e);
         }
       },
     ],

--- a/src/js/media-store/state-mediator.ts
+++ b/src/js/media-store/state-mediator.ts
@@ -408,7 +408,9 @@ export const stateMediator: StateMediator = {
         const {
           options: { noMutedPref },
         } = stateOwners;
-        if (noMutedPref) return;
+        const { media } = stateOwners;
+        // The muted enabled attribute should still override the preference.
+        if (!media || media.muted || noMutedPref) return;
         try {
           const mutedPref =
             globalThis.localStorage.getItem('media-chrome-pref-muted') ===

--- a/src/js/media-store/state-mediator.ts
+++ b/src/js/media-store/state-mediator.ts
@@ -391,22 +391,12 @@ export const stateMediator: StateMediator = {
       if (!media) return;
 
       try {
-        if (value) {
-          globalThis.localStorage.setItem('is-muted', 'true');
-          globalThis.localStorage.setItem(
-            'media-chrome-pref-volume',
-            media.volume.toString()
-          );
-          media.volume = 0;
-        } else {
-          globalThis.localStorage.setItem('is-muted', 'false');
-          const volumePref = globalThis.localStorage.getItem(
-            'media-chrome-pref-volume'
-          );
-          media.volume = +volumePref;
-        }
+        globalThis.localStorage.setItem(
+          'media-chrome-pref-muted',
+          value ? 'true' : 'false'
+        );
       } catch (e) {
-        console.debug('Error setting muted state or volume pref', e);
+        console.debug('Error setting muted pref', e);
       }
 
       media.muted = value;
@@ -454,11 +444,12 @@ export const stateMediator: StateMediator = {
           const volumePref = globalThis.localStorage.getItem(
             'media-chrome-pref-volume'
           );
-          const isMuted =
-            globalThis.localStorage.getItem('is-muted') === 'true';
+          const mutedPref =
+            globalThis.localStorage.getItem('media-chrome-pref-muted') ===
+            'true';
 
-          media.muted = isMuted;
-          if (!isMuted && volumePref !== null) {
+          media.muted = mutedPref;
+          if (!mutedPref && volumePref !== null) {
             media.volume = +volumePref;
           }
 

--- a/src/js/media-store/state-mediator.ts
+++ b/src/js/media-store/state-mediator.ts
@@ -391,26 +391,19 @@ export const stateMediator: StateMediator = {
       if (!media) return;
 
       try {
-        const volumeBeforeMute = globalThis.localStorage.getItem(
-          'media-chrome-pref-volume-before-mute'
-        );
         if (value) {
-          if (!volumeBeforeMute || volumeBeforeMute === '0') {
-            globalThis.localStorage.setItem(
-              'media-chrome-pref-volume-before-mute',
-              media.volume.toString()
-            );
-          }
+          globalThis.localStorage.setItem('is-muted', 'true');
+          globalThis.localStorage.setItem(
+            'media-chrome-pref-volume',
+            media.volume.toString()
+          );
           media.volume = 0;
-          globalThis.localStorage.setItem('media-chrome-pref-volume', '0');
         } else {
-          if (volumeBeforeMute !== null) {
-            media.volume = +volumeBeforeMute;
-            globalThis.localStorage.setItem(
-              'media-chrome-pref-volume',
-              volumeBeforeMute
-            );
-          }
+          globalThis.localStorage.setItem('is-muted', 'false');
+          const prefVolume = globalThis.localStorage.getItem(
+            'media-chrome-pref-volume'
+          );
+          media.volume = +prefVolume;
         }
       } catch (err) {
         // ignore
@@ -439,12 +432,6 @@ export const stateMediator: StateMediator = {
             'media-chrome-pref-volume',
             value.toString()
           );
-          if (!media.muted && value > 0) {
-            globalThis.localStorage.setItem(
-              'media-chrome-pref-volume-before-mute',
-              value.toString()
-            );
-          }
         }
       } catch (err) {
         // ignore
@@ -467,16 +454,11 @@ export const stateMediator: StateMediator = {
           const volumePref = globalThis.localStorage.getItem(
             'media-chrome-pref-volume'
           );
-          const volumeBeforeMute = globalThis.localStorage.getItem(
-            'media-chrome-pref-volume-before-mute'
-          );
-          const muteState = volumePref === '0';
+          const isMuted =
+            globalThis.localStorage.getItem('is-muted') === 'true';
 
-          if (muteState) {
+          if (isMuted) {
             media.muted = true;
-            if (volumeBeforeMute !== null) {
-              media.volume = +volumeBeforeMute;
-            }
           } else {
             if (volumePref !== null) {
               media.volume = +volumePref;

--- a/src/js/media-store/state-mediator.ts
+++ b/src/js/media-store/state-mediator.ts
@@ -400,13 +400,13 @@ export const stateMediator: StateMediator = {
           media.volume = 0;
         } else {
           globalThis.localStorage.setItem('is-muted', 'false');
-          const prefVolume = globalThis.localStorage.getItem(
+          const volumePref = globalThis.localStorage.getItem(
             'media-chrome-pref-volume'
           );
-          media.volume = +prefVolume;
+          media.volume = +volumePref;
         }
-      } catch (err) {
-        // ignore
+      } catch (e) {
+        console.debug('Error setting muted state or volume pref', e);
       }
 
       media.muted = value;
@@ -433,8 +433,8 @@ export const stateMediator: StateMediator = {
             value.toString()
           );
         }
-      } catch (err) {
-        // ignore
+      } catch (e) {
+        console.debug('Error setting volume pref', e);
       }
       if (!Number.isFinite(+value)) return;
       media.volume = +value;
@@ -457,19 +457,16 @@ export const stateMediator: StateMediator = {
           const isMuted =
             globalThis.localStorage.getItem('is-muted') === 'true';
 
-          if (isMuted) {
-            media.muted = true;
-          } else {
-            if (volumePref !== null) {
-              media.volume = +volumePref;
-            }
+          media.muted = isMuted;
+          if (!isMuted && volumePref !== null) {
+            media.volume = +volumePref;
           }
 
           if (volumePref == null) return;
           stateMediator.mediaVolume.set(+volumePref, stateOwners);
           handler(+volumePref);
         } catch (e) {
-          console.debug('Error getting volume pref', e);
+          console.debug('Error getting muted state or volume pref', e);
         }
       },
     ],


### PR DESCRIPTION
Closes #1072
## Changes
- `MEDIA_UNMUTE_REQUEST`: When unmuting, if the preferred volume is too low (<= 0.25), set the volume to 0.25. Otherwise, restore the preferred volume.
- `MEDIA_VOLUME_REQUEST`: When volume is 0 and are unmuted, automatically mute.
- `mediaMuted` set behavior: When muting, set `media-chrome-pref-muted` to `true` in localStorage and when unmuting set it to `false`.
- `stateOwnersUpdateHandlers` behavior: calls `mediaMuted`'s set with the `mutedPref` value.

I replicated the same user experience as yt when muting and unmuting (restoring the previously selected volume), with the exception that if the preferred volume is too low (<=0.25), it is set to 0.25 to ensure the audio is clearly perceptible. I'm open to any other suggestions for doing this :)