### PR TITLE
fix: Content shifts when <media-volume-range> control is tab-focused

### DIFF
--- a/src/js/media-chrome-range.ts
+++ b/src/js/media-chrome-range.ts
@@ -31,6 +31,7 @@ function getTemplateHTML(_attrs: Record<string, string>) {
         cursor: var(--media-cursor, pointer);
         pointer-events: auto;
         touch-action: none; ${/* Prevent scrolling when dragging on mobile. */ ''}
+        overflow: hidden; ${/* Prevent absolute positioned #range from affecting parent layout on focus */ ''}
       }
 
       ${/* Reset before `outline` on track could be set by a CSS var */ ''}


### PR DESCRIPTION
This PR closes #1254 

Added overflow: hidden to the :host element to prevent the absolutely positioned #range input from affecting the parent container's layout when it receives focus