### PR TITLE
fix(fullscreen-api): mediaIsFullscreen state is updating properly

### DIFF
--- a/src/js/utils/fullscreen-api.ts
+++ b/src/js/utils/fullscreen-api.ts
@@ -154,11 +154,10 @@ export const isFullscreen = (stateOwners) => {
     }
 
     // If there is no shadowRoot or the shadowRoot exists but does not contain the fullScreenElement, no need to proceed further.
-    // Fallback: check if currentFullscreenElement is exactly fullscreenElement or if it contains fullscreenElement in its light DOM,
+    // Fallback: check if currentFullscreenElement contains fullscreenElement in its light DOM,
     // since there's no shadow DOM to traverse.
     if (!currentRoot || !currentRoot.contains(fullscreenElement)) {      
-      return currentFullscreenElement === fullscreenElement || 
-        currentFullscreenElement.contains(fullscreenElement);
+      return currentFullscreenElement.contains(fullscreenElement);
     }
 
     // If we get here, the shadowRoot exists and does contain the fullscreenElement,


### PR DESCRIPTION
Fixes #1104 

## Changes
- Added case to detect the `fullscreenElement` when no shadow root is present or the `fullscreenElement` is not in the current shadow root.