### PR TITLE
feat:: expose <div> container via part so host DOM styles can target it

### DIFF
--- a/src/js/menu/media-chrome-menu.ts
+++ b/src/js/menu/media-chrome-menu.ts
@@ -136,7 +136,7 @@ function getTemplateHTML(_attrs: Record<string, string>) {
         right: -100%;
       }
 
-      :host::part(container) {
+      #container {
         display: flex;
         flex-direction: column;
         min-height: 0;
@@ -144,7 +144,7 @@ function getTemplateHTML(_attrs: Record<string, string>) {
         transform: translate(0, 0);
       }
 
-      :host::part(container).has-expanded {
+      #container.has-expanded {
         transition: transform .2s ease-in;
         transform: translate(-100%, 0);
       }


### PR DESCRIPTION
This PR adds the part="container" attribute to the internal container <div> in `media-chrome-menu`, allowing users to style it from the light DOM using the ::part(container) selector. This enables better theme customization and external control over layout and appearance.

Fixes [#1100](https://github.com/muxinc/media-chrome/issues/1100).

Usage: 

`media-settings-menu::part(container){
   // css
}`