### PR TITLE
fix: decode special characters in chapter text

### DIFF
--- a/src/js/media-store/state-mediator.ts
+++ b/src/js/media-store/state-mediator.ts
@@ -293,6 +293,9 @@ export const prepareStateOwners = async (
   );
 };
 
+const domParser = new globalThis.DOMParser();
+const parseHtmlToText = (text: string) => text ? domParser.parseFromString(text, 'text/html').body.textContent || text : text;
+
 export const stateMediator: StateMediator = {
   mediaError: {
     get(stateOwners, event) {
@@ -742,7 +745,7 @@ export const stateMediator: StateMediator = {
 
       return Array.from(chaptersTrack?.cues ?? []).map(
         ({ text, startTime, endTime }: VTTCue) => ({
-          text: text ? new DOMParser().parseFromString(text, 'text/html').body.textContent || text : text,
+          text: parseHtmlToText(text),
           startTime,
           endTime,
         })

--- a/src/js/media-store/state-mediator.ts
+++ b/src/js/media-store/state-mediator.ts
@@ -742,7 +742,7 @@ export const stateMediator: StateMediator = {
 
       return Array.from(chaptersTrack?.cues ?? []).map(
         ({ text, startTime, endTime }: VTTCue) => ({
-          text,
+          text: text ? new DOMParser().parseFromString(text, 'text/html').body.textContent || text : text,
           startTime,
           endTime,
         })

--- a/src/js/utils/server-safe-globals.ts
+++ b/src/js/utils/server-safe-globals.ts
@@ -72,6 +72,15 @@ const globalThisShim = {
       media,
     };
   },
+  DOMParser: class DOMParser {
+    parseFromString(string: string, _contentType: string) {
+      return {
+        body: {
+          textContent: string
+        }
+      };
+    }
+  },
 } as unknown as typeof globalThis;
 
 export const isServer =


### PR DESCRIPTION
Fixes #1132 

You can test with this VTT file:
```
WEBVTT

00:00:00.000 --> 00:00:11.000
Intro

00:00:11.000 --> 00:01:11.000
test &amp; test

00:01:11.000 --> 00:02:11.000
test &lt; &gt; &quot; &apos;

00:02:11.000 --> 00:03:11.000
test &copy; &reg; &trade;
```

- `&lt;` should display as <
- `&gt;` should display as >
- `&quot;` should display as "
- `&apos;` should display as '
- `&copy;` should display as ©
- `&reg;` should display as ®
- `&trade;` should display as ™