### PR TITLE
Fix: media controller and control bar now recognize each other across shadow roots

### DIFF
--- a/src/js/media-control-bar.ts
+++ b/src/js/media-control-bar.ts
@@ -5,7 +5,7 @@
 */
 import { MediaStateReceiverAttributes } from './constants.js';
 import type MediaController from './media-controller.js';
-import { namedNodeMapToObject } from './utils/element-utils.js';
+import { namedNodeMapToObject, findElementAcrossShadowDOM } from './utils/element-utils.js';
 import { globalThis } from './utils/server-safe-globals.js';
 
 function getTemplateHTML(_attrs: Record<string, string>) {
@@ -81,8 +81,7 @@ class MediaControlBar extends globalThis.HTMLElement {
         this.#mediaController = null;
       }
       if (newValue && this.isConnected) {
-        // @ts-ignore
-        this.#mediaController = this.getRootNode()?.getElementById(newValue);
+        this.#mediaController = findElementAcrossShadowDOM(this.getRootNode() as Document | ShadowRoot | HTMLElement, newValue) as MediaController;
         this.#mediaController?.associateElement?.(this);
       }
     }
@@ -93,10 +92,7 @@ class MediaControlBar extends globalThis.HTMLElement {
       MediaStateReceiverAttributes.MEDIA_CONTROLLER
     );
     if (mediaControllerId) {
-      // @ts-ignore
-      this.#mediaController = (this.getRootNode() as Document)?.getElementById(
-        mediaControllerId
-      );
+      this.#mediaController = findElementAcrossShadowDOM(this.getRootNode() as Document | ShadowRoot | Element, mediaControllerId) as MediaController;
       this.#mediaController?.associateElement?.(this);
     }
   }

--- a/src/js/utils/element-utils.ts
+++ b/src/js/utils/element-utils.ts
@@ -390,3 +390,33 @@ export function setStringAttr(
 
   el.setAttribute(attrName, nextValue);
 }
+
+/**
+ * Finds an element by ID across shadow DOM boundaries
+ * @param root - The root element to start searching from (Document, ShadowRoot, or Element)
+ * @param id - The ID of the element to find
+ * @returns The found element or null
+ */
+export function findElementAcrossShadowDOM(root: Document | ShadowRoot | Element, id: string): Element | null {
+  // First try direct getElementById if we're in a Document
+  if (root instanceof Document) {
+    const element = root.getElementById(id);
+    if (element) return element;
+  }
+
+  // Search in the current root
+  const element = root.querySelector(`#${id}`);
+  if (element) return element;
+
+  // Search in all shadow roots
+  const shadowRoots = Array.from(root.querySelectorAll('*'))
+    .map(el => el.shadowRoot)
+    .filter(Boolean) as ShadowRoot[];
+
+  for (const shadowRoot of shadowRoots) {
+    const element = findElementAcrossShadowDOM(shadowRoot, id);
+    if (element) return element;
+  }
+
+  return null;
+}


### PR DESCRIPTION
Fixes #940 
## Changes
- Added a utility function to find elements by ID across shadow DOM boundaries
- Updated `media-control-bar` to use this function