### PR TITLE
Fix race condition between input and pointermove in <media-time-range>

### DIFF
--- a/src/js/media-time-range.ts
+++ b/src/js/media-time-range.ts
@@ -429,7 +429,7 @@ class MediaTimeRange extends MediaChromeRange {
   #boxPaddingLeft: number;
   #boxPaddingRight: number;
   #mediaChaptersCues;
-  #isSeekInProgress: boolean;
+  #isPointerDown: boolean;
 
   constructor() {
     super();
@@ -536,7 +536,7 @@ class MediaTimeRange extends MediaChromeRange {
       this.range.valueAsNumber = value;
     }
 
-    if (!this.#isSeekInProgress) {
+    if (!this.#isPointerDown) {
       this.updateBar();
     }
   };
@@ -838,10 +838,10 @@ class MediaTimeRange extends MediaChromeRange {
         this.#handlePointerMove(evt as MouseEvent);
         break;
       case 'pointerup':
-        if (this.#isSeekInProgress) this.#isSeekInProgress = false;
+        if (this.#isPointerDown) this.#isPointerDown = false;
         break;
       case 'pointerdown':
-        this.#isSeekInProgress = true;
+        this.#isPointerDown = true;
         break;
       case 'pointerleave':
         this.#previewRequest(null);


### PR DESCRIPTION
Resolve https://github.com/muxinc/media-chrome/issues/1180

This PR resolves a race condition in <media-time-range> where the `input` event would trigger, but a `pointermove` update could fire immediately afterward and override the expected seek position. This caused the thumb to glitch back before settling at the clicked position.

### Changes
- Introduced `#isPointerDown` flag to prevent `updateBar` from running during the conflict window.
- Updated `handleEvent` to correctly manage the suppression logic when `input` and `pointermove` events overlap.
- Ensures the `input` event’s seek update always wins, preventing visual glitches.

### Result
Clicking or dragging the timeline now updates smoothly without the thumb jumping back briefly.