### PR TITLE
fix: race condition w/ default subtitles (Vue)

### DIFF
--- a/src/js/media-store/state-mediator.ts
+++ b/src/js/media-store/state-mediator.ts
@@ -695,6 +695,10 @@ export const stateMediator: StateMediator = {
           toggleSubtitleTracks(stateOwners, true);
         };
 
+        media.addEventListener(
+          'loadstart',
+          updateDefaultSubtitlesCallback
+        );
         media.textTracks?.addEventListener(
           'addtrack',
           updateDefaultSubtitlesCallback
@@ -704,10 +708,11 @@ export const stateMediator: StateMediator = {
           updateDefaultSubtitlesCallback
         );
 
-        // Invoke immediately as well, in case subs/cc tracks are already added
-        updateDefaultSubtitlesCallback();
-
         return () => {
+          media.removeEventListener(
+            'loadstart',
+            updateDefaultSubtitlesCallback
+          );
           media.textTracks?.removeEventListener(
             'addtrack',
             updateDefaultSubtitlesCallback


### PR DESCRIPTION
related https://github.com/muxinc/elements/issues/1062

fixes the above issue by delaying toggling subtitles on by default until the video loadstart event is triggered.