### PR TITLE
fix: move vercel edge to dev dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "4.11.1",
       "license": "MIT",
       "dependencies": {
-        "@vercel/edge": "^1.2.1",
         "ce-la-react": "^0.3.0"
       },
       "devDependencies": {
@@ -17,6 +16,7 @@
         "@open-wc/testing": "^3.1.6",
         "@types/mocha": "^10.0.6",
         "@types/react": "19.1.2",
+        "@vercel/edge": "^1.2.1",
         "@web/dev-server-esbuild": "^1.0.2",
         "@web/test-runner": "^0.19.0",
         "@web/test-runner-playwright": "^0.11.0",
@@ -1824,9 +1824,11 @@
       "license": "ISC"
     },
     "node_modules/@vercel/edge": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@vercel/edge/-/edge-1.2.1.tgz",
-      "integrity": "sha512-1++yncEyIAi68D3UEOlytYb1IUcIulMWdoSzX2h9LuSeeyR7JtaIgR8DcTQ6+DmYOQn+5MCh6LY+UmK6QBByNA=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@vercel/edge/-/edge-1.2.2.tgz",
+      "integrity": "sha512-1+y+f6rk0Yc9ss9bRDgz/gdpLimwoRteKHhrcgHvEpjbP1nyT3ByqEMWm2BTcpIO5UtDmIFXc8zdq4LR190PDA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@web/browser-logs": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
     "url": "git+https://github.com/muxinc/media-chrome.git"
   },
   "dependencies": {
-    "@vercel/edge": "^1.2.1",
     "ce-la-react": "^0.3.0"
   },
   "devDependencies": {
@@ -113,6 +112,7 @@
     "@open-wc/testing": "^3.1.6",
     "@types/mocha": "^10.0.6",
     "@types/react": "19.1.2",
+    "@vercel/edge": "^1.2.1",
     "@web/dev-server-esbuild": "^1.0.2",
     "@web/test-runner": "^0.19.0",
     "@web/test-runner-playwright": "^0.11.0",


### PR DESCRIPTION
fix #1158

shouldn't be part of Media Chrome's dependencies 