### PR TITLE
feat: hotkeys are now available after entering fullscreen by click

### DIFF
--- a/src/js/media-fullscreen-button.ts
+++ b/src/js/media-fullscreen-button.ts
@@ -15,7 +15,6 @@ import {
   getStringAttr,
   setBooleanAttr,
   setStringAttr,
-  getMediaController,
 } from './utils/element-utils.js';
 
 const enterFullscreenIcon = `<svg aria-hidden="true" viewBox="0 0 26 24">
@@ -109,12 +108,6 @@ class MediaFullscreenButton extends MediaChromeButton {
 
     if (attrName === MediaUIAttributes.MEDIA_IS_FULLSCREEN) {
       updateAriaLabel(this);
-
-      // Move focus to media element for mouse clicks (enables player hotkeys),
-      // but keep focus on button for keyboard navigation (maintains accessibility)
-      if (this.#lastActionEvent instanceof PointerEvent) {
-        this.moveFocusToMedia();
-      }
     }
   }
 
@@ -142,26 +135,19 @@ class MediaFullscreenButton extends MediaChromeButton {
 
   handleClick(e: Event): void {
     this.#lastActionEvent = e;
+    const isPointerEvent = this.#lastActionEvent instanceof PointerEvent;
 
-    const eventName = this.mediaIsFullscreen
-      ? MediaUIEvents.MEDIA_EXIT_FULLSCREEN_REQUEST
-      : MediaUIEvents.MEDIA_ENTER_FULLSCREEN_REQUEST;
-      
-    this.dispatchEvent(
-      new globalThis.CustomEvent(eventName, { composed: true, bubbles: true })
-    );
-  }
+    const event = this.mediaIsFullscreen
+      ? new globalThis.CustomEvent(
+          MediaUIEvents.MEDIA_EXIT_FULLSCREEN_REQUEST,
+          { composed: true, bubbles: true }
+        )
+      : new globalThis.CustomEvent(
+          MediaUIEvents.MEDIA_ENTER_FULLSCREEN_REQUEST,
+          { composed: true, bubbles: true, detail: isPointerEvent }
+        );
 
-  private moveFocusToMedia(): void {
-    const mediaController = getMediaController(this);
-    if (!mediaController) return;
-
-    const mediaElement = mediaController.querySelector(
-      '[slot="media"]'
-    ) as HTMLElement | null;
-    if (!mediaElement) return;
-
-    mediaElement.focus();
+    this.dispatchEvent(event);
   }
 }
 

--- a/src/js/media-store/request-map.ts
+++ b/src/js/media-store/request-map.ts
@@ -11,7 +11,7 @@ import {
   updateTracksModeTo,
 } from '../utils/captions.js';
 import { getSubtitleTracks, toggleSubtitleTracks } from './util.js';
-import { StateMediator, StateOwners } from './state-mediator.js';
+import { StateMediator, StateOwners, EventOrAction } from './state-mediator.js';
 import { MediaState } from './media-store.js';
 
 export type MediaUIEventsType =
@@ -39,7 +39,7 @@ export type RequestMap = {
   [K in MediaRequestTypes]: (
     stateMediator: StateMediator,
     stateOwners: StateOwners,
-    action: Partial<Pick<CustomEvent<any>, 'type' | 'detail'>>
+    action: EventOrAction<any>
   ) => Partial<MediaState> | undefined | void;
 };
 
@@ -267,7 +267,11 @@ export const requestMap: RequestMap = {
     const value = false;
     stateMediator[key].set(value, stateOwners);
   },
-  [MediaUIEvents.MEDIA_ENTER_FULLSCREEN_REQUEST](stateMediator, stateOwners) {
+  [MediaUIEvents.MEDIA_ENTER_FULLSCREEN_REQUEST](
+    stateMediator,
+    stateOwners,
+    event
+  ) {
     const key = 'mediaIsFullscreen';
     const value = true;
     // Exit PiP if in PiP and entering fullscreen
@@ -275,7 +279,7 @@ export const requestMap: RequestMap = {
       // Should be async
       stateMediator.mediaIsPip.set(false, stateOwners);
     }
-    stateMediator[key].set(value, stateOwners);
+    stateMediator[key].set(value, stateOwners, event);
   },
   [MediaUIEvents.MEDIA_EXIT_FULLSCREEN_REQUEST](stateMediator, stateOwners) {
     const key = 'mediaIsFullscreen';

--- a/src/js/media-store/state-mediator.ts
+++ b/src/js/media-store/state-mediator.ts
@@ -125,7 +125,11 @@ export type FacadeGetter<T, D = T> = (
   event?: EventOrAction<D>
 ) => T;
 
-export type FacadeSetter<T> = (value: T, stateOwners: StateOwners) => void;
+export type FacadeSetter<T> = (
+  value: T,
+  stateOwners: StateOwners,
+  event?: EventOrAction<any>
+) => void;
 
 export type StateOwnerUpdateHandler<T> = (
   handler: (value: T) => void,
@@ -403,7 +407,7 @@ export const stateMediator: StateMediator = {
       if (!media) return;
 
       // Prevent storing muted preference if 'muted' or noMutedPref are present
-      if(!media.hasAttribute("muted") && !noMutedPref) {
+      if (!media.hasAttribute('muted') && !noMutedPref) {
         try {
           globalThis.localStorage.setItem(
             'media-chrome-pref-muted',
@@ -982,11 +986,13 @@ export const stateMediator: StateMediator = {
     get(stateOwners) {
       return isFullscreen(stateOwners);
     },
-    set(value, stateOwners) {
+    set(value, stateOwners, event) {
       if (!value) {
         exitFullscreen(stateOwners);
       } else {
         enterFullscreen(stateOwners);
+        const isPointer = event.detail;
+        if (isPointer) stateOwners.media?.focus();
       }
     },
     // older Safari version may require webkit-specific events


### PR DESCRIPTION
Closes [this issue](https://github.com/muxinc/elements/issues/1169)

## Changes
- In order to maintain accessibility, when fullscreen is entered by keyboard, the focus will be on the fullscreen button. Pressing the spacebar will enter/exit fullscreen.
- When fullscreen is entered by click, the focus will be on the media element. Pressing the spacebar will play/pause the video (enabling player hotkeys).