### PR TITLE
fix: Sync captions toggle and menu on attribute/list changes

### DIFF
--- a/src/js/menu/media-captions-menu.ts
+++ b/src/js/menu/media-captions-menu.ts
@@ -66,7 +66,8 @@ class MediaCaptionsMenu extends MediaChromeMenu {
       attrName === MediaUIAttributes.MEDIA_SUBTITLES_SHOWING &&
       oldValue !== newValue
     ) {
-      this.value = newValue;
+      this.value = newValue || "";
+      this.#render();
     }
   }
 
@@ -116,7 +117,11 @@ class MediaCaptionsMenu extends MediaChromeMenu {
   }
 
   #render(): void {
-    if (this.#prevState === JSON.stringify(this.mediaSubtitlesList)) return;
+    
+    const hasListChanged = this.#prevState !== JSON.stringify(this.mediaSubtitlesList);
+    const hasShowingChanged = this.value !== this.getAttribute(MediaUIAttributes.MEDIA_SUBTITLES_SHOWING);
+
+    if (!hasListChanged && !hasShowingChanged) return;
     this.#prevState = JSON.stringify(this.mediaSubtitlesList);
 
     this.defaultSlot.textContent = '';


### PR DESCRIPTION
Fixes https://github.com/muxinc/media-chrome/issues/1205 by ensuring the captions menu and toggle stays in sync with attribute and list changes.

### What was done
- Trigger a `render` event when the `MEDIA_SUBTITLES_SHOWING` attribute changes.
- On `render` event check if attribute showing change then update list with the check icon.