### PR TITLE
fix: Updated ce-la-react

### DIFF
--- a/examples/nextjs-with-typescript/package-lock.json
+++ b/examples/nextjs-with-typescript/package-lock.json
@@ -31,17 +31,17 @@
       }
     },
     "../..": {
-      "version": "4.9.1",
+      "version": "4.16.0",
       "license": "MIT",
       "dependencies": {
-        "@vercel/edge": "^1.2.1",
-        "ce-la-react": "^0.3.0"
+        "ce-la-react": "^0.3.2"
       },
       "devDependencies": {
         "@custom-elements-manifest/analyzer": "^0.10.2",
         "@open-wc/testing": "^3.1.6",
         "@types/mocha": "^10.0.6",
         "@types/react": "19.1.2",
+        "@vercel/edge": "^1.2.1",
         "@web/dev-server-esbuild": "^1.0.2",
         "@web/test-runner": "^0.19.0",
         "@web/test-runner-playwright": "^0.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.16.0",
       "license": "MIT",
       "dependencies": {
-        "ce-la-react": "^0.3.0"
+        "ce-la-react": "^0.3.2"
       },
       "devDependencies": {
         "@custom-elements-manifest/analyzer": "^0.10.2",
@@ -3189,9 +3189,9 @@
       }
     },
     "node_modules/ce-la-react": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/ce-la-react/-/ce-la-react-0.3.0.tgz",
-      "integrity": "sha512-84SEDLNHaAjykzlkqgKRq95hA3qnxrsTrwh4hTgBq6tfpINqajxz4bkz9q4orhUfpqDPQRgdCzYTF3bHcvTIlQ==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/ce-la-react/-/ce-la-react-0.3.2.tgz",
+      "integrity": "sha512-QJ6k4lOD/btI08xG8jBPxRCGXvCnusGGkTsiXk0u3NqUu/W+BXRnFD4PYjwtqh8AWmGa5LDbGk0fLQsqr0nSMA==",
       "license": "BSD-3-Clause",
       "peerDependencies": {
         "react": ">=17.0.0"

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "url": "git+https://github.com/muxinc/media-chrome.git"
   },
   "dependencies": {
-    "ce-la-react": "^0.3.0"
+    "ce-la-react": "^0.3.2"
   },
   "devDependencies": {
     "@custom-elements-manifest/analyzer": "^0.10.2",


### PR DESCRIPTION
Relates to https://github.com/muxinc/next-video/issues/397 and https://github.com/muxinc/ce-la-react/pull/7

Upgrades ce-la-react to prevent missing key warning when using custom components on SSR.