### PR TITLE
feat: set i18n through media-controller

### DIFF
--- a/examples/vanilla/basic-i18n.html
+++ b/examples/vanilla/basic-i18n.html
@@ -32,7 +32,7 @@
     <main>
       <h1>Media Chrome - Basic Audio and Video Example</h1>
 
-      <media-controller audio language="fr">
+      <media-controller audio lang="fr">
         <audio
           slot="media"
           src="https://stream.mux.com/O4h5z00885HEucNNa1rV02wZapcGp01FXXoJd35AHmGX7g/audio.m4a"
@@ -50,7 +50,7 @@
       <br><br>
 
       <!-- Using a video tag for audio-only -->
-      <media-controller audio language="fr">
+      <media-controller audio lang="fr">
         <video
           playsinline
           slot="media"
@@ -68,7 +68,7 @@
 
       <br><br>
 
-      <media-controller language="fr">
+      <media-controller lang="fr">
         <video
           playsinline
           slot="media"

--- a/examples/vanilla/basic-i18n.html
+++ b/examples/vanilla/basic-i18n.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width" />
+    <title>Media Chrome Basic Audio and Video Usage Example</title>
+    <script type="module" src="../../dist/lang/fr.js"></script>
+    <script type="module" src="../../dist/index.js"></script>
+
+    <style>
+      /* Hide custom elements that are not defined yet */
+      :not(:defined) {
+        display: none;
+      }
+
+      /** add styles to prevent CLS (Cumulative Layout Shift) */
+      media-controller:not([audio]) {
+        display: block;         /* expands the container if preload=none */
+        max-width: 960px;       /* allows the container to shrink if small */
+        aspect-ratio: 2.4;   /* set container aspect ratio if preload=none */
+      }
+
+      video {
+        width: 100%;      /* prevents video to expand beyond its container */
+      }
+
+      .examples {
+        margin-top: 20px;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Media Chrome - Basic Audio and Video Example</h1>
+
+      <media-controller audio language="fr">
+        <audio
+          slot="media"
+          src="https://stream.mux.com/O4h5z00885HEucNNa1rV02wZapcGp01FXXoJd35AHmGX7g/audio.m4a"
+        ></audio>
+        <media-control-bar>
+          <media-play-button></media-play-button>
+          <media-time-display showduration></media-time-display>
+          <media-time-range></media-time-range>
+          <media-playback-rate-button></media-playback-rate-button>
+          <media-mute-button></media-mute-button>
+          <media-volume-range></media-volume-range>
+        </media-control-bar>
+      </media-controller>
+
+      <br><br>
+
+      <!-- Using a video tag for audio-only -->
+      <media-controller audio language="fr">
+        <video
+          playsinline
+          slot="media"
+          src="https://stream.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/high.mp4"
+        ></video>
+        <media-control-bar>
+          <media-play-button></media-play-button>
+          <media-time-display showduration></media-time-display>
+          <media-time-range></media-time-range>
+          <media-playback-rate-button></media-playback-rate-button>
+          <media-mute-button></media-mute-button>
+          <media-volume-range></media-volume-range>
+        </media-control-bar>
+      </media-controller>
+
+      <br><br>
+
+      <media-controller language="fr">
+        <video
+          playsinline
+          slot="media"
+          src="https://stream.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/high.mp4"
+        ></video>
+        <media-poster-image
+          slot="poster"
+          src="https://image.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/thumbnail.jpg"
+          placeholdersrc="data:image/jpeg;base64,/9j/2wBDABQODxIPDRQSEBIXFRQYHjIhHhwcHj0sLiQySUBMS0dARkVQWnNiUFVtVkVGZIhlbXd7gYKBTmCNl4x9lnN+gXz/2wBDARUXFx4aHjshITt8U0ZTfHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHz/wAARCAAUADADASIAAhEBAxEB/8QAGAAAAwEBAAAAAAAAAAAAAAAAAAECBAP/xAAdEAEBAAEEAwAAAAAAAAAAAAAAARECAxITFCFR/8QAGQEAAwADAAAAAAAAAAAAAAAAAAEDAgQF/8QAGBEBAQEBAQAAAAAAAAAAAAAAAAETERL/2gAMAwEAAhEDEQA/ANeC4ldyI1b2EtIzzrrIqYZLvl5FGkGdbfQzGPvo76WsPxXLlfqbaA5va2iVJADgPELACsD/2Q=="
+        ></media-poster-image>
+        <media-loading-indicator slot="centered-chrome" noautohide></media-loading-indicator>
+        <media-control-bar>
+          <media-play-button></media-play-button>
+          <media-mute-button></media-mute-button>
+          <media-volume-range></media-volume-range>
+          <media-time-display></media-time-display>
+          <media-time-range></media-time-range>
+          <media-duration-display></media-duration-display>
+          <media-playback-rate-button></media-playback-rate-button>
+          <media-fullscreen-button></media-fullscreen-button>
+        </media-control-bar>
+      </media-controller>
+
+      <div class="examples">
+        <a href="./">View more examples</a>
+      </div>
+    </main>
+  </body>
+</html>

--- a/src/js/media-controller.ts
+++ b/src/js/media-controller.ts
@@ -33,6 +33,7 @@ import {
 } from './utils/element-utils.js';
 import { createMediaStore, MediaStore } from './media-store/media-store.js';
 import { CustomElement } from './utils/CustomElement.js';
+import { i18n } from './utils/i18n.js';
 
 const ButtonPressedKeys = [
   'ArrowLeft',
@@ -61,6 +62,7 @@ export const Attributes = {
   NO_DEFAULT_STORE: 'nodefaultstore',
   KEYBOARD_FORWARD_SEEK_OFFSET: 'keyboardforwardseekoffset',
   KEYBOARD_BACKWARD_SEEK_OFFSET: 'keyboardbackwardseekoffset',
+  LANGUAGE: 'language',
 };
 
 /**
@@ -87,7 +89,8 @@ class MediaController extends MediaContainer {
       Attributes.HOTKEYS,
       Attributes.DEFAULT_STREAM_TYPE,
       Attributes.DEFAULT_SUBTITLES,
-      Attributes.DEFAULT_DURATION
+      Attributes.DEFAULT_DURATION,
+      Attributes.LANGUAGE
     );
   }
 
@@ -273,6 +276,15 @@ class MediaController extends MediaContainer {
     setBooleanAttr(this, Attributes.NO_DEFAULT_STORE, value);
   }
 
+  get language(): string | undefined {
+    return getStringAttr(this, Attributes.LANGUAGE);
+  }
+
+  set language(value: string | undefined) {
+    console.log('value', value);
+    setStringAttr(this, Attributes.LANGUAGE, value);
+  }
+
   attributeChangedCallback(
     attrName: string,
     oldValue: string | null,
@@ -333,6 +345,8 @@ class MediaController extends MediaContainer {
         type: 'fullscreenelementchangerequest',
         detail: this.fullscreenElement,
       });
+    } else if (attrName === Attributes.LANGUAGE && newValue !== oldValue) {
+      i18n.setLanguage(newValue);
     }
   }
 

--- a/src/js/media-controller.ts
+++ b/src/js/media-controller.ts
@@ -276,7 +276,7 @@ class MediaController extends MediaContainer {
     setBooleanAttr(this, Attributes.NO_DEFAULT_STORE, value);
   }
 
-  get language(): string | undefined {
+  get lang(): string | undefined {
     return getStringAttr(this, Attributes.LANGUAGE);
   }
 

--- a/src/js/media-controller.ts
+++ b/src/js/media-controller.ts
@@ -33,7 +33,7 @@ import {
 } from './utils/element-utils.js';
 import { createMediaStore, MediaStore } from './media-store/media-store.js';
 import { CustomElement } from './utils/CustomElement.js';
-import { i18n } from './utils/i18n.js';
+import { setLanguage } from './utils/i18n.js';
 
 const ButtonPressedKeys = [
   'ArrowLeft',
@@ -345,7 +345,7 @@ class MediaController extends MediaContainer {
         detail: this.fullscreenElement,
       });
     } else if (attrName === Attributes.LANGUAGE && newValue !== oldValue) {
-      i18n.setLanguage(newValue);
+      setLanguage(newValue);
     }
   }
 

--- a/src/js/media-controller.ts
+++ b/src/js/media-controller.ts
@@ -281,7 +281,6 @@ class MediaController extends MediaContainer {
   }
 
   set language(value: string | undefined) {
-    console.log('value', value);
     setStringAttr(this, Attributes.LANGUAGE, value);
   }
 

--- a/src/js/media-controller.ts
+++ b/src/js/media-controller.ts
@@ -62,7 +62,7 @@ export const Attributes = {
   NO_DEFAULT_STORE: 'nodefaultstore',
   KEYBOARD_FORWARD_SEEK_OFFSET: 'keyboardforwardseekoffset',
   KEYBOARD_BACKWARD_SEEK_OFFSET: 'keyboardbackwardseekoffset',
-  LANGUAGE: 'language',
+  LANGUAGE: 'lang',
 };
 
 /**

--- a/src/js/media-controller.ts
+++ b/src/js/media-controller.ts
@@ -280,7 +280,7 @@ class MediaController extends MediaContainer {
     return getStringAttr(this, Attributes.LANGUAGE);
   }
 
-  set language(value: string | undefined) {
+  set lang(value: string | undefined) {
     setStringAttr(this, Attributes.LANGUAGE, value);
   }
 

--- a/src/js/utils/i18n.ts
+++ b/src/js/utils/i18n.ts
@@ -4,6 +4,14 @@ const translationsLanguages = {
   en: En,
 };
 
+let currentLanguage = globalThis.navigator?.language.split('-')[0] || 'en';
+
+export const setLanguage = (langCode: string) => {
+  currentLanguage = langCode;
+};
+
+export const getLanguage = () => currentLanguage;
+
 export const addTranslation = (
   langCode: string,
   languageDictionary: TranslateDictionary
@@ -11,39 +19,11 @@ export const addTranslation = (
   translationsLanguages[langCode] = languageDictionary;
 };
 
-export class I18n {
-  private static instance: I18n;
-  private currentLanguage: string;
-
-  private constructor() {
-    this.currentLanguage = globalThis.navigator?.language.split('-')[0] || 'en';
-  }
-
-  public static getInstance(): I18n {
-    if (!I18n.instance) {
-      I18n.instance = new I18n();
-    }
-    return I18n.instance;
-  }
-
-  public setLanguage(langCode: string) {
-    this.currentLanguage = langCode;
-  }
-
-  public getLanguage(): string {
-    return this.currentLanguage;
-  }
-}
-
-const i18n = I18n.getInstance();
-
-export { i18n };
-
 export const t = (
   key: TranslateKeys,
   variables: Record<string, string | number> = {}
 ) => {
-  const result = translationsLanguages[i18n.getLanguage()]?.[key] || En[key];
+  const result = translationsLanguages[currentLanguage]?.[key] || En[key];
 
   return result.replace(/\{(\w+)\}/g, (_, varName) =>
     variables[varName] !== undefined

--- a/src/js/utils/i18n.ts
+++ b/src/js/utils/i18n.ts
@@ -10,8 +10,6 @@ export const setLanguage = (langCode: string) => {
   currentLanguage = langCode;
 };
 
-export const getLanguage = () => currentLanguage;
-
 export const addTranslation = (
   langCode: string,
   languageDictionary: TranslateDictionary

--- a/src/js/utils/i18n.ts
+++ b/src/js/utils/i18n.ts
@@ -11,13 +11,39 @@ export const addTranslation = (
   translationsLanguages[langCode] = languageDictionary;
 };
 
-const getBrowserLanguage = () => globalThis.navigator?.language.split('-')[0] || 'en';
+export class I18n {
+  private static instance: I18n;
+  private currentLanguage: string;
+
+  private constructor() {
+    this.currentLanguage = globalThis.navigator?.language.split('-')[0] || 'en';
+  }
+
+  public static getInstance(): I18n {
+    if (!I18n.instance) {
+      I18n.instance = new I18n();
+    }
+    return I18n.instance;
+  }
+
+  public setLanguage(langCode: string) {
+    this.currentLanguage = langCode;
+  }
+
+  public getLanguage(): string {
+    return this.currentLanguage;
+  }
+}
+
+const i18n = I18n.getInstance();
+
+export { i18n };
 
 export const t = (
   key: TranslateKeys,
   variables: Record<string, string | number> = {}
 ) => {
-  const result = translationsLanguages[getBrowserLanguage()]?.[key] || En[key];
+  const result = translationsLanguages[i18n.getLanguage()]?.[key] || En[key];
 
   return result.replace(/\{(\w+)\}/g, (_, varName) =>
     variables[varName] !== undefined


### PR DESCRIPTION
This adds ~~a singleton class~~ `let` to manage the language, and uses the browser language as fallback. If the browser language isn't present as language file, it'll just grab the `en`, like it did before.

The language for this can be set through an attribute on media-controller like in the example. So: 
```html
<media-controller language="fr"></media-controller>
```

Now this can be managed outside media-chrome through a cookie, interface element or whatsoever.