### PR TITLE
fix: React noMutedPref and noVolumePref

### DIFF
--- a/src/js/media-controller.ts
+++ b/src/js/media-controller.ts
@@ -101,6 +101,7 @@ class MediaController extends MediaContainer {
       Attributes.DEFAULT_SUBTITLES,
       Attributes.DEFAULT_DURATION,
       Attributes.NO_MUTED_PREF,
+      Attributes.NO_VOLUME_PREF,
       Attributes.LANG
     );
   }
@@ -389,6 +390,13 @@ class MediaController extends MediaContainer {
         type: 'optionschangerequest',
         detail: {
           mediaLang: newValue,
+        },
+      });
+    } else if (attrName === Attributes.NO_VOLUME_PREF && newValue !== oldValue) {
+      this.#mediaStore?.dispatch({
+        type: 'optionschangerequest',
+        detail: {
+          noVolumePref: this.hasAttribute(Attributes.NO_VOLUME_PREF),
         },
       });
     } else if (attrName === Attributes.NO_MUTED_PREF && newValue !== oldValue) {


### PR DESCRIPTION
Closes #1220

Now, the `noMutedPref` and `noVolumePref` properties work as intended in React (previously only working for vanilla HTML)