### PR TITLE
fix: muted pref covers border cases

### DIFF
--- a/src/js/media-store/state-mediator.ts
+++ b/src/js/media-store/state-mediator.ts
@@ -406,19 +406,34 @@ export const stateMediator: StateMediator = {
       const { media, options: { noMutedPref } = {} } = stateOwners;
       if (!media) return;
 
-      // Prevent storing muted preference if 'muted' or noMutedPref are present
-      if (!media.hasAttribute('muted') && !noMutedPref) {
-        try {
-          globalThis.localStorage.setItem(
-            'media-chrome-pref-muted',
-            value ? 'true' : 'false'
-          );
-        } catch (e) {
-          console.debug('Error setting muted pref', e);
-        }
-      }
-
       media.muted = value;
+
+      try {
+        const hasLocalStoragePrefMuted =
+          globalThis.localStorage.getItem('media-chrome-pref-muted') !== null;
+
+        const hasMutedAttribute = media.hasAttribute('muted');
+
+        if (noMutedPref) {
+          // remove stored preference if exists
+          if(hasLocalStoragePrefMuted) globalThis.localStorage.removeItem('media-chrome-pref-muted');
+          return;
+        }
+
+        // If muted attribute is present but there's no stored preference, it was probably set manually in the HTML
+        // Don't store preference in localStorage since it will be overridden
+        if (hasMutedAttribute && !hasLocalStoragePrefMuted) {
+          return;
+        }
+
+        // Store the preference
+        globalThis.localStorage.setItem(
+          'media-chrome-pref-muted',
+          value ? 'true' : 'false'
+        );
+      } catch (e) {
+        console.debug('Error setting muted pref', e);
+      }
     },
     mediaEvents: ['volumechange'],
     stateOwnersUpdateHandlers: [


### PR DESCRIPTION
Closes #1226 
## Problem
When a user muted/unmuted, the preference updated immediately, but after a page refresh, the localStorage failed to update because the `muted` media attribute interfered with the logic.

### Example when there's no `muted` attr present and `noMutedPref` is false:
- Mute: localStorage preference updates to `true`
- Refresh: video starts muted
- Unmute: localStorage doesn’t update → **but it should update bc the preference is enabled**
- Refresh: video stays muted → **should start unmuted but doesn't bc the localStorage value is not updated, so it can't recover the user preference**

With the previous logic, we prevented localStorage updates when the `muted` attribute existed, even if it was set by the preference system.

## Solution
Refactored muted pref logic:
1. **If `noMutedPref` is enabled**: Remove the stored preference
2. **If `muted` attribute exists but there's no stored preference**: The `muted` attribute was probably set manually in the HTML. Don't store preference in localStorage to respect the manual override.
3. **Otherwise**: Store the preference in localStorage (even if the `muted` attribute exists, since it might have been set by the preference system itself after a page refresh).

## Testing
Please test the following 4 scenarios to verify the fix:
### Case 1: `noMutedPref` false, `muted` false
1. Start with a fresh page (no localStorage value)
2. Mute the video → Check that `media-chrome-pref-muted` is `true`
3. Refresh the page → Video should start muted
4. Unmute the video → Check that `media-chrome-pref-muted` is `false`
5. Refresh the page → Video should start unmuted

### Case 2: `noMutedPref` true, `muted` false
1. Mute/unmute the video
2. Check that `media-chrome-pref-muted` is not stored
3. Remove `noMutedPref` attribute → Mute the video → localStorage should now store the preference

### Case 3: `noMutedPref` false, `muted` true
1. Start with a fresh page (no localStorage value)
2. The video should start muted
3. Unmute the video → Check that `media-chrome-pref-muted` is not stored
4. Refresh the page → Video should start muted (manual muted attribute takes precedence)

### Case 4: `noMutedPref` true, `muted` true
Same steps as case 3. Manual muted attribute takes precedence.