### PR TITLE
fix: preview alignment bug due to regression

### DIFF
--- a/src/js/media-chrome-range.ts
+++ b/src/js/media-chrome-range.ts
@@ -243,9 +243,15 @@ function getTemplateHTML(_attrs: Record<string, string>) {
         <svg id="segments"><clipPath id="segments-clipping"></clipPath></svg>
       </div>
       <input id="range" type="range" min="0" max="1" step="any" value="0">
+
+      ${this.getContainerTemplateHTML(_attrs)}
     </div>
     <div id="rightgap"></div>
   `;
+}
+
+function getContainerTemplateHTML(_attrs: Record<string, string>) {
+  return '';
 }
 
 /**
@@ -313,6 +319,7 @@ function getTemplateHTML(_attrs: Record<string, string>) {
 class MediaChromeRange extends globalThis.HTMLElement {
   static shadowRootOptions = { mode: 'open' as ShadowRootMode };
   static getTemplateHTML = getTemplateHTML;
+  static getContainerTemplateHTML = getContainerTemplateHTML;
 
   #mediaController;
   #isInputTarget;

--- a/src/js/media-time-range.ts
+++ b/src/js/media-time-range.ts
@@ -40,9 +40,8 @@ const updateAriaValueText = (el: any): void => {
   range.setAttribute('aria-valuetext', fullPhrase);
 };
 
-function getTemplateHTML(_attrs: Record<string, string>) {
+function getContainerTemplateHTML(_attrs: Record<string, string>) {
   return /*html*/ `
-    ${MediaChromeRange.getTemplateHTML(_attrs)}
     <style>
       :host {
         --media-box-border-radius: 4px;
@@ -408,7 +407,7 @@ const calcTimeFromRangeValue = (
  */
 class MediaTimeRange extends MediaChromeRange {
   static shadowRootOptions = { mode: 'open' as ShadowRootMode };
-  static getTemplateHTML = getTemplateHTML;
+  static getContainerTemplateHTML = getContainerTemplateHTML;
 
   static get observedAttributes(): string[] {
     return [


### PR DESCRIPTION
introduced in 535ff62. The mouse cursor did not align with the tooltip preview.

The cause was because the media-time-range html should have gone in the media-chrome-range container element but did not after my change in 535ff62.

Bug visible in https://media-chrome.mux.dev/examples/vanilla/basic.html if you hover on left / right side of time range.


<img width="449" height="328" alt="SCR-20251212-pams" src="https://github.com/user-attachments/assets/142612b0-1895-4b74-897f-2b3ce709891a" />
