### PR TITLE
Fix toggle button accessibility: replace aria-checked with aria-pressed

### DIFF
--- a/docs/src/pages/docs/en/components/media-captions-button.mdx
+++ b/docs/src/pages/docs/en/components/media-captions-button.mdx
@@ -75,7 +75,7 @@ css={`.my-icon {
   border-radius: 5px;
 }
 
-media-captions-button[aria-checked=true] .my-icon {
+media-captions-button[aria-pressed=true] .my-icon {
   font-weight: 700;
   text-decoration: underline;
   color: red;

--- a/src/js/media-captions-button.ts
+++ b/src/js/media-captions-button.ts
@@ -20,17 +20,17 @@ const ccIconOff = `<svg aria-hidden="true" viewBox="0 0 26 24">
 function getSlotTemplateHTML(_attrs: Record<string, string>) {
   return /*html*/ `
     <style>
-      :host([aria-checked="true"]) slot[name=off] {
+      :host([aria-pressed="true"]) slot[name=off] {
         display: none !important;
       }
 
       ${/* Double negative, but safer if display doesn't equal 'block' */ ''}
-      :host(:not([aria-checked="true"])) slot[name=on] {
+      :host(:not([aria-pressed="true"])) slot[name=on] {
         display: none !important;
       }
 
-      :host([aria-checked="true"]) slot[name=tooltip-enable],
-      :host(:not([aria-checked="true"])) slot[name=tooltip-disable] {
+      :host([aria-pressed="true"]) slot[name=tooltip-enable],
+      :host(:not([aria-pressed="true"])) slot[name=tooltip-disable] {
         display: none;
       }
     </style>
@@ -50,7 +50,7 @@ function getTooltipContentHTML() {
 }
 
 const updateAriaChecked = (el: HTMLElement) => {
-  el.setAttribute('aria-checked', areSubsOn(el).toString());
+  el.setAttribute('aria-pressed', areSubsOn(el).toString());
 };
 
 /**

--- a/src/js/menu/media-captions-menu-button.ts
+++ b/src/js/menu/media-captions-menu-button.ts
@@ -21,12 +21,12 @@ const ccIconOff = `<svg aria-hidden="true" viewBox="0 0 26 24">
 function getSlotTemplateHTML() {
   return /*html*/ `
     <style>
-      :host([aria-checked="true"]) slot[name=off] {
+      :host([aria-pressed="true"]) slot[name=off] {
         display: none !important;
       }
 
       ${/* Double negative, but safer if display doesn't equal 'block' */ ''}
-      :host(:not([aria-checked="true"])) slot[name=on] {
+      :host(:not([aria-pressed="true"])) slot[name=on] {
         display: none !important;
       }
 
@@ -47,7 +47,7 @@ function getTooltipContentHTML() {
 }
 
 const updateAriaChecked = (el: HTMLElement): void => {
-  el.setAttribute('aria-checked', areSubsOn(el).toString());
+  el.setAttribute('aria-pressed', areSubsOn(el).toString());
 };
 
 const updateAriaLabel = (el: HTMLElement): void => {

--- a/src/js/menu/media-chrome-menu-item.ts
+++ b/src/js/menu/media-chrome-menu-item.ts
@@ -41,7 +41,7 @@ function getTemplateHTML(_attrs: Record<string, string>) {
         outline-offset: var(--media-menu-item-hover-outline-offset,  var(--media-menu-item-outline-offset, -1px));
       }
 
-      :host([aria-checked="true"]) {
+      :host([aria-pressed="true"]) {
         background: var(--media-menu-item-checked-background);
       }
 
@@ -112,7 +112,7 @@ function getTemplateHTML(_attrs: Record<string, string>) {
         visibility: hidden;
       }
 
-      :host([aria-checked="true"]) [part~="checked-indicator"] {
+      :host([aria-pressed="true"]) [part~="checked-indicator"] {
         visibility: visible;
       }
     </style>
@@ -204,8 +204,8 @@ class MediaChromeMenuItem extends globalThis.HTMLElement {
       this.setAttribute('tabindex', '-1');
     }
 
-    if (isCheckable(this) && !this.hasAttribute('aria-checked')) {
-      this.setAttribute('aria-checked', 'false');
+    if (isCheckable(this) && !this.hasAttribute('aria-pressed')) {
+      this.setAttribute('aria-pressed', 'false');
     }
 
     this.addEventListener('click', this);
@@ -243,7 +243,7 @@ class MediaChromeMenuItem extends globalThis.HTMLElement {
     newValue: string | null
   ): void {
     if (attrName === Attributes.CHECKED && isCheckable(this) && !this.#dirty) {
-      this.setAttribute('aria-checked', newValue != null ? 'true' : 'false');
+      this.setAttribute('aria-pressed', newValue != null ? 'true' : 'false');
     } else if (attrName === Attributes.TYPE && newValue !== oldValue) {
       this.role = 'menuitem' + newValue;
     } else if (attrName === Attributes.DISABLED && newValue !== oldValue) {
@@ -329,7 +329,7 @@ class MediaChromeMenuItem extends globalThis.HTMLElement {
 
   get checked() {
     if (!isCheckable(this)) return undefined;
-    return this.getAttribute('aria-checked') === 'true';
+    return this.getAttribute('aria-pressed') === 'true';
   }
 
   set checked(value) {
@@ -337,7 +337,7 @@ class MediaChromeMenuItem extends globalThis.HTMLElement {
 
     this.#dirty = true;
     // Firefox doesn't support the property .ariaChecked.
-    this.setAttribute('aria-checked', value ? 'true' : 'false');
+    this.setAttribute('aria-pressed', value ? 'true' : 'false');
 
     if (value) {
       this.part.add('checked');
@@ -459,19 +459,19 @@ class MediaChromeMenuItem extends globalThis.HTMLElement {
     const items = this.#ownerElement?.radioGroupItems;
     if (!items) return;
 
-    // Default to the last aria-checked element if there isn't an active element already.
+    // Default to the last aria-pressed element if there isn't an active element already.
     let checkedItem = items
-      .filter((item) => item.getAttribute('aria-checked') === 'true')
+      .filter((item) => item.getAttribute('aria-pressed') === 'true')
       .pop();
 
     // If there isn't an active element or a checked element, default to the first element.
     if (!checkedItem) checkedItem = items[0];
 
     for (const item of items) {
-      item.setAttribute('aria-checked', 'false');
+      item.setAttribute('aria-pressed', 'false');
     }
 
-    checkedItem?.setAttribute('aria-checked', 'true');
+    checkedItem?.setAttribute('aria-pressed', 'true');
   }
 }
 

--- a/src/js/menu/media-chrome-menu.ts
+++ b/src/js/menu/media-chrome-menu.ts
@@ -223,7 +223,7 @@ function getTemplateHTML(_attrs: Record<string, string>) {
         padding: .3em .5em;
       }
 
-      media-chrome-menu-item[aria-checked="true"] {
+      media-chrome-menu-item[aria-pressed="true"] {
         background: var(--media-menu-item-checked-background, rgb(255 255 255 / .2));
       }
 


### PR DESCRIPTION
This PR resolves [#1192](https://github.com/muxinc/media-chrome/issues/1192).

The toggle button was incorrectly using `aria-checked`, which is not valid for buttons. 
According to the ARIA specification, toggle buttons should use `aria-pressed` to indicate toggle buttons. 

Reference: [MDN aria-pressed](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-pressed)

### Changes
- Replaced `aria-checked` with `aria-pressed` on toggle buttons.
- Ensured accessibility semantics are correct for screen readers.

This improves accessibility compliance and ensures correct behavior for assistive technologies.