### PR TITLE
fix: Safari issue where sibling slots disappear when hiding a slot

### DIFF
--- a/src/js/menu/media-playback-rate-menu-button.ts
+++ b/src/js/menu/media-playback-rate-menu-button.ts
@@ -18,6 +18,10 @@ function getSlotTemplateHTML(attrs: Record<string, string>) {
         padding: var(--media-button-padding, var(--media-control-padding, 10px 5px));
       }
       
+      :host([aria-expanded="true"]) slot {
+        display: block;
+      }
+
       :host([aria-expanded="true"]) slot[name=tooltip] {
         display: none;
       }


### PR DESCRIPTION
This PR fixes [1243](https://github.com/muxinc/media-chrome/issues/1243) a Safari-specific rendering issue in Media Chrome where setting a slot to `display: none` would cause sibling slots to disappear. 

### Changes
- Added a CSS rule to explicitly set `display: block` on all other slots when a specific slot (e.g., tooltip) is hidden.
- Ensures consistent behavior across Safari, Chrome, and Firefox.
