### PR TITLE
Fix: `nohotkeys` prop disables all shortcuts

### DIFF
--- a/src/js/media-controller.ts
+++ b/src/js/media-controller.ts
@@ -134,7 +134,9 @@ class MediaController extends MediaContainer {
       prevState = nextState;
     };
 
-    this.enableHotkeys();
+    this.hasAttribute(Attributes.NO_HOTKEYS)
+      ? this.disableHotkeys()
+      : this.enableHotkeys();
   }
 
   #setupDefaultStore() {
@@ -396,7 +398,9 @@ class MediaController extends MediaContainer {
       );
     }
 
-    this.enableHotkeys();
+    this.hasAttribute(Attributes.NO_HOTKEYS)
+      ? this.disableHotkeys()
+      : this.enableHotkeys();
   }
 
   disconnectedCallback(): void {


### PR DESCRIPTION
Closes #1169 

## Changes
Conditionally enable or disable hotkeys based on the presence of the `NO_HOTKEYS` attribute.