### PR TITLE
Prevent scrollbar when media-time-range expands to show media-preview-thumbnail

### DIFF
--- a/src/js/media-container.ts
+++ b/src/js/media-container.ts
@@ -53,6 +53,7 @@ function getTemplateHTML(_attrs: Record<string, string>) {
         display: inline-block;
         line-height: 0;
         background-color: var(--media-background-color, #000);
+        overflow: hidden;
       }
 
       :host(:not([${Attributes.AUDIO}])) [part~=layer]:not([part~=media-layer]) {


### PR DESCRIPTION
This solves [1215](https://github.com/muxinc/media-chrome/issues/1215) where a scrollbar would briefly appear when hovering over the progress bar due to the media-time-range expands media-preview-thumbnail beyond its container boundaries.

Changes:
	•	Added overflow: hidden to media-controller to prevent unwanted scrollbars when the preview thumbnail is positioned or resized.
