### PR TITLE
feat: persist subtitles state across element disconnect/reconnect

### DIFF
--- a/src/js/media-controller.ts
+++ b/src/js/media-controller.ts
@@ -451,14 +451,14 @@ class MediaController extends MediaContainer {
     // Restore subtitles state if it was saved before disconnecting
     if (this.#subtitlesState !== undefined && this.#mediaStore && this.media) {
       // Wait for mediaStore to sync, then try to restore
-      requestAnimationFrame(() => {
+      setTimeout(() => {
         if (this.media?.textTracks?.length) {
           this.#mediaStore?.dispatch({
             type: MediaUIEvents.MEDIA_TOGGLE_SUBTITLES_REQUEST,
             detail: this.#subtitlesState,
           });
         }
-      });
+      }, 0);
     }
 
     this.hasAttribute(Attributes.NO_HOTKEYS)


### PR DESCRIPTION
This PR closes #777 

Persists the user's captions/subtitles preference when the media-controller element is disconnected from and reconnected to the DOM. The state is stored in a private property and automatically restored when the element is reconnected, ensuring a seamless user experience in scenarios where the element lifecycle includes disconnect/reconnect cycles.
