### PR TITLE
fix: Use CSS variable for focus shadow in media button

### DIFF
--- a/src/js/media-chrome-button.ts
+++ b/src/js/media-chrome-button.ts
@@ -50,7 +50,7 @@ function getTemplateHTML(_attrs: Record<string, string>, _props: Record<string, 
       */ ''
       }
       :host(:focus-visible) {
-        box-shadow: var(--media-menu-item-focus-shadow, inset 0 0 0 2px rgb(27 127 204 / .9));
+        box-shadow: var(--media-focus-box-shadow, inset 0 0 0 2px rgb(27 127 204 / .9));
         outline: 0;
       }
       ${


### PR DESCRIPTION
Use CSS variable (if present) for box-shadow