### PR TITLE
Discourage external access to example JS

### DIFF
--- a/examples/vanilla/index.html
+++ b/examples/vanilla/index.html
@@ -3,11 +3,6 @@
   <head>
     <meta name="viewport" content="width=device-width" />
     <title>Media Chrome Examples</title>
-    <!-- this page is getting hit with a lot of traffic, so we've enabled analytics to figure out where it's coming from -->
-    <script type="module">
-      import { inject } from 'https://cdn.jsdelivr.net/npm/@vercel/analytics@1.5.0/+esm'
-      inject();
-    </script>
   </head>
   <body>
     <h1>Explore the examples</h1>

--- a/middleware.ts
+++ b/middleware.ts
@@ -6,9 +6,11 @@ export const config = {
 
 const allowedDomains = [
   process.env.VERCEL_URL,
+  process.env.VERCEL_BRANCH_URL,
+  process.env.VERCEL_PROJECT_PRODUCTION_URL,
   'localhost',
   '127.0.0.1'
-];
+].filter(Boolean);
 
 const get403 = (url: URL) => 
   new Response(

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,37 @@
+import { next } from '@vercel/edge'
+
+export const config = {
+  matcher: '/dist/:path*.js',
+};
+
+const allowedDomains = [
+  process.env.VERCEL_URL,
+  'localhost',
+  '127.0.0.1'
+];
+
+const get403 = (url: URL) => 
+  new Response(
+    `Please use jsDelivr instead: https://cdn.jsdelivr.net/npm/media-chrome${url.pathname}`,
+    {
+      status: 403,
+      headers: {
+        'Content-Type': 'text/plain',
+      }
+    }
+  );
+
+export default function middleware(request: Request): Response {
+  const referer = request.headers.get('referer');
+  const url = new URL(request.url);
+
+  if (!referer) return get403(url);
+  
+  const refererUrl = new URL(referer);
+  const isAllowedDomain = allowedDomains.some(domain => 
+    refererUrl.hostname === domain || refererUrl.hostname.endsWith(`.${domain}`)
+  );
+  
+  if (!isAllowedDomain) return get403(url);
+  return next();
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -25,13 +25,19 @@ export default function middleware(request: Request): Response {
   const referer = request.headers.get('referer');
   const url = new URL(request.url);
 
-  if (!referer) return get403(url);
+  if (!referer) {
+    console.warn(`No referer header found for request to ${url}`);
+    return get403(url);
+  }
   
   const refererUrl = new URL(referer);
   const isAllowedDomain = allowedDomains.some(domain => 
     refererUrl.hostname === domain || refererUrl.hostname.endsWith(`.${domain}`)
   );
   
-  if (!isAllowedDomain) return get403(url);
+  if (!isAllowedDomain) {
+    console.warn(`Blocked request from disallowed domain: ${refererUrl.hostname}. Allowed domains: ${allowedDomains.join(', ')}`);
+    return get403(url);
+  }
   return next();
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "4.9.0",
       "license": "MIT",
       "dependencies": {
+        "@vercel/edge": "^1.2.1",
         "ce-la-react": "^0.1.3"
       },
       "devDependencies": {
@@ -1830,6 +1831,11 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@vercel/edge": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@vercel/edge/-/edge-1.2.1.tgz",
+      "integrity": "sha512-1++yncEyIAi68D3UEOlytYb1IUcIulMWdoSzX2h9LuSeeyR7JtaIgR8DcTQ6+DmYOQn+5MCh6LY+UmK6QBByNA=="
     },
     "node_modules/@web/browser-logs": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "url": "git+https://github.com/muxinc/media-chrome.git"
   },
   "dependencies": {
+    "@vercel/edge": "^1.2.1",
     "ce-la-react": "^0.1.3"
   },
   "devDependencies": {

--- a/vercel.json
+++ b/vercel.json
@@ -6,5 +6,20 @@
     "source": "/examples/", "destination": "/examples/vanilla/"
   }, {
     "source": "/examples/:path((?!vanilla/).*)", "destination": "/examples/vanilla/:path*"
-  }]
+  }],
+  "headers": [
+    {
+      "source": "/dist/(.*)\\.js",
+      "headers": [
+        {
+          "key": "Cross-Origin-Resource-Policy",
+          "value": "same-origin"
+        },
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex, nofollow"
+        }
+      ]
+    }
+  ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -6,20 +6,5 @@
     "source": "/examples/", "destination": "/examples/vanilla/"
   }, {
     "source": "/examples/:path((?!vanilla/).*)", "destination": "/examples/vanilla/:path*"
-  }],
-  "headers": [
-    {
-      "source": "/dist/(.*)\\.js",
-      "headers": [
-        {
-          "key": "Cross-Origin-Resource-Policy",
-          "value": "same-origin"
-        },
-        {
-          "key": "X-Robots-Tag",
-          "value": "noindex, nofollow"
-        }
-      ]
-    }
-  ]
+  }]
 }


### PR DESCRIPTION
We'd like to encourage users to access media chrome through npm or a CDN like jsdeliver