### PR TITLE
Feat: Prevent storing local storage values if not used

### DIFF
--- a/src/js/media-controller.ts
+++ b/src/js/media-controller.ts
@@ -59,6 +59,7 @@ export const Attributes = {
   NO_AUTO_SEEK_TO_LIVE: 'noautoseektolive',
   NO_HOTKEYS: 'nohotkeys',
   NO_VOLUME_PREF: 'novolumepref',
+  NO_MUTED_PREF: 'nomutedpref',
   NO_SUBTITLES_LANG_PREF: 'nosubtitleslangpref',
   NO_DEFAULT_STORE: 'nodefaultstore',
   KEYBOARD_FORWARD_SEEK_OFFSET: 'keyboardforwardseekoffset',
@@ -81,6 +82,7 @@ export const Attributes = {
  * @attr {string} seektoliveoffset
  * @attr {boolean} noautoseektolive
  * @attr {boolean} novolumepref
+ * @attr {boolean} nomutedpref
  * @attr {boolean} nosubtitleslangpref
  * @attr {boolean} nodefaultstore
  * @attr {string} lang
@@ -161,6 +163,7 @@ class MediaController extends MediaContainer {
         noAutoSeekToLive: this.hasAttribute(Attributes.NO_AUTO_SEEK_TO_LIVE),
         // NOTE: This wasn't updated if it was changed later. Should it be? (CJP)
         noVolumePref: this.hasAttribute(Attributes.NO_VOLUME_PREF),
+        noMutedPref: this.hasAttribute(Attributes.NO_MUTED_PREF),
         noSubtitlesLangPref: this.hasAttribute(
           Attributes.NO_SUBTITLES_LANG_PREF
         ),
@@ -267,6 +270,14 @@ class MediaController extends MediaContainer {
 
   set noVolumePref(value: boolean | undefined) {
     setBooleanAttr(this, Attributes.NO_VOLUME_PREF, value);
+  }
+
+  get noMutedPref(): boolean | undefined {
+    return getBooleanAttr(this, Attributes.NO_MUTED_PREF);
+  }
+
+  set noMutedPref(value: boolean | undefined) {
+    setBooleanAttr(this, Attributes.NO_MUTED_PREF, value);
   }
 
   get noSubtitlesLangPref(): boolean | undefined {

--- a/src/js/media-store/state-mediator.ts
+++ b/src/js/media-store/state-mediator.ts
@@ -403,7 +403,7 @@ export const stateMediator: StateMediator = {
       if (!media) return;
 
       // Prevent storing muted preference if 'muted' or noMutedPref are present
-      if(!media.hasAttribute("muted") || !noMutedPref) {
+      if(!media.hasAttribute("muted") && !noMutedPref) {
         try {
           globalThis.localStorage.setItem(
             'media-chrome-pref-muted',

--- a/src/js/media-store/state-mediator.ts
+++ b/src/js/media-store/state-mediator.ts
@@ -402,13 +402,16 @@ export const stateMediator: StateMediator = {
       const { media } = stateOwners;
       if (!media) return;
 
-      try {
-        globalThis.localStorage.setItem(
-          'media-chrome-pref-muted',
-          value ? 'true' : 'false'
-        );
-      } catch (e) {
-        console.debug('Error setting muted pref', e);
+      // Prevent updating localStorage when it's not considered ("muted" attr overrides value)
+      if(!media.hasAttribute("muted")) {
+        try {
+          globalThis.localStorage.setItem(
+            'media-chrome-pref-muted',
+            value ? 'true' : 'false'
+          );
+        } catch (e) {
+          console.debug('Error setting muted pref', e);
+        }
       }
 
       media.muted = value;

--- a/src/js/media-store/state-mediator.ts
+++ b/src/js/media-store/state-mediator.ts
@@ -399,11 +399,11 @@ export const stateMediator: StateMediator = {
       return media?.muted ?? false;
     },
     set(value, stateOwners) {
-      const { media } = stateOwners;
+      const { media, options: { noMutedPref } = {} } = stateOwners;
       if (!media) return;
 
-      // Prevent updating localStorage when it's not considered ("muted" attr overrides value)
-      if(!media.hasAttribute("muted")) {
+      // Prevent storing muted preference if 'muted' or noMutedPref are present
+      if(!media.hasAttribute("muted") || !noMutedPref) {
         try {
           globalThis.localStorage.setItem(
             'media-chrome-pref-muted',
@@ -445,14 +445,15 @@ export const stateMediator: StateMediator = {
       return media?.volume ?? 1.0;
     },
     set(value, stateOwners) {
-      const { media } = stateOwners;
+      const { media, options: { noVolumePref } = {} } = stateOwners;
       if (!media) return;
       // Store the last set volume as a local preference, if ls is supported
       /** @TODO How should we handle globalThis dependencies/"state ownership"? (CJP) */
       try {
         if (value == null) {
           globalThis.localStorage.removeItem('media-chrome-pref-volume');
-        } else {
+        } else if (!media.hasAttribute('muted') && !noVolumePref) {
+          // Prevent storing volume preference if 'muted' or noVolumePref are present
           globalThis.localStorage.setItem(
             'media-chrome-pref-volume',
             value.toString()


### PR DESCRIPTION
Closes #1194 

This PR prevents storing local storage values in the following cases:
- When the `muted` attribute is present on the media element
- When the `nomutedpref` attribute is present on the media-controller
- When the `novolumepref` attribute is present on the media-controller

## Changes
- Added `nomutedpref` attribute to the media controller
- Prevent storing muted preference if `muted` or `nomutedpref` are present
- Prevent storing volume preference if `muted` or `novolumepref` are present