### PR TITLE
docs: clarify <media-preview-thumbnail> needs a VTT track and add reference link

### DIFF
--- a/docs/src/pages/docs/en/components/media-preview-thumbnail.mdx
+++ b/docs/src/pages/docs/en/components/media-preview-thumbnail.mdx
@@ -7,9 +7,17 @@ source: https://github.com/muxinc/media-chrome/tree/main/src/js/media-preview-th
 
 > This component is automatically rendered internally by [`<media-time-range>`](media-time-range). While the default implementation covers most use cases, the documentation below describes how the component works for applications with advanced use cases.
 
-The `<media-preview-thumbnail>` component displays an image while the user hovers over the media time range.
+The `<media-preview-thumbnail>` component is automatically shown when the user hovers over the media time range. It appears if a metadata text track labeled **"thumbnails"** is provided, for example:
 
-<style>
+```html
+<track default label="thumbnails" kind="metadata" src="thumbnails.vtt">
+```
+
+The VTT file defines the images (and their coordinates) that are displayed as preview thumbnails. This enables the hover-to-preview functionality.
+
+For more details on how thumbnails are integrated and controlled, see [`<media-time-range>`](media-time-range#preview-thumbnails).
+
+```css
   media-preview-thumbnail {
     display: block;
   }
@@ -17,21 +25,25 @@ The `<media-preview-thumbnail>` component displays an image while the user hover
   media-preview-thumbnail[mediapreviewimage] {
     height: 160px;
   }
-</style>
+```
 
-<h3>Default (no src)</h3>
+### Default (no src)
 
+```jsx
 <media-preview-thumbnail></media-preview-thumbnail>
+```
 
 ```html
 <media-preview-thumbnail></media-preview-thumbnail>
 ```
 
-<h3>With thumbnail and coords</h3>
+### With thumbnail and coords
 
+```jsx
 <media-preview-thumbnail
   mediapreviewimage="https://image.mux.com/O6LdRc0112FEJXH00bGsN9Q31yu5EIVHTgjTKRkKtEq1k/storyboard.jpg"
   mediapreviewcoords="284 640 284 160"></media-preview-thumbnail>
+```
 
 ```html
 <media-preview-thumbnail


### PR DESCRIPTION
Resolves [#1179](https://github.com/muxinc/media-chrome/issues/1179#issuecomment-3204189445) where a user reported confusion about why the component wasn’t displaying thumbnails by default. This update makes the requirement for a VTT track explicit and provides a direct link to the samples in [media-time-range ](https://www.media-chrome.org/docs/en/components/media-time-range#preview-thumbnails)for further details.

This PR updates the documentation for `<media-preview-thumbnail>` to clarify that preview thumbnails only appear when a metadata text track labeled “thumbnails” is provided with a valid VTT file.
