### PR TITLE
feat:hide-cursor-controls-on-inactivity

### DIFF
--- a/docs/src/pages/docs/en/components/media-controller.md
+++ b/docs/src/pages/docs/en/components/media-controller.md
@@ -25,7 +25,7 @@ Use this to enable audio chrome UI, which will not have any of the slots describ
 
 `autohide (seconds, default: 2)` (video only)
 
-Use this to autohide all controls/chrome (except for the `media`) after `n` seconds of inactivity, unless the media is paused. To disable `autohide`, set the value to -1.
+Use this to autohide all controls/chrome (except for the `media`) and the cursor after `n` seconds of inactivity, unless the media is paused. This only works if the controls are not being hovered. To disable `autohide`, set the value to -1.
 
 Example:
 
@@ -41,6 +41,20 @@ Example (`autohide` disabled):
 
 ```html
 <media-controller autohide="-1">
+  ...
+</media-controller>
+```
+
+### autohideovercontrols
+
+`autohideovercontrols (boolean)` 
+
+This attribute extends `autohide` by also hiding the controls and cursor, even if they are being hovered, in addition to the usual `autohide` behavior. If the media is paused, the controls and cursor remains visible.
+
+Example:
+
+```html
+<media-controller autohide autohideovercontrols>
   ...
 </media-controller>
 ```

--- a/examples/nextjs-with-typescript/src/app/globals.css
+++ b/examples/nextjs-with-typescript/src/app/globals.css
@@ -21,3 +21,9 @@
     text-wrap: balance;
   }
 }
+
+@layer components {
+  button, [role="button"] {
+    cursor: var(--custom-cursor, pointer);
+  }
+}

--- a/examples/nextjs-with-typescript/src/app/globals.css
+++ b/examples/nextjs-with-typescript/src/app/globals.css
@@ -24,6 +24,6 @@
 
 @layer components {
   button, [role="button"] {
-    cursor: var(--custom-cursor, pointer);
+    cursor: var(--media-cursor, pointer);
   }
 }

--- a/src/js/constants.ts
+++ b/src/js/constants.ts
@@ -108,7 +108,7 @@ export const MediaUIAttributes = MediaUIPropsEntries.reduce(
 ) as MediaUIAttributes;
 
 const AdditionalStateChangeEvents = {
-  USER_INACTIVE: 'userinactivechange',
+  USER_INACTIVE_CHANGE: 'userinactivechange',
   BREAKPOINTS_CHANGE: 'breakpointchange',
   BREAKPOINTS_COMPUTED: 'breakpointscomputed',
 } as const;
@@ -186,7 +186,8 @@ export const TextTrackKinds = {
   METADATA: 'metadata',
 } as const;
 
-export type TextTrackKinds = typeof TextTrackKinds[keyof typeof TextTrackKinds];
+export type TextTrackKinds =
+  (typeof TextTrackKinds)[keyof typeof TextTrackKinds];
 
 export const TextTrackModes = {
   DISABLED: 'disabled',
@@ -220,7 +221,7 @@ export const AvailabilityStates = {
 } as const;
 
 export type AvailabilityStates =
-  typeof AvailabilityStates[keyof typeof AvailabilityStates];
+  (typeof AvailabilityStates)[keyof typeof AvailabilityStates];
 
 export const StreamTypes = {
   LIVE: 'live',
@@ -228,7 +229,7 @@ export const StreamTypes = {
   UNKNOWN: 'unknown',
 } as const;
 
-export type StreamTypes = typeof StreamTypes[keyof typeof StreamTypes];
+export type StreamTypes = (typeof StreamTypes)[keyof typeof StreamTypes];
 
 export const VolumeLevels = {
   HIGH: 'high',

--- a/src/js/extras/media-clip-selector/index.ts
+++ b/src/js/extras/media-clip-selector/index.ts
@@ -35,7 +35,7 @@ template.innerHTML = `
     }
 
     #startHandle, #endHandle {
-      cursor: pointer;
+      cursor: var(--custom-cursor, pointer);
       height: 80%;
       width: ${HANDLE_W}px;
       border-radius: 4px;

--- a/src/js/extras/media-clip-selector/index.ts
+++ b/src/js/extras/media-clip-selector/index.ts
@@ -35,7 +35,7 @@ template.innerHTML = `
     }
 
     #startHandle, #endHandle {
-      cursor: var(--custom-cursor, pointer);
+      cursor: var(--media-cursor, pointer);
       height: 80%;
       width: ${HANDLE_W}px;
       border-radius: 4px;

--- a/src/js/media-chrome-button.ts
+++ b/src/js/media-chrome-button.ts
@@ -35,7 +35,7 @@ template.innerHTML = /*html*/ `
     box-sizing: border-box;
     transition: background .15s linear;
     pointer-events: auto;
-    cursor: pointer;
+    cursor: var(--custom-cursor, pointer);
     -webkit-tap-highlight-color: transparent;
   }
 

--- a/src/js/media-chrome-button.ts
+++ b/src/js/media-chrome-button.ts
@@ -35,7 +35,7 @@ template.innerHTML = /*html*/ `
     box-sizing: border-box;
     transition: background .15s linear;
     pointer-events: auto;
-    cursor: var(--custom-cursor, pointer);
+    cursor: var(--media-cursor, pointer);
     -webkit-tap-highlight-color: transparent;
   }
 

--- a/src/js/media-chrome-range.ts
+++ b/src/js/media-chrome-range.ts
@@ -26,7 +26,7 @@ template.innerHTML = /*html*/ `
       position: relative;
       width: 100px;
       transition: background .15s linear;
-      cursor: var(--custom-cursor, pointer);
+      cursor: var(--media-cursor, pointer);
       pointer-events: auto;
       touch-action: none; ${/* Prevent scrolling when dragging on mobile. */ ''}
     }
@@ -80,7 +80,7 @@ template.innerHTML = /*html*/ `
       height: var(--media-time-range-hover-height, max(100% + 7px, 25px));
       width: 100%;
       position: absolute;
-      cursor: var(--custom-cursor, pointer);
+      cursor: var(--media-cursor, pointer);
 
       -webkit-appearance: none; ${
         /* Hides the slider so that custom slider can be made */ ''
@@ -181,7 +181,7 @@ template.innerHTML = /*html*/ `
       translate: -50%;
       position: absolute;
       left: 0;
-      cursor: var(--custom-cursor, pointer);
+      cursor: var(--media-cursor, pointer);
     }
 
     #thumb {

--- a/src/js/media-chrome-range.ts
+++ b/src/js/media-chrome-range.ts
@@ -26,7 +26,7 @@ template.innerHTML = /*html*/ `
       position: relative;
       width: 100px;
       transition: background .15s linear;
-      cursor: pointer;
+      cursor: var(--custom-cursor, pointer);
       pointer-events: auto;
       touch-action: none; ${/* Prevent scrolling when dragging on mobile. */ ''}
     }
@@ -80,7 +80,7 @@ template.innerHTML = /*html*/ `
       height: var(--media-time-range-hover-height, max(100% + 7px, 25px));
       width: 100%;
       position: absolute;
-      cursor: pointer;
+      cursor: var(--custom-cursor, pointer);
 
       -webkit-appearance: none; ${
         /* Hides the slider so that custom slider can be made */ ''
@@ -181,7 +181,7 @@ template.innerHTML = /*html*/ `
       translate: -50%;
       position: absolute;
       left: 0;
-      cursor: pointer;
+      cursor: var(--custom-cursor, pointer);
     }
 
     #thumb {
@@ -393,7 +393,10 @@ class MediaChromeRange extends globalThis.HTMLElement {
 
     this.#cssRules.pointer = getOrInsertCSSRule(this.shadowRoot, '#pointer');
     this.#cssRules.progress = getOrInsertCSSRule(this.shadowRoot, '#progress');
-    this.#cssRules.thumb = getOrInsertCSSRule(this.shadowRoot, '#thumb, ::slotted([slot="thumb"])');
+    this.#cssRules.thumb = getOrInsertCSSRule(
+      this.shadowRoot,
+      '#thumb, ::slotted([slot="thumb"])'
+    );
     this.#cssRules.activeSegment = getOrInsertCSSRule(
       this.shadowRoot,
       '#segments-clipping rect:nth-child(0)'

--- a/src/js/media-container.ts
+++ b/src/js/media-container.ts
@@ -576,11 +576,11 @@ class MediaContainer extends globalThis.HTMLElement {
 
     // If hovering over something other than controls, we're free to make inactive
 
-    const alwaysFadeControls = this.hasAttribute(
+    const alwaysHideControls = this.hasAttribute(
       Attributes.ALWAYS_HIDE_CONTROLS
     );
     // @ts-ignore
-    if ([this, this.media].includes(event.target) || alwaysFadeControls) {
+    if ([this, this.media].includes(event.target) || alwaysHideControls) {
       this.#scheduleInactive();
     }
   }

--- a/src/js/media-container.ts
+++ b/src/js/media-container.ts
@@ -28,6 +28,7 @@ export const Attributes = {
   KEYBOARD_CONTROL: 'keyboardcontrol',
   NO_AUTOHIDE: 'noautohide',
   USER_INACTIVE: 'userinactive',
+  ALWAYS_HIDE_CONTROLS: 'alwayshidecontrols',
 };
 
 const template: HTMLTemplateElement = document.createElement('template');
@@ -185,6 +186,16 @@ template.innerHTML = /*html*/ `
 }])) ::slotted([slot=media]) {
       cursor: none;
     }
+
+    :host([${Attributes.USER_INACTIVE}][${
+  Attributes.ALWAYS_HIDE_CONTROLS
+}]:not([${MediaUIAttributes.MEDIA_PAUSED}]):not([${
+  MediaUIAttributes.MEDIA_IS_CASTING
+}]):not([${Attributes.AUDIO}])) * {
+     --custom-cursor: none;
+     cursor: none;
+    }
+
 
     ::slotted(media-control-bar)  {
       align-self: stretch;
@@ -564,8 +575,12 @@ class MediaContainer extends globalThis.HTMLElement {
     clearTimeout(this.#inactiveTimeout);
 
     // If hovering over something other than controls, we're free to make inactive
+
+    const alwaysFadeControls = this.hasAttribute(
+      Attributes.ALWAYS_HIDE_CONTROLS
+    );
     // @ts-ignore
-    if ([this, this.media].includes(event.target)) {
+    if ([this, this.media].includes(event.target) || alwaysFadeControls) {
       this.#scheduleInactive();
     }
   }
@@ -602,7 +617,7 @@ class MediaContainer extends globalThis.HTMLElement {
     this.setAttribute(Attributes.USER_INACTIVE, '');
 
     const evt = new globalThis.CustomEvent(
-      MediaStateChangeEvents.USER_INACTIVE,
+      MediaStateChangeEvents.USER_INACTIVE_CHANGE,
       { composed: true, bubbles: true, detail: true }
     );
     this.dispatchEvent(evt);
@@ -614,7 +629,7 @@ class MediaContainer extends globalThis.HTMLElement {
     this.removeAttribute(Attributes.USER_INACTIVE);
 
     const evt = new globalThis.CustomEvent(
-      MediaStateChangeEvents.USER_INACTIVE,
+      MediaStateChangeEvents.USER_INACTIVE_CHANGE,
       { composed: true, bubbles: true, detail: false }
     );
     this.dispatchEvent(evt);
@@ -683,6 +698,14 @@ class MediaContainer extends globalThis.HTMLElement {
 
   set noAutohide(value: boolean | undefined) {
     setBooleanAttr(this, Attributes.NO_AUTOHIDE, value);
+  }
+
+  get alwaysHideControls(): boolean | undefined {
+    return getBooleanAttr(this, Attributes.ALWAYS_HIDE_CONTROLS);
+  }
+
+  set alwaysHideControls(value: boolean | undefined) {
+    setBooleanAttr(this, Attributes.ALWAYS_HIDE_CONTROLS, value);
   }
 
   get userInteractive(): boolean | undefined {

--- a/src/js/media-container.ts
+++ b/src/js/media-container.ts
@@ -305,6 +305,7 @@ function getBreakpoints(breakpoints: Record<string, string>, width: number) {
  *
  * @attr {boolean} audio
  * @attr {string} autohide
+ * @attr {boolean} autohideovercontrols
  * @attr {string} breakpoints
  * @attr {boolean} gesturesdisabled
  * @attr {boolean} keyboardcontrol

--- a/src/js/media-container.ts
+++ b/src/js/media-container.ts
@@ -28,7 +28,7 @@ export const Attributes = {
   KEYBOARD_CONTROL: 'keyboardcontrol',
   NO_AUTOHIDE: 'noautohide',
   USER_INACTIVE: 'userinactive',
-  ALWAYS_HIDE_CONTROLS: 'alwayshidecontrols',
+  AUTOHIDE_OVER_CONTROLS: 'autohideovercontrols',
 };
 
 const template: HTMLTemplateElement = document.createElement('template');
@@ -179,7 +179,7 @@ template.innerHTML = /*html*/ `
       transition: var(--media-control-transition-out, opacity 1s);
     }
 
-    :host([${Attributes.USER_INACTIVE}]:not([${
+    :host([${Attributes.USER_INACTIVE}]:not([${Attributes.NO_AUTOHIDE}]):not([${
   MediaUIAttributes.MEDIA_PAUSED
 }]):not([${MediaUIAttributes.MEDIA_IS_CASTING}]):not([${
   Attributes.AUDIO
@@ -188,11 +188,11 @@ template.innerHTML = /*html*/ `
     }
 
     :host([${Attributes.USER_INACTIVE}][${
-  Attributes.ALWAYS_HIDE_CONTROLS
-}]:not([${MediaUIAttributes.MEDIA_PAUSED}]):not([${
-  MediaUIAttributes.MEDIA_IS_CASTING
-}]):not([${Attributes.AUDIO}])) * {
-     --custom-cursor: none;
+  Attributes.AUTOHIDE_OVER_CONTROLS
+}]:not([${Attributes.NO_AUTOHIDE}]):not([${
+  MediaUIAttributes.MEDIA_PAUSED
+}]):not([${MediaUIAttributes.MEDIA_IS_CASTING}]):not([${Attributes.AUDIO}])) * {
+     --media-cursor: none;
      cursor: none;
     }
 
@@ -576,11 +576,11 @@ class MediaContainer extends globalThis.HTMLElement {
 
     // If hovering over something other than controls, we're free to make inactive
 
-    const alwaysHideControls = this.hasAttribute(
-      Attributes.ALWAYS_HIDE_CONTROLS
+    const autohideOverControls = this.hasAttribute(
+      Attributes.AUTOHIDE_OVER_CONTROLS
     );
     // @ts-ignore
-    if ([this, this.media].includes(event.target) || alwaysHideControls) {
+    if ([this, this.media].includes(event.target) || autohideOverControls) {
       this.#scheduleInactive();
     }
   }
@@ -700,12 +700,12 @@ class MediaContainer extends globalThis.HTMLElement {
     setBooleanAttr(this, Attributes.NO_AUTOHIDE, value);
   }
 
-  get alwaysHideControls(): boolean | undefined {
-    return getBooleanAttr(this, Attributes.ALWAYS_HIDE_CONTROLS);
+  get autohideOverControls(): boolean | undefined {
+    return getBooleanAttr(this, Attributes.AUTOHIDE_OVER_CONTROLS);
   }
 
-  set alwaysHideControls(value: boolean | undefined) {
-    setBooleanAttr(this, Attributes.ALWAYS_HIDE_CONTROLS, value);
+  set autohideOverControls(value: boolean | undefined) {
+    setBooleanAttr(this, Attributes.AUTOHIDE_OVER_CONTROLS, value);
   }
 
   get userInteractive(): boolean | undefined {

--- a/src/js/media-live-button.ts
+++ b/src/js/media-live-button.ts
@@ -30,7 +30,7 @@ slotTemplate.innerHTML = /*html*/ `
   }
 
   :host([${MEDIA_TIME_IS_LIVE}]:not([${MEDIA_PAUSED}])) {
-    cursor: not-allowed;
+    cursor: var(--custom-cursor, not-allowed);
   }
 
   slot[name=text]{

--- a/src/js/media-live-button.ts
+++ b/src/js/media-live-button.ts
@@ -30,7 +30,7 @@ slotTemplate.innerHTML = /*html*/ `
   }
 
   :host([${MEDIA_TIME_IS_LIVE}]:not([${MEDIA_PAUSED}])) {
-    cursor: var(--custom-cursor, not-allowed);
+    cursor: var(--media-cursor, not-allowed);
   }
 
   slot[name=text]{

--- a/src/js/media-time-display.ts
+++ b/src/js/media-time-display.ts
@@ -115,7 +115,7 @@ class MediaTimeDisplay extends MediaTextDisplay {
       this.shadowRoot,
       ':host(:hover:not([notoggle]))'
     );
-    style.setProperty('cursor', 'var(--custom-cursor, pointer)');
+    style.setProperty('cursor', 'var(--media-cursor, pointer)');
     style.setProperty(
       'background',
       'var(--media-control-hover-background, rgba(50 50 70 / .7))'

--- a/src/js/media-time-display.ts
+++ b/src/js/media-time-display.ts
@@ -115,7 +115,7 @@ class MediaTimeDisplay extends MediaTextDisplay {
       this.shadowRoot,
       ':host(:hover:not([notoggle]))'
     );
-    style.setProperty('cursor', 'pointer');
+    style.setProperty('cursor', 'var(--custom-cursor, pointer)');
     style.setProperty(
       'background',
       'var(--media-control-hover-background, rgba(50 50 70 / .7))'

--- a/src/js/menu/media-chrome-menu-item.ts
+++ b/src/js/menu/media-chrome-menu-item.ts
@@ -16,7 +16,7 @@ template.innerHTML = /*html*/ `
       );
       outline: var(--media-menu-item-outline, 0);
       outline-offset: var(--media-menu-item-outline-offset, -1px);
-      cursor: pointer;
+      cursor: var(--custom-cursor, pointer);
       display: flex;
       align-items: center;
       align-self: stretch;
@@ -34,7 +34,7 @@ template.innerHTML = /*html*/ `
     }
 
     :host(:hover) {
-      cursor: pointer;
+      cursor: var(--custom-cursor, pointer);
       background: var(--media-menu-item-hover-background, rgb(92 92 102 / .5));
       outline: var(--media-menu-item-hover-outline);
       outline-offset: var(--media-menu-item-hover-outline-offset,  var(--media-menu-item-outline-offset, -1px));

--- a/src/js/menu/media-chrome-menu-item.ts
+++ b/src/js/menu/media-chrome-menu-item.ts
@@ -16,7 +16,7 @@ template.innerHTML = /*html*/ `
       );
       outline: var(--media-menu-item-outline, 0);
       outline-offset: var(--media-menu-item-outline-offset, -1px);
-      cursor: var(--custom-cursor, pointer);
+      cursor: var(--media-cursor, pointer);
       display: flex;
       align-items: center;
       align-self: stretch;
@@ -34,7 +34,7 @@ template.innerHTML = /*html*/ `
     }
 
     :host(:hover) {
-      cursor: var(--custom-cursor, pointer);
+      cursor: var(--media-cursor, pointer);
       background: var(--media-menu-item-hover-background, rgb(92 92 102 / .5));
       outline: var(--media-menu-item-hover-outline);
       outline-offset: var(--media-menu-item-hover-outline-offset,  var(--media-menu-item-outline-offset, -1px));

--- a/src/js/menu/media-chrome-menu.ts
+++ b/src/js/menu/media-chrome-menu.ts
@@ -167,12 +167,12 @@ template.innerHTML = /*html*/ `
     slot[name="header"]::slotted(*) {
       padding: .4em .7em;
       border-bottom: 1px solid rgb(255 255 255 / .25);
-      cursor: default;
+      cursor: var(--custom-cursor, default);
     }
 
     slot[name="header"] > button[part~="back"],
     slot[name="header"]::slotted(button[part~="back"]) {
-      cursor: pointer;
+      cursor: var(--custom-cursor, pointer);
     }
 
     svg[part~="back"] {

--- a/src/js/menu/media-chrome-menu.ts
+++ b/src/js/menu/media-chrome-menu.ts
@@ -167,12 +167,12 @@ template.innerHTML = /*html*/ `
     slot[name="header"]::slotted(*) {
       padding: .4em .7em;
       border-bottom: 1px solid rgb(255 255 255 / .25);
-      cursor: var(--custom-cursor, default);
+      cursor: var(--media-cursor, default);
     }
 
     slot[name="header"] > button[part~="back"],
     slot[name="header"]::slotted(button[part~="back"]) {
-      cursor: var(--custom-cursor, pointer);
+      cursor: var(--media-cursor, pointer);
     }
 
     svg[part~="back"] {


### PR DESCRIPTION
This PR resolves [issue #756](https://github.com/muxinc/media-chrome/issues/756), addressing the case where controls and the cursor should hide even when hovering over the controls.

### Changes Introduced
- Added the alwaysHideControls attribute to the media controller.
- When this attribute is present, controls and the cursor will hide after user inactivity, even if the user is hovering over the controls only if video is playing and not casting.

#### Behavior
##### With alwaysHideControls:
- After clicking play, if the user does not move the cursor, both the controls and cursor will hide—even when hovering over the controls.
#### Without alwaysHideControls (default behavior):
- Controls and cursor will only hide if the user is not hovering over the controls is playing and is not casting