### PR TITLE
Replace aria-checked with data-captions-enabled in captions-menu-button

### DIFF
--- a/src/js/menu/media-captions-menu-button.ts
+++ b/src/js/menu/media-captions-menu-button.ts
@@ -21,12 +21,12 @@ const ccIconOff = `<svg aria-hidden="true" viewBox="0 0 26 24">
 function getSlotTemplateHTML() {
   return /*html*/ `
     <style>
-      :host([aria-checked="true"]) slot[name=off] {
+      :host([data-captions-enabled="true"]) slot[name=off] {
         display: none !important;
       }
 
       ${/* Double negative, but safer if display doesn't equal 'block' */ ''}
-      :host(:not([aria-checked="true"])) slot[name=on] {
+      :host(:not([data-captions-enabled="true"])) slot[name=on] {
         display: none !important;
       }
 
@@ -47,7 +47,7 @@ function getTooltipContentHTML() {
 }
 
 const updateAriaChecked = (el: HTMLElement): void => {
-  el.setAttribute('aria-checked', areSubsOn(el).toString());
+  el.setAttribute('data-captions-enabled', areSubsOn(el).toString());
 };
 
 const updateAriaLabel = (el: HTMLElement): void => {


### PR DESCRIPTION
This resolve [1192](https://github.com/muxinc/media-chrome/issues/1192) 

Changes:

* Updates the captions button to remove the incorrect use of `aria-checked`. 
* The button now uses a new attribute `data-captions-enabled` to reflect when captions are active.  

This change preserves styling/customization while ensuring accessibility is correct,  since `aria-checked` is not appropriate for this use case. 