### PR TITLE
Add visual feedback in players with autoplay

### DIFF
--- a/src/js/media-controller.ts
+++ b/src/js/media-controller.ts
@@ -129,7 +129,7 @@ class MediaController extends MediaContainer {
           AttributeToStateChangeEventMap[attrName],
           { composed: true, detail: stateValue }
         );
-
+        
         this.dispatchEvent(evt);
       });
       prevState = nextState;
@@ -376,10 +376,10 @@ class MediaController extends MediaContainer {
     if (!this.#mediaStore && !this.hasAttribute(Attributes.NO_DEFAULT_STORE)) {
       this.#setupDefaultStore();
     }
-
-    // If the media element has the 'autoplay' attribute, simulate a "playing" state and
-    // display the loading indicator while metadata is loading (to have some visual feedback)
-    if (this.media?.hasAttribute('autoplay')) {
+    
+    // If the media element has the 'autoplay' and 'muted' attributes, simulate a "playing" state and
+    // display the loading indicator while metadata is still loading (to have some visual feedback)
+    if (this.media?.hasAttribute('autoplay') && this.media?.hasAttribute('muted')) {
       this.#isAutoplay = true;
       setBooleanAttr(this, MediaUIAttributes.MEDIA_PAUSED, false);
       setBooleanAttr(this, MediaUIAttributes.MEDIA_LOADING, true);
@@ -397,7 +397,7 @@ class MediaController extends MediaContainer {
     
       this.media?.addEventListener('play', onActualPlay, { once: true });
     }
-    
+
     this.#mediaStore?.dispatch({
       type: 'documentelementchangerequest',
       detail: document,


### PR DESCRIPTION
Closes #1078 

### Current behavior
When using a player with autoplay enabled, the play button remains in a paused state until the metadata is loaded and playback begins, so there is no visible indication that the video is preparing to play which leads to a confusing user experience.
## Changes
To provide immediate visual feedback, this PR simulates playback and loading states until the actual play event fires. 
- Added `#isAutoplay = false` to track simulated autoplay state.
- In connectedCallback: If the media element has the autoplay attribute => Set `mediaPaused = false` and `mediaLoading = true` to simulate playback. Listen for the actual play event to end the simulation and update real state.
- Updated propagateMediaState helper: Added `isAutoplay = false` param and skipped setting `mediaPaused` when `isAutoplay` is true to avoid misleading state changes before playback starts (when simulating autoplay).