### PR TITLE
Check that language exists before splitting

### DIFF
--- a/src/js/utils/i18n.ts
+++ b/src/js/utils/i18n.ts
@@ -4,7 +4,7 @@ const translationsLanguages = {
   en: En,
 };
 
-let currentLanguage = globalThis.navigator?.language.split('-')[0] || 'en';
+let currentLanguage = globalThis.navigator?.language?.split('-')[0] || 'en';
 
 export const setLanguage = (langCode: string) => {
   currentLanguage = langCode;


### PR DESCRIPTION
This code assumes that if there is a navigator, that `navigator.language` exists. Ran into issues server rendering on Cloudflare since they don't have this property.

I've made a report on their end, but this should be checked so we can safely fallback to `en` 

https://github.com/cloudflare/workerd/issues/4067 