### PR TITLE
Refresh ARIA labels and tooltips of components on media controller lang updates

### DIFF
--- a/examples/vanilla/index.html
+++ b/examples/vanilla/index.html
@@ -11,6 +11,7 @@
     <ul>
       <li><a href="basic.html">Basic example</a></li>
       <li><a href="advanced.html">Advanced example</a></li>
+      <li><a href="translations.html">Translations example</a></li>
       <li><a href="mobile.html">Mobile example</a></li>
       <li><a href="portrait.html">Portrait video example</a></li>
       <li><a href="casting.html">Casting video example</a></li>

--- a/examples/vanilla/translations.html
+++ b/examples/vanilla/translations.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width">
+    <title>Media Chrome Advanced Video Usage Example</title>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/hls-video-element@1.1/+esm"></script>
+    <script type="module" src="../../dist/index.js"></script>
+    <script type="module" src="../../dist/menu/index.js"></script>
+    <script type="module" src="../../dist/lang/es.js"></script>
+    <script type="module" src="../../dist/lang/pt.js"></script>
+    <script type="module" src="../../dist/lang/fr.js"></script>
+    <style>
+      /* Hide custom elements that are not defined yet */
+      :not(:defined) {
+        display: none;
+      }
+
+      /** add styles to prevent CLS (Cumulative Layout Shift) */
+      media-controller:not([audio]) {
+        display: grid;          /* expands the container if preload=none */
+        max-width: 960px;       /* allows the container to shrink if small */
+        aspect-ratio: 16 / 9;   /* set container aspect ratio if preload=none */
+      }
+
+      hls-video,
+      img[slot="poster"] {
+        grid-area: 1 / 1;     /* position poster img on top of video element */
+        width: 100%;          /* prevents video to expand beyond its container */
+        height: fit-content;  /* Fix Safari aspect-ratio overflow glitch for custom media elements */
+      }
+
+      media-audio-track-menu[mediaaudiotrackunavailable],
+      media-audio-track-menu-button[mediaaudiotrackunavailable],
+      media-rendition-menu[mediarenditionunavailable],
+      media-rendition-menu-button[mediarenditionunavailable],
+      media-fullscreen-button[mediafullscreenunavailable],
+      media-airplay-button[mediaairplayunavailable],
+      media-cast-button[mediacastunavailable],
+      media-pip-button[mediapipunavailable] {
+        display: none;
+      }
+
+      media-settings-menu-item[aria-haspopup]:is(
+        :not([submenusize]),
+        [submenusize="0"],
+        [submenusize="1"]
+      ) {
+        display: none;
+      }
+
+      .examples {
+        margin-top: 20px;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- The main tag is used to exclude other body content in https://www.media-chrome.org/docs/en/examples -->
+    <main>
+      <h1>Media Chrome - Advanced Video Usage Example</h1>
+
+      <media-controller
+        id="mc"
+        defaultsubtitles
+        keyboardforwardseekoffset="15"
+        keyboardbackwardseekoffset="5"
+      >
+        <hls-video
+          id="video"
+          slot="media"
+          src="https://stream.mux.com/Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008.m3u8"
+          stream-type="on-demand"
+          preload="metadata"
+          playsinline
+          crossorigin
+        >
+          <track default kind="metadata" label="thumbnails" src="https://image.mux.com/Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008/storyboard.vtt">
+          <track default kind="chapters" src="./vtt/elephantsdream/chapters.vtt">
+        </hls-video>
+        <img
+          slot="poster"
+          srcset="
+            https://image.mux.com/Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008/thumbnail.webp?time=13&width=640 640w,
+            https://image.mux.com/Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008/thumbnail.webp?time=13&width=960 960w,
+            https://image.mux.com/Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008/thumbnail.webp?time=13&width=1280 1280w,
+            https://image.mux.com/Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008/thumbnail.webp?time=13 1920w
+          "
+          alt="Elephants Dream"
+          decoding="async"
+        >
+        <media-loading-indicator slot="centered-chrome" noautohide></media-loading-indicator>
+        <media-error-dialog slot="dialog"></media-error-dialog>
+        <media-settings-menu anchor="auto" hidden>
+          <media-settings-menu-item>
+            Speed
+            <media-playback-rate-menu slot="submenu" hidden>
+              <div slot="title">Speed</div>
+            </media-playback-rate-menu>
+          </media-settings-menu-item>
+          <media-settings-menu-item>
+            Quality
+            <media-rendition-menu slot="submenu" hidden>
+              <div slot="title">Quality</div>
+            </media-rendition-menu>
+          </media-settings-menu-item>
+          <media-settings-menu-item>
+            Captions
+            <media-captions-menu slot="submenu" hidden>
+              <div slot="title">Captions</div>
+            </media-captions-menu>
+          </media-settings-menu-item>
+          <media-settings-menu-item>
+            Audio
+            <media-audio-track-menu slot="submenu" hidden>
+              <div slot="title">Audio</div>
+            </media-audio-track-menu>
+          </media-settings-menu-item>
+        </media-settings-menu>
+        <media-control-bar>
+          <media-play-button></media-play-button>
+          <media-seek-backward-button seekoffset="5"></media-seek-backward-button>
+          <media-seek-forward-button seekoffset="15"></media-seek-forward-button>
+          <media-mute-button></media-mute-button>
+          <media-time-display></media-time-display>
+          <media-time-range></media-time-range>
+          <media-duration-display></media-duration-display>
+          <media-settings-menu-button></media-settings-menu-button>
+          <media-pip-button></media-pip-button>
+          <media-cast-button></media-cast-button>
+          <media-airplay-button></media-airplay-button>
+          <media-fullscreen-button></media-fullscreen-button>
+        </media-control-bar>
+      </media-controller>
+    </main>
+
+    <p>
+        <button id='switch-spa' onclick='setLang("es")'>Switch to Spanish</button>
+        <button id='switch-spa' onclick='setLang("fr")'>Switch to French</button>
+        <button id='switch-spa' onclick='setLang("pt")'>Switch to Portuguese</button>
+        <button id='switch-spa' onclick='setLang("en")'>Switch to English</button>
+    </p>
+
+    <script>
+      function setLang(lang) {
+          const mediaController = document.getElementById('mc');
+          mediaController.setAttribute('lang', lang);
+      }
+    </script>
+
+    <div class="examples">
+      <a href="./">View more examples</a>
+    </div>
+  </body>
+</html>

--- a/src/js/constants.ts
+++ b/src/js/constants.ts
@@ -78,6 +78,7 @@ export const MediaUIProps = {
   MEDIA_VOLUME_LEVEL: 'mediaVolumeLevel',
   MEDIA_VOLUME_UNAVAILABLE: 'mediaVolumeUnavailable',
   MEDIA_WIDTH: 'mediaWidth',
+  LANG: 'lang',
 } as const;
 
 export type MediaUIProps = typeof MediaUIProps;

--- a/src/js/media-airplay-button.ts
+++ b/src/js/media-airplay-button.ts
@@ -44,14 +44,19 @@ slotTemplate.innerHTML = /*html*/ `
   </slot>
 `;
 
-const tooltipContent = /*html*/ `
+const createTooltipContent = () => /*html*/ `
   <slot name="tooltip-enter">${t('start airplay')}</slot>
   <slot name="tooltip-exit">${t('stop airplay')}</slot>
 `;
 
-const updateAriaLabel = (el: MediaAirplayButton): void => {
+const updateAriaLabelTooltip = (el: MediaAirplayButton): void => {
   const label = el.mediaIsAirplaying ? t('stop airplay') : t('start airplay');
   el.setAttribute('aria-label', label);
+
+  const tooltip = el.shadowRoot?.querySelector('slot[name="tooltip-content"]');
+  if (tooltip) {
+    tooltip.innerHTML = createTooltipContent();
+  }
 };
 
 /**
@@ -76,12 +81,12 @@ class MediaAirplayButton extends MediaChromeButton {
   }
 
   constructor(options: { slotTemplate?: HTMLTemplateElement } = {}) {
-    super({ slotTemplate, tooltipContent, ...options });
+    super({ slotTemplate, tooltipContent: createTooltipContent(), updateAriaLabelTooltip: ()=> updateAriaLabelTooltip(this), ...options });
   }
 
   connectedCallback(): void {
     super.connectedCallback();
-    updateAriaLabel(this);
+    updateAriaLabelTooltip(this);
   }
 
   attributeChangedCallback(
@@ -92,7 +97,7 @@ class MediaAirplayButton extends MediaChromeButton {
     super.attributeChangedCallback(attrName, oldValue, newValue);
 
     if (attrName === MediaUIAttributes.MEDIA_IS_AIRPLAYING) {
-      updateAriaLabel(this);
+      updateAriaLabelTooltip(this);
     }
   }
 

--- a/src/js/media-captions-button.ts
+++ b/src/js/media-captions-button.ts
@@ -41,13 +41,19 @@ slotTemplate.innerHTML = /*html*/ `
   </slot>
 `;
 
-const tooltipContent = /*html*/ `
+const createTooltipContent = () => /*html*/ `
   <slot name="tooltip-enable">${t('Enable captions')}</slot>
   <slot name="tooltip-disable">${t('Disable captions')}</slot>
 `;
 
-const updateAriaChecked = (el: HTMLElement) => {
+const updateAriaCheckedTooltip = (el: HTMLElement) => {
   el.setAttribute('aria-checked', areSubsOn(el).toString());
+  el.setAttribute('aria-label', t('closed captions'));
+
+  const tooltip = el.shadowRoot?.querySelector('slot[name="tooltip-content"]');
+  if (tooltip) {
+    tooltip.innerHTML = createTooltipContent();
+  }
 };
 
 /**
@@ -72,7 +78,8 @@ class MediaCaptionsButton extends MediaChromeButton {
   private _captionsReady: boolean;
 
   constructor(options: any = {}) {
-    super({ slotTemplate, tooltipContent, ...options });
+    super({ slotTemplate, tooltipContent: createTooltipContent(), updateAriaLabelTooltip: ()=> updateAriaCheckedTooltip(this), ...options });
+
     // Internal variable to keep track of when we have some or no captions (or subtitles, if using subtitles fallback)
     // Used for `default-showing` behavior.
     this._captionsReady = false;
@@ -81,8 +88,7 @@ class MediaCaptionsButton extends MediaChromeButton {
   connectedCallback(): void {
     super.connectedCallback();
     this.setAttribute('role', 'switch');
-    this.setAttribute('aria-label', t('closed captions'));
-    updateAriaChecked(this);
+    updateAriaCheckedTooltip(this);
   }
 
   attributeChangedCallback(
@@ -92,8 +98,8 @@ class MediaCaptionsButton extends MediaChromeButton {
   ) {
     super.attributeChangedCallback(attrName, oldValue, newValue);
 
-    if (attrName === MediaUIAttributes.MEDIA_SUBTITLES_SHOWING) {
-      updateAriaChecked(this);
+    if (attrName === MediaUIAttributes.MEDIA_SUBTITLES_SHOWING || attrName === MediaUIAttributes.LANG) {
+      updateAriaCheckedTooltip(this);
     }
   }
 

--- a/src/js/media-cast-button.ts
+++ b/src/js/media-cast-button.ts
@@ -43,14 +43,19 @@ slotTemplate.innerHTML = /*html*/ `
   </slot>
 `;
 
-const tooltipContent = /*html*/ `
+const createTooltipContent = () => /*html*/ `
   <slot name="tooltip-enter">${t('Start casting')}</slot>
   <slot name="tooltip-exit">${t('Stop casting')}</slot>
 `;
 
-const updateAriaLabel = (el: MediaCastButton) => {
+const updateAriaLabelTooltip = (el: MediaCastButton) => {
   const label = el.mediaIsCasting ? t('stop casting') : t('start casting');
   el.setAttribute('aria-label', label);
+
+  const tooltip = el.shadowRoot?.querySelector('slot[name="tooltip-content"]');
+  if (tooltip) {
+    tooltip.innerHTML = createTooltipContent();
+  }
 };
 
 /**
@@ -73,12 +78,12 @@ class MediaCastButton extends MediaChromeButton {
   }
 
   constructor(options = {}) {
-    super({ slotTemplate, tooltipContent, ...options });
+    super({ slotTemplate, tooltipContent: createTooltipContent(), updateAriaLabelTooltip: ()=> updateAriaLabelTooltip(this), ...options });
   }
 
   connectedCallback(): void {
     super.connectedCallback();
-    updateAriaLabel(this);
+    updateAriaLabelTooltip(this);
   }
 
   attributeChangedCallback(
@@ -88,8 +93,8 @@ class MediaCastButton extends MediaChromeButton {
   ) {
     super.attributeChangedCallback(attrName, oldValue, newValue);
 
-    if (attrName === MediaUIAttributes.MEDIA_IS_CASTING) {
-      updateAriaLabel(this);
+    if (attrName === MediaUIAttributes.MEDIA_IS_CASTING || attrName === MediaUIAttributes.LANG) {
+      updateAriaLabelTooltip(this);
     }
   }
 

--- a/src/js/media-controller.ts
+++ b/src/js/media-controller.ts
@@ -33,7 +33,6 @@ import {
 } from './utils/element-utils.js';
 import { createMediaStore, MediaStore } from './media-store/media-store.js';
 import { CustomElement } from './utils/CustomElement.js';
-import { setLanguage } from './utils/i18n.js';
 
 const ButtonPressedKeys = [
   'ArrowLeft',
@@ -63,7 +62,6 @@ export const Attributes = {
   NO_DEFAULT_STORE: 'nodefaultstore',
   KEYBOARD_FORWARD_SEEK_OFFSET: 'keyboardforwardseekoffset',
   KEYBOARD_BACKWARD_SEEK_OFFSET: 'keyboardbackwardseekoffset',
-  LANG: 'lang',
 };
 
 /**
@@ -83,7 +81,6 @@ export const Attributes = {
  * @attr {boolean} novolumepref
  * @attr {boolean} nosubtitleslangpref
  * @attr {boolean} nodefaultstore
- * @attr {string} lang
  */
 class MediaController extends MediaContainer {
   static get observedAttributes() {
@@ -93,7 +90,6 @@ class MediaController extends MediaContainer {
       Attributes.DEFAULT_STREAM_TYPE,
       Attributes.DEFAULT_SUBTITLES,
       Attributes.DEFAULT_DURATION,
-      Attributes.LANG
     );
   }
 
@@ -364,9 +360,7 @@ class MediaController extends MediaContainer {
         type: 'fullscreenelementchangerequest',
         detail: this.fullscreenElement,
       });
-    } else if (attrName === Attributes.LANG && newValue !== oldValue) {
-      setLanguage(newValue);
-    }
+    } 
   }
 
   connectedCallback(): void {

--- a/src/js/media-fullscreen-button.ts
+++ b/src/js/media-fullscreen-button.ts
@@ -55,12 +55,12 @@ slotTemplate.innerHTML = /*html*/ `
   </slot>
 `;
 
-const tooltipContent = /*html*/ `
+const createTooltipContent = () => /*html*/ `
   <slot name="tooltip-enter">${t('Enter fullscreen mode')}</slot>
   <slot name="tooltip-exit">${t('Exit fullscreen mode')}</slot>
 `;
 
-const updateAriaLabel = (el: MediaFullscreenButton) => {
+const updateAriaLabelTooltip = (el: MediaFullscreenButton) => {
   const label = el.mediaIsFullscreen
     ? t('exit fullscreen mode')
     : t('enter fullscreen mode');
@@ -87,12 +87,12 @@ class MediaFullscreenButton extends MediaChromeButton {
   }
 
   constructor(options: object = {}) {
-    super({ slotTemplate, tooltipContent, ...options });
+    super({ slotTemplate, tooltipContent: createTooltipContent(), updateAriaLabelTooltip: ()=> updateAriaLabelTooltip(this), ...options });
   }
 
   connectedCallback(): void {
     super.connectedCallback();
-    updateAriaLabel(this);
+    updateAriaLabelTooltip(this);
   }
 
   attributeChangedCallback(
@@ -103,7 +103,7 @@ class MediaFullscreenButton extends MediaChromeButton {
     super.attributeChangedCallback(attrName, oldValue, newValue);
 
     if (attrName === MediaUIAttributes.MEDIA_IS_FULLSCREEN) {
-      updateAriaLabel(this);
+      updateAriaLabelTooltip(this);
     }
   }
 

--- a/src/js/media-live-button.ts
+++ b/src/js/media-live-button.ts
@@ -49,10 +49,16 @@ slotTemplate.innerHTML = /*html*/ `
   <slot name="spacer">&nbsp;</slot><slot name="text">${t('live')}</slot>
 `;
 
-const updateAriaAttributes = (el: MediaLiveButton): void => {
+const updateAriaAttributesLabel = (el: MediaLiveButton): void => {
   const isPausedOrNotLive = el.mediaPaused || !el.mediaTimeIsLive;
   const label = isPausedOrNotLive ? t('seek to live') : t('playing live');
   el.setAttribute('aria-label', label);
+
+  const status = el.shadowRoot?.querySelector('slot[name=text]');
+  if (status) {
+    const liveText = t('live');
+    status.textContent = liveText;
+  }
 
   isPausedOrNotLive
     ? el.removeAttribute('aria-disabled')
@@ -77,11 +83,11 @@ class MediaLiveButton extends MediaChromeButton {
   }
 
   constructor(options: object = {}) {
-    super({ slotTemplate, ...options });
+    super({ slotTemplate, updateAriaLabelTooltip: ()=> updateAriaAttributesLabel(this), ...options });
   }
 
   connectedCallback(): void {
-    updateAriaAttributes(this);
+    updateAriaAttributesLabel(this);
     super.connectedCallback();
   }
 
@@ -91,7 +97,7 @@ class MediaLiveButton extends MediaChromeButton {
     newValue: string | null
   ): void {
     super.attributeChangedCallback(attrName, oldValue, newValue);
-    updateAriaAttributes(this);
+    updateAriaAttributesLabel(this);
   }
 
   /**

--- a/src/js/media-mute-button.ts
+++ b/src/js/media-mute-button.ts
@@ -53,15 +53,20 @@ slotTemplate.innerHTML = /*html*/ `
   </slot>
 `;
 
-const tooltipContent = /*html*/ `
+const createTooltipContent = () => /*html*/ `
   <slot name="tooltip-mute">${t('Mute')}</slot>
   <slot name="tooltip-unmute">${t('Unmute')}</slot>
 `;
 
-const updateAriaLabel = (el: MediaMuteButton) => {
+const updateAriaLabelTooltip = (el: MediaMuteButton) => {
   const muted = el.mediaVolumeLevel === 'off';
   const label = muted ? t('unmute') : t('mute');
   el.setAttribute('aria-label', label);
+
+  const tooltip = el.shadowRoot?.querySelector('slot[name="tooltip-content"]');
+  if (tooltip) {
+    tooltip.innerHTML = createTooltipContent();
+  }
 };
 
 /**
@@ -81,11 +86,11 @@ class MediaMuteButton extends MediaChromeButton {
   }
 
   constructor(options: object = {}) {
-    super({ slotTemplate, tooltipContent, ...options });
+    super({ slotTemplate, tooltipContent: createTooltipContent(), updateAriaLabelTooltip: ()=> updateAriaLabelTooltip(this), ...options });
   }
 
   connectedCallback(): void {
-    updateAriaLabel(this);
+    updateAriaLabelTooltip(this);
     super.connectedCallback();
   }
 
@@ -95,7 +100,7 @@ class MediaMuteButton extends MediaChromeButton {
     newValue: string | null
   ): void {
     if (attrName === MediaUIAttributes.MEDIA_VOLUME_LEVEL) {
-      updateAriaLabel(this);
+      updateAriaLabelTooltip(this);
     }
     super.attributeChangedCallback(attrName, oldValue, newValue);
   }

--- a/src/js/media-pip-button.ts
+++ b/src/js/media-pip-button.ts
@@ -41,16 +41,21 @@ slotTemplate.innerHTML = /*html*/ `
   </slot>
 `;
 
-const tooltipContent = /*html*/ `
+const createTooltipContent = () => /*html*/ `
   <slot name="tooltip-enter">${t('Enter picture in picture mode')}</slot>
   <slot name="tooltip-exit">${t('Exit picture in picture mode')}</slot>
 `;
 
-const updateAriaLabel = (el: MediaPipButton): void => {
+const updateAriaLabelTooltip = (el: MediaPipButton): void => {
   const label = el.mediaIsPip
     ? t('exit picture in picture mode')
     : t('enter picture in picture mode');
   el.setAttribute('aria-label', label);
+
+  const tooltip = el.shadowRoot?.querySelector('slot[name="tooltip-content"]');
+  if (tooltip) {
+    tooltip.innerHTML = createTooltipContent();
+  }
 };
 
 /**
@@ -73,11 +78,11 @@ class MediaPipButton extends MediaChromeButton {
   }
 
   constructor(options: object = {}) {
-    super({ slotTemplate, tooltipContent, ...options });
+    super({ slotTemplate, tooltipContent: createTooltipContent(), updateAriaLabelTooltip: ()=> updateAriaLabelTooltip(this), ...options });
   }
 
   connectedCallback(): void {
-    updateAriaLabel(this);
+    updateAriaLabelTooltip(this);
     super.connectedCallback();
   }
 
@@ -87,7 +92,7 @@ class MediaPipButton extends MediaChromeButton {
     newValue: string | null
   ): void {
     if (attrName === MediaUIAttributes.MEDIA_IS_PIP) {
-      updateAriaLabel(this);
+      updateAriaLabelTooltip(this);
     }
     super.attributeChangedCallback(attrName, oldValue, newValue);
   }

--- a/src/js/media-play-button.ts
+++ b/src/js/media-play-button.ts
@@ -32,14 +32,19 @@ slotTemplate.innerHTML = /*html*/ `
   </slot>
 `;
 
-const tooltipContent = /*html*/ `
+const createTooltipContent = () => /*html*/ `
   <slot name="tooltip-play">${t('Play')}</slot>
   <slot name="tooltip-pause">${t('Pause')}</slot>
 `;
 
-const updateAriaLabel = (el: any): void => {
+const updateAriaLabelTooltip = (el: any): void => {
   const label = el.mediaPaused ? t('play') : t('pause');
   el.setAttribute('aria-label', label);
+
+  const tooltip = el.shadowRoot?.querySelector('slot[name="tooltip-content"]');
+  if (tooltip) {
+    tooltip.innerHTML = createTooltipContent();
+  }
 };
 
 /**
@@ -61,11 +66,11 @@ class MediaPlayButton extends MediaChromeButton {
   }
 
   constructor(options = {}) {
-    super({ slotTemplate, tooltipContent, ...options });
+    super({ slotTemplate, tooltipContent: createTooltipContent(), updateAriaLabelTooltip: ()=> updateAriaLabelTooltip(this), ...options });
   }
 
   connectedCallback(): void {
-    updateAriaLabel(this);
+    updateAriaLabelTooltip(this);
     super.connectedCallback();
   }
 
@@ -75,7 +80,7 @@ class MediaPlayButton extends MediaChromeButton {
     newValue: string | null
   ): void {
     if (attrName === MediaUIAttributes.MEDIA_PAUSED) {
-      updateAriaLabel(this);
+      updateAriaLabelTooltip(this);
     }
     super.attributeChangedCallback(attrName, oldValue, newValue);
   }

--- a/src/js/media-playback-rate-button.ts
+++ b/src/js/media-playback-rate-button.ts
@@ -22,6 +22,19 @@ slotTemplate.innerHTML = /*html*/ `
   </style>
   <slot name="icon"></slot>
 `;
+const createTooltipContent = () => /*html*/ `
+  ${t('Playback rate')}
+`;
+
+const updateAriaLabelTooltip = (el: MediaPlaybackRateButton, playbackRate: number) => {
+  const label = t('Playback rate {playbackRate}', { playbackRate })
+  el.setAttribute('aria-label', label)
+
+  const tooltip = el.shadowRoot?.querySelector('slot[name="tooltip-content"]');
+  if (tooltip) {
+    tooltip.innerHTML = createTooltipContent();
+  }
+};
 
 /**
  * @attr {string} rates - Set custom playback rates for the user to choose from.
@@ -47,7 +60,8 @@ class MediaPlaybackRateButton extends MediaChromeButton {
   constructor(options = {}) {
     super({
       slotTemplate,
-      tooltipContent: t('Playback rate'),
+      tooltipContent: createTooltipContent(),
+      updateAriaLabelTooltip: () => updateAriaLabelTooltip(this, DEFAULT_RATE),
       ...options,
     });
     this.container = this.shadowRoot.querySelector('slot[name="icon"]');
@@ -70,10 +84,7 @@ class MediaPlaybackRateButton extends MediaChromeButton {
         ? newPlaybackRate
         : DEFAULT_RATE;
       this.container.innerHTML = `${playbackRate}x`;
-      this.setAttribute(
-        'aria-label',
-        t('Playback rate {playbackRate}', { playbackRate })
-      );
+      updateAriaLabelTooltip(this, playbackRate);
     }
   }
 

--- a/src/js/media-seek-backward-button.ts
+++ b/src/js/media-seek-backward-button.ts
@@ -18,6 +18,20 @@ slotTemplate.innerHTML = `
   <slot name="icon">${backwardIcon}</slot>
 `;
 
+const createTooltipContent = () => /*html*/ `
+  ${t('Seek backward')}
+`;
+
+const updateAriaLabelTooltip = (el: MediaSeekBackwardButton) => {
+  const label = t('seek back {seekOffset} seconds', { seekOffset: el.seekOffset && DEFAULT_SEEK_OFFSET })
+  el.setAttribute('aria-label', label)
+
+  const tooltip = el.shadowRoot?.querySelector('slot[name="tooltip-content"]');
+  if (tooltip) {
+    tooltip.innerHTML = createTooltipContent();
+  }
+};
+
 const DEFAULT_TIME = 0;
 
 /**
@@ -40,7 +54,8 @@ class MediaSeekBackwardButton extends MediaChromeButton {
   constructor(options = {}) {
     super({
       slotTemplate,
-      tooltipContent: t('Seek backward'),
+      tooltipContent: createTooltipContent(),
+      updateAriaLabelTooltip: () => updateAriaLabelTooltip(this),
       ...options,
     });
   }
@@ -51,6 +66,7 @@ class MediaSeekBackwardButton extends MediaChromeButton {
       Attributes.SEEK_OFFSET,
       DEFAULT_SEEK_OFFSET
     );
+    updateAriaLabelTooltip(this);
     super.connectedCallback();
   }
 
@@ -60,6 +76,7 @@ class MediaSeekBackwardButton extends MediaChromeButton {
     newValue: string | null
   ): void {
     if (attrName === Attributes.SEEK_OFFSET) {
+      updateAriaLabelTooltip(this);
       this.seekOffset = getNumericAttr(
         this,
         Attributes.SEEK_OFFSET,
@@ -81,10 +98,7 @@ class MediaSeekBackwardButton extends MediaChromeButton {
 
   set seekOffset(value: number) {
     setNumericAttr(this, Attributes.SEEK_OFFSET, value);
-    this.setAttribute(
-      'aria-label',
-      t('seek back {seekOffset} seconds', { seekOffset: this.seekOffset })
-    );
+    updateAriaLabelTooltip(this);
     updateIconText(getSlotted(this, 'icon'), this.seekOffset as any);
   }
 

--- a/src/js/media-seek-forward-button.ts
+++ b/src/js/media-seek-forward-button.ts
@@ -18,6 +18,20 @@ slotTemplate.innerHTML = `
   <slot name="icon">${forwardIcon}</slot>
 `;
 
+const createTooltipContent = () => /*html*/ `
+  ${t('Seek forward')}
+`;
+
+const updateAriaLabelTooltip = (el: MediaSeekForwardButton) => {
+  const label = t('seek forward {seekOffset} seconds', { seekOffset: el.seekOffset && DEFAULT_SEEK_OFFSET })
+  el.setAttribute('aria-label', label)
+
+  const tooltip = el.shadowRoot?.querySelector('slot[name="tooltip-content"]');
+  if (tooltip) {
+    tooltip.innerHTML = createTooltipContent();
+  }
+};
+
 const DEFAULT_TIME = 0;
 
 /**
@@ -40,7 +54,8 @@ class MediaSeekForwardButton extends MediaChromeButton {
   constructor(options = {}) {
     super({
       slotTemplate,
-      tooltipContent: t('Seek forward'),
+      tooltipContent: createTooltipContent(),
+      updateAriaLabelTooltip: () => updateAriaLabelTooltip(this),
       ...options,
     });
   }
@@ -51,6 +66,7 @@ class MediaSeekForwardButton extends MediaChromeButton {
       Attributes.SEEK_OFFSET,
       DEFAULT_SEEK_OFFSET
     );
+    updateAriaLabelTooltip(this);
     super.connectedCallback();
   }
 
@@ -60,6 +76,7 @@ class MediaSeekForwardButton extends MediaChromeButton {
     newValue: string | null
   ): void {
     if (attrName === Attributes.SEEK_OFFSET) {
+      updateAriaLabelTooltip(this);
       this.seekOffset = getNumericAttr(
         this,
         Attributes.SEEK_OFFSET,
@@ -81,10 +98,7 @@ class MediaSeekForwardButton extends MediaChromeButton {
 
   set seekOffset(value: number) {
     setNumericAttr(this, Attributes.SEEK_OFFSET, value);
-    this.setAttribute(
-      'aria-label',
-      t('seek forward {seekOffset} seconds', { seekOffset: this.seekOffset })
-    );
+    updateAriaLabelTooltip(this);
     updateIconText(getSlotted(this, 'icon'), this.seekOffset as any);
   }
 

--- a/src/js/media-time-range.ts
+++ b/src/js/media-time-range.ts
@@ -323,6 +323,10 @@ const calcTimeFromRangeValue = (
   return value * (endTime - startTime) + startTime;
 };
 
+const updateAriaLabel = (el: HTMLInputElement) => {
+  el.setAttribute('aria-label', t('seek'));
+};
+
 /**
  * @slot preview - An element that slides along the timeline to the position of the pointer hovering.
  * @slot preview-arrow - An arrow element that slides along the timeline to the position of the pointer hovering.
@@ -448,7 +452,7 @@ class MediaTimeRange extends MediaChromeRange {
 
   connectedCallback(): void {
     super.connectedCallback();
-    this.range.setAttribute('aria-label', t('seek'));
+    updateAriaLabel(this.range);
     this.#toggleRangeAnimation();
 
     // NOTE: Adding an event listener to an ancestor here.
@@ -470,7 +474,7 @@ class MediaTimeRange extends MediaChromeRange {
     newValue: string | null
   ): void {
     super.attributeChangedCallback(attrName, oldValue, newValue);
-
+    updateAriaLabel(this.range);
     if (oldValue == newValue) return;
 
     if (

--- a/src/js/media-volume-range.ts
+++ b/src/js/media-volume-range.ts
@@ -21,6 +21,11 @@ const toVolume = (el: any): number => {
 const formatAsPercentString = (value: number): string =>
   `${Math.round(value * 100)}%`;
 
+
+const updateAriaLabel = (el: HTMLInputElement) => {
+  el.setAttribute('aria-label', t('volume'));
+};
+
 /**
  * @attr {string} mediavolume - (read-only) Set to the media volume.
  * @attr {boolean} mediamuted - (read-only) Set to the media muted state.
@@ -57,7 +62,7 @@ class MediaVolumeRange extends MediaChromeRange {
 
   connectedCallback(): void {
     super.connectedCallback();
-    this.range.setAttribute('aria-label', t('volume'));
+    updateAriaLabel(this.range);
   }
 
   attributeChangedCallback(
@@ -66,7 +71,7 @@ class MediaVolumeRange extends MediaChromeRange {
     newValue: string | null
   ): void {
     super.attributeChangedCallback(attrName, oldValue, newValue);
-
+    updateAriaLabel(this.range);
     if (
       attrName === MediaUIAttributes.MEDIA_VOLUME ||
       attrName === MediaUIAttributes.MEDIA_MUTED

--- a/src/js/menu/media-audio-track-menu-button.ts
+++ b/src/js/menu/media-audio-track-menu-button.ts
@@ -1,4 +1,4 @@
-import { MediaUIAttributes } from '../constants.js';
+import { MediaUIAttributes, MediaUIProps } from '../constants.js';
 import { MediaChromeMenuButton } from './media-chrome-menu-button.js';
 import { globalThis, document } from '../utils/server-safe-globals.js';
 import {
@@ -23,6 +23,19 @@ slotTemplate.innerHTML = /*html*/ `
   <slot name="icon">${audioTrackIcon}</slot>
 `;
 
+const createTooltipContent = () => /*html*/ `
+  ${t('Audio')}
+`;
+
+const updateAriaLabelTooltip = (el: MediaAudioTrackMenuButton) => {
+  el.setAttribute('aria-label', t('Audio'));
+
+  const tooltip = el.shadowRoot?.querySelector('slot[name="tooltip-content"]');
+  if (tooltip) {
+    tooltip.innerHTML = createTooltipContent();
+  }
+};
+
 /**
  * @attr {string} mediaaudiotrackenabled - (read-only) Set to the selected audio track id.
  * @attr {(unavailable|unsupported)} mediaaudiotrackunavailable - (read-only) Set if audio track selection is unavailable.
@@ -39,12 +52,12 @@ class MediaAudioTrackMenuButton extends MediaChromeMenuButton {
   }
 
   constructor() {
-    super({ slotTemplate, tooltipContent: t('Audio') });
+    super({ slotTemplate, tooltipContent: createTooltipContent(), updateAriaLabelTooltip: () => updateAriaLabelTooltip(this) });
   }
 
   connectedCallback(): void {
     super.connectedCallback();
-    this.setAttribute('aria-label', t('Audio'));
+    updateAriaLabelTooltip(this);
   }
 
   attributeChangedCallback(
@@ -53,6 +66,9 @@ class MediaAudioTrackMenuButton extends MediaChromeMenuButton {
     newValue: string | null
   ): void {
     super.attributeChangedCallback(attrName, oldValue, newValue);
+    if (attrName === MediaUIProps.LANG) {
+      updateAriaLabelTooltip(this);
+    }
   }
 
   /**

--- a/src/js/menu/media-captions-menu-button.ts
+++ b/src/js/menu/media-captions-menu-button.ts
@@ -41,8 +41,18 @@ slotTemplate.innerHTML = /*html*/ `
   </slot>
 `;
 
-const updateAriaChecked = (el: HTMLElement): void => {
+const createTooltipContent = () => /*html*/ `
+  ${t('Captions')}
+`;
+
+const updateAriaCheckedLabel = (el: HTMLElement): void => {
   el.setAttribute('aria-checked', areSubsOn(el).toString());
+  el.setAttribute('aria-label', t('closed captions'));
+
+  const tooltip = el.shadowRoot?.querySelector('slot[name="tooltip-content"]');
+  if (tooltip) {
+    tooltip.innerHTML = createTooltipContent();
+  }
 };
 
 /**
@@ -67,7 +77,7 @@ class MediaCaptionsMenuButton extends MediaChromeMenuButton {
   #captionsReady: boolean;
 
   constructor(options: Record<string, any> = {}) {
-    super({ slotTemplate, tooltipContent: t('Captions'), ...options });
+    super({ slotTemplate, tooltipContent: createTooltipContent(), updateAriaLabelTooltip: ()=> updateAriaCheckedLabel(this), ...options });
     // Internal variable to keep track of when we have some or no captions (or subtitles, if using subtitles fallback)
     // Used for `default-showing` behavior.
     this.#captionsReady = false;
@@ -75,9 +85,7 @@ class MediaCaptionsMenuButton extends MediaChromeMenuButton {
 
   connectedCallback(): void {
     super.connectedCallback();
-
-    this.setAttribute('aria-label', t('closed captions'));
-    updateAriaChecked(this);
+    updateAriaCheckedLabel(this);
   }
 
   attributeChangedCallback(
@@ -88,7 +96,7 @@ class MediaCaptionsMenuButton extends MediaChromeMenuButton {
     super.attributeChangedCallback(attrName, oldValue, newValue);
 
     if (attrName === MediaUIAttributes.MEDIA_SUBTITLES_SHOWING) {
-      updateAriaChecked(this);
+      updateAriaCheckedLabel(this);
     }
   }
 

--- a/src/js/menu/media-captions-menu.ts
+++ b/src/js/menu/media-captions-menu.ts
@@ -1,5 +1,5 @@
 import { globalThis, document } from '../utils/server-safe-globals.js';
-import { MediaUIAttributes, MediaUIEvents } from '../constants.js';
+import { MediaUIAttributes, MediaUIEvents, MediaUIProps } from '../constants.js';
 import { getMediaController } from '../utils/element-utils.js';
 import {
   MediaChromeMenu,
@@ -43,6 +43,7 @@ class MediaCaptionsMenu extends MediaChromeMenu {
       ...super.observedAttributes,
       MediaUIAttributes.MEDIA_SUBTITLES_LIST,
       MediaUIAttributes.MEDIA_SUBTITLES_SHOWING,
+      MediaUIProps.LANG,
     ];
   }
 
@@ -66,13 +67,16 @@ class MediaCaptionsMenu extends MediaChromeMenu {
     ) {
       this.value = newValue;
     }
+
+    if (attrName === MediaUIProps.LANG && oldValue !== newValue) {
+      this.#triggerRender();
+    }
   }
 
   connectedCallback(): void {
     super.connectedCallback();
     this.addEventListener('change', this.#onChange);
   }
-
   disconnectedCallback(): void {
     super.disconnectedCallback();
     this.removeEventListener('change', this.#onChange);
@@ -148,6 +152,11 @@ class MediaCaptionsMenu extends MediaChromeMenu {
 
       this.defaultSlot.append(item);
     }
+  }
+
+  #triggerRender(): void {
+    this.#prevState = undefined; // Reset previous state to force re-render
+    this.#render();
   }
 
   #onChange(): void {

--- a/src/js/menu/media-playback-rate-menu-button.ts
+++ b/src/js/menu/media-playback-rate-menu-button.ts
@@ -31,6 +31,20 @@ slotTemplate.innerHTML = /*html*/ `
   <slot name="icon"></slot>
 `;
 
+const createTooltipContent = () => /*html*/ `
+  ${t('Playback rate')}
+`;
+
+const updateAriaLabelTooltip = (el: MediaPlaybackRateMenuButton, playbackRate: number) => {
+  const label = t('Playback rate {playbackRate}', { playbackRate })
+  el.setAttribute('aria-label', label)
+
+  const tooltip = el.shadowRoot?.querySelector('slot[name="tooltip-content"]');
+  if (tooltip) {
+    tooltip.innerHTML = createTooltipContent();
+  }
+};
+
 /**
  * @attr {string} rates - Set custom playback rates for the user to choose from.
  * @attr {string} mediaplaybackrate - (read-only) Set to the media playback rate.
@@ -55,7 +69,8 @@ class MediaPlaybackRateMenuButton extends MediaChromeMenuButton {
   constructor(options = {}) {
     super({
       slotTemplate,
-      tooltipContent: t('Playback rate'),
+      tooltipContent: createTooltipContent(),
+      updateAriaLabelTooltip: () => updateAriaLabelTooltip(this, DEFAULT_RATE),
       ...options,
     });
     this.container = this.shadowRoot.querySelector('slot[name="icon"]');
@@ -78,10 +93,7 @@ class MediaPlaybackRateMenuButton extends MediaChromeMenuButton {
         ? newPlaybackRate
         : DEFAULT_RATE;
       this.container.innerHTML = `${playbackRate}x`;
-      this.setAttribute(
-        'aria-label',
-        t('Playback rate {playbackRate}', { playbackRate })
-      );
+      updateAriaLabelTooltip(this, playbackRate);
     }
   }
 

--- a/src/js/menu/media-rendition-menu-button.ts
+++ b/src/js/menu/media-rendition-menu-button.ts
@@ -24,6 +24,20 @@ slotTemplate.innerHTML = /*html*/ `
   <slot name="icon">${renditionIcon}</slot>
 `;
 
+const createTooltipContent = () => /*html*/ `
+  ${t('Quality')}
+`;
+
+const updateAriaLabel = (el: MediaRenditionMenuButton) => {
+  const label = t('quality');
+  el.setAttribute('aria-label', label)
+
+  const tooltip = el.shadowRoot?.querySelector('slot[name="tooltip-content"]');
+  if (tooltip) {
+    tooltip.innerHTML = createTooltipContent();
+  }
+};
+
 /**
  * @attr {string} mediarenditionselected - (read-only) Set to the selected rendition id.
  * @attr {(unavailable|unsupported)} mediarenditionunavailable - (read-only) Set if rendition selection is unavailable.
@@ -41,12 +55,12 @@ class MediaRenditionMenuButton extends MediaChromeMenuButton {
   }
 
   constructor() {
-    super({ slotTemplate, tooltipContent: t('Quality') });
+    super({ slotTemplate, tooltipContent: createTooltipContent(), updateAriaLabelTooltip: () => updateAriaLabel(this) });
   }
 
   connectedCallback(): void {
     super.connectedCallback();
-    this.setAttribute('aria-label', t('quality'));
+    updateAriaLabel(this);
   }
 
   /**

--- a/src/js/menu/media-rendition-menu.ts
+++ b/src/js/menu/media-rendition-menu.ts
@@ -1,5 +1,5 @@
 import { globalThis } from '../utils/server-safe-globals.js';
-import { MediaUIAttributes, MediaUIEvents } from '../constants.js';
+import { MediaUIAttributes, MediaUIEvents, MediaUIProps } from '../constants.js';
 import {
   getMediaController,
   getStringAttr,
@@ -33,6 +33,7 @@ class MediaRenditionMenu extends MediaChromeMenu {
       MediaUIAttributes.MEDIA_RENDITION_SELECTED,
       MediaUIAttributes.MEDIA_RENDITION_UNAVAILABLE,
       MediaUIAttributes.MEDIA_HEIGHT,
+      MediaUIProps.LANG,
     ];
   }
 
@@ -63,6 +64,9 @@ class MediaRenditionMenu extends MediaChromeMenu {
       oldValue !== newValue
     ) {
       this.#render();
+    }
+    if (attrName === MediaUIProps.LANG && oldValue !== newValue) {
+      this.#triggerRender();
     }
   }
 
@@ -170,6 +174,12 @@ class MediaRenditionMenu extends MediaChromeMenu {
 
     item.prepend(createIndicator(this, 'checked-indicator'));
     this.defaultSlot.append(item);
+  }
+
+  #triggerRender(): void {
+    this.#prevState.mediaRenditionList = undefined; // Reset previous state to force re-render
+    this.#prevState.mediaHeight = undefined;
+    this.#render();
   }
 
   #onChange(): void {

--- a/src/js/menu/media-settings-menu-button.ts
+++ b/src/js/menu/media-settings-menu-button.ts
@@ -17,6 +17,20 @@ slotTemplate.innerHTML = /*html*/ `
   </slot>
 `;
 
+const createTooltipContent = () => /*html*/ `
+  ${t('Settings')}
+`;
+
+const updateAriaLabelTooltip = (el: MediaSettingsMenuButton) => {
+  const label = t('settings');
+  el.setAttribute('aria-label', label)
+
+  const tooltip = el.shadowRoot?.querySelector('slot[name="tooltip-content"]');
+  if (tooltip) {
+    tooltip.innerHTML = createTooltipContent();
+  }
+};
+
 /**
  * @attr {string} target - CSS id selector for the element to be targeted by the button.
  */
@@ -26,12 +40,12 @@ class MediaSettingsMenuButton extends MediaChromeMenuButton {
   }
 
   constructor() {
-    super({ slotTemplate, tooltipContent: t('Settings') });
+    super({ slotTemplate, tooltipContent: createTooltipContent(), updateAriaLabelTooltip: () => updateAriaLabelTooltip(this)});
   }
 
   connectedCallback(): void {
     super.connectedCallback();
-    this.setAttribute('aria-label', t('settings'));
+    updateAriaLabelTooltip(this);
   }
 
   /**


### PR DESCRIPTION
##Problem

Currently, components render aria-label and tooltip text only once during construction. If a new language is added or the lang attribute is set on the <media-controller> after components are initialized, these labels do not update. The current implementation only supports loading additional languages before the initial render, limiting support for dynamic internationalization.

##Solution
	•	Added a mutation observer to detect changes to the lang attribute on the media controller.
	•	Triggered updates to aria-label and tooltip values when the language changes.
	•	Enabled support for adding new languages after the media controller is created, ensuring components re-evaluate their labels dynamically.

This resolves [#1126](https://github.com/muxinc/media-chrome/issues/1126) and improves support for dynamic i18n workflows.
