### PR TITLE
Reflect disablePictureInPicture in media to  media-controller PIP as unavailable

### DIFF
--- a/src/js/media-store/state-mediator.ts
+++ b/src/js/media-store/state-mediator.ts
@@ -1066,6 +1066,9 @@ export const stateMediator: StateMediator = {
       const { media } = stateOwners;
       if (!pipSupported || !hasPipSupport(media as HTMLVideoElement))
         return AvailabilityStates.UNSUPPORTED;
+      else if (media?.disablePictureInPicture)
+        return AvailabilityStates.UNAVAILABLE;
+      return undefined;
     },
   },
   mediaVolumeUnavailable: {


### PR DESCRIPTION
In state‑mediator, now checks if the media element has the `disablePictureInPicture` attribute. If present, the mediator adds `mediapipunavailable="unavailable"` to the <media-controller> element and this to their child's like `media-pip-button` adding the ability to style it.