### PR TITLE
fix: Patch Memory Leaks

### DIFF
--- a/examples/nextjs-with-typescript/next-env.d.ts
+++ b/examples/nextjs-with-typescript/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/examples/nextjs-with-typescript/package-lock.json
+++ b/examples/nextjs-with-typescript/package-lock.json
@@ -14,7 +14,7 @@
         "@mui/material": "^7.0.2",
         "@mux/mux-video": "^0.17.5",
         "media-chrome": "file:../../",
-        "next": "15.3.8",
+        "next": "~16.1.1",
         "react": "19.2.2",
         "react-dom": "19.2.2"
       },
@@ -31,7 +31,7 @@
       }
     },
     "../..": {
-      "version": "4.17.0",
+      "version": "4.17.2",
       "license": "MIT",
       "dependencies": {
         "ce-la-react": "^0.3.2"
@@ -53,6 +53,7 @@
         "react": "19.2.2",
         "resolve.exports": "^2.0.3",
         "rimraf": "^3.0.2",
+        "shx": "^0.4.0",
         "sinon": "^14.0.1",
         "typescript": "^5.5.2",
         "typescript-eslint": "^7.14.1",
@@ -1328,9 +1329,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.3.8",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.3.8.tgz",
-      "integrity": "sha512-SAfHg0g91MQVMPioeFeDjE+8UPF3j3BvHjs8ZKJAUz1BG7eMPvfCKOAgNWJ6s1MLNeP6O2InKQRTNblxPWuq+Q==",
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.1.tgz",
+      "integrity": "sha512-3oxyM97Sr2PqiVyMyrZUtrtM3jqqFxOQJVuKclDsgj/L728iZt/GyslkN4NwarledZATCenbk4Offjk1hQmaAA==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -1344,9 +1345,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.3.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.3.5.tgz",
-      "integrity": "sha512-lM/8tilIsqBq+2nq9kbTW19vfwFve0NR7MxfkuSUbRSgXlMQoJYg+31+++XwKVSXk4uT23G2eF/7BRIKdn8t8w==",
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.1.tgz",
+      "integrity": "sha512-JS3m42ifsVSJjSTzh27nW+Igfha3NdBOFScr9C80hHGrWx55pTrVL23RJbqir7k7/15SKlrLHhh/MQzqBBYrQA==",
       "cpu": [
         "arm64"
       ],
@@ -1360,9 +1361,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.3.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.3.5.tgz",
-      "integrity": "sha512-WhwegPQJ5IfoUNZUVsI9TRAlKpjGVK0tpJTL6KeiC4cux9774NYE9Wu/iCfIkL/5J8rPAkqZpG7n+EfiAfidXA==",
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.1.tgz",
+      "integrity": "sha512-hbyKtrDGUkgkyQi1m1IyD3q4I/3m9ngr+V93z4oKHrPcmxwNL5iMWORvLSGAf2YujL+6HxgVvZuCYZfLfb4bGw==",
       "cpu": [
         "x64"
       ],
@@ -1376,9 +1377,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.3.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.3.5.tgz",
-      "integrity": "sha512-LVD6uMOZ7XePg3KWYdGuzuvVboxujGjbcuP2jsPAN3MnLdLoZUXKRc6ixxfs03RH7qBdEHCZjyLP/jBdCJVRJQ==",
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.1.tgz",
+      "integrity": "sha512-/fvHet+EYckFvRLQ0jPHJCUI5/B56+2DpI1xDSvi80r/3Ez+Eaa2Yq4tJcRTaB1kqj/HrYKn8Yplm9bNoMJpwQ==",
       "cpu": [
         "arm64"
       ],
@@ -1392,9 +1393,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.3.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.3.5.tgz",
-      "integrity": "sha512-k8aVScYZ++BnS2P69ClK7v4nOu702jcF9AIHKu6llhHEtBSmM2zkPGl9yoqbSU/657IIIb0QHpdxEr0iW9z53A==",
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.1.tgz",
+      "integrity": "sha512-MFHrgL4TXNQbBPzkKKur4Fb5ICEJa87HM7fczFs2+HWblM7mMLdco3dvyTI+QmLBU9xgns/EeeINSZD6Ar+oLg==",
       "cpu": [
         "arm64"
       ],
@@ -1408,9 +1409,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.3.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.3.5.tgz",
-      "integrity": "sha512-2xYU0DI9DGN/bAHzVwADid22ba5d/xrbrQlr2U+/Q5WkFUzeL0TDR963BdrtLS/4bMmKZGptLeg6282H/S2i8A==",
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.1.tgz",
+      "integrity": "sha512-20bYDfgOQAPUkkKBnyP9PTuHiJGM7HzNBbuqmD0jiFVZ0aOldz+VnJhbxzjcSabYsnNjMPsE0cyzEudpYxsrUQ==",
       "cpu": [
         "x64"
       ],
@@ -1424,9 +1425,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.3.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.3.5.tgz",
-      "integrity": "sha512-TRYIqAGf1KCbuAB0gjhdn5Ytd8fV+wJSM2Nh2is/xEqR8PZHxfQuaiNhoF50XfY90sNpaRMaGhF6E+qjV1b9Tg==",
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.1.tgz",
+      "integrity": "sha512-9pRbK3M4asAHQRkwaXwu601oPZHghuSC8IXNENgbBSyImHv/zY4K5udBusgdHkvJ/Tcr96jJwQYOll0qU8+fPA==",
       "cpu": [
         "x64"
       ],
@@ -1440,9 +1441,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.3.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.3.5.tgz",
-      "integrity": "sha512-h04/7iMEUSMY6fDGCvdanKqlO1qYvzNxntZlCzfE8i5P0uqzVQWQquU1TIhlz0VqGQGXLrFDuTJVONpqGqjGKQ==",
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.1.tgz",
+      "integrity": "sha512-bdfQkggaLgnmYrFkSQfsHfOhk/mCYmjnrbRCGgkMcoOBZ4n+TRRSLmT/CU5SATzlBJ9TpioUyBW/vWFXTqQRiA==",
       "cpu": [
         "arm64"
       ],
@@ -1456,9 +1457,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.3.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.3.5.tgz",
-      "integrity": "sha512-5fhH6fccXxnX2KhllnGhkYMndhOiLOLEiVGYjP2nizqeGWkN10sA9taATlXwake2E2XMvYZjjz0Uj7T0y+z1yw==",
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.1.tgz",
+      "integrity": "sha512-Ncwbw2WJ57Al5OX0k4chM68DKhEPlrXBaSXDCi2kPi5f4d8b3ejr3RRJGfKBLrn2YJL5ezNS7w2TZLHSti8CMw==",
       "cpu": [
         "x64"
       ],
@@ -1553,12 +1554,6 @@
       "integrity": "sha512-zxnHvoMQVqewTJr/W4pKjF0bMGiKJv1WX7bSrkl46Hg0QjESbzBROWK0Wg4RphzSOS5Jiy7eFimmM3UgMrMZbQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@swc/counter": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
-      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "license": "Apache-2.0"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -2526,6 +2521,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.9.14",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.14.tgz",
+      "integrity": "sha512-B0xUquLkiGLgHhpPBqvl7GWegWBUNuujQ6kXd/r1U38ElPT6Ok8KZ8e+FpUGEc2ZoRQUzq/aUnaKFc/svWUGSg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -2594,17 +2598,6 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dependencies": {
-        "streamsearch": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.16.0"
       }
     },
     "node_modules/call-bind": {
@@ -5148,15 +5141,14 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.3.8",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.3.8.tgz",
-      "integrity": "sha512-L+4c5Hlr84fuaNADZbB9+ceRX9/CzwxJ+obXIGHupboB/Q1OLbSUapFs4bO8hnS/E6zV/JDX7sG1QpKVR2bguA==",
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.1.1.tgz",
+      "integrity": "sha512-QI+T7xrxt1pF6SQ/JYFz95ro/mg/1Znk5vBebsWwbpejj1T0A23hO7GYEaVac9QUOT2BIMiuzm0L99ooq7k0/w==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.3.8",
-        "@swc/counter": "0.1.3",
+        "@next/env": "16.1.1",
         "@swc/helpers": "0.5.15",
-        "busboy": "1.6.0",
+        "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
         "styled-jsx": "5.1.6"
@@ -5165,22 +5157,22 @@
         "next": "dist/bin/next"
       },
       "engines": {
-        "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
+        "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.3.5",
-        "@next/swc-darwin-x64": "15.3.5",
-        "@next/swc-linux-arm64-gnu": "15.3.5",
-        "@next/swc-linux-arm64-musl": "15.3.5",
-        "@next/swc-linux-x64-gnu": "15.3.5",
-        "@next/swc-linux-x64-musl": "15.3.5",
-        "@next/swc-win32-arm64-msvc": "15.3.5",
-        "@next/swc-win32-x64-msvc": "15.3.5",
-        "sharp": "^0.34.1"
+        "@next/swc-darwin-arm64": "16.1.1",
+        "@next/swc-darwin-x64": "16.1.1",
+        "@next/swc-linux-arm64-gnu": "16.1.1",
+        "@next/swc-linux-arm64-musl": "16.1.1",
+        "@next/swc-linux-x64-gnu": "16.1.1",
+        "@next/swc-linux-x64-musl": "16.1.1",
+        "@next/swc-win32-arm64-msvc": "16.1.1",
+        "@next/swc-win32-x64-msvc": "16.1.1",
+        "sharp": "^0.34.4"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
-        "@playwright/test": "^1.41.2",
+        "@playwright/test": "^1.51.1",
         "babel-plugin-react-compiler": "*",
         "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
         "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
@@ -6291,14 +6283,6 @@
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
     },
     "node_modules/string-width": {
       "version": "5.1.2",

--- a/examples/nextjs-with-typescript/package.json
+++ b/examples/nextjs-with-typescript/package.json
@@ -15,7 +15,7 @@
     "@mui/material": "^7.0.2",
     "@mux/mux-video": "^0.17.5",
     "media-chrome": "file:../../",
-    "next": "15.3.8",
+    "next": "~16.1.1",
     "react": "19.2.2",
     "react-dom": "19.2.2"
   },

--- a/examples/nextjs-with-typescript/tsconfig.json
+++ b/examples/nextjs-with-typescript/tsconfig.json
@@ -14,7 +14,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -32,7 +32,8 @@
     "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx",
-    ".next/types/**/*.ts"
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
   ],
   "exclude": [
     "node_modules"

--- a/examples/vanilla/memory-leak-tester.html
+++ b/examples/vanilla/memory-leak-tester.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width" />
+    <title>&lt;mux-video&gt; example</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css">
+    <link rel="stylesheet" href="./styles.css">
+    <script type="module" src="../../dist/index.js"></script>
+    <style>
+      mux-video {
+        display: block;
+        width: 100%;
+        aspect-ratio: 16 / 9;
+        margin: 1rem 0 2rem;
+      }
+    </style>
+  </head>
+  <body>
+    <button id="mount">Mount player</button>
+    <button id="unmount">Unmount player</button>
+
+    <div id="root"></div>
+
+    <script type="module">
+      const root = document.getElementById('root');
+      let controller = null;
+
+      function mount() {
+        if (controller) return;
+
+        controller = document.createElement('media-controller');
+
+        controller.innerHTML = `
+          <video
+            slot="media"
+            playsinline
+            src="https://stream.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/high.mp4">
+          </video>
+          <media-poster-image
+            slot="poster"
+            src="https://image.mux.com/A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/thumbnail.jpg"
+            placeholdersrc="data:image/jpeg;base64,/9j/2wBDABQODxIPDRQSEBIXFRQYHjIhHhwcHj0sLiQySUBMS0dARkVQWnNiUFVtVkVGZIhlbXd7gYKBTmCNl4x9lnN+gXz/2wBDARUXFx4aHjshITt8U0ZTfHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHz/wAARCAAUADADASIAAhEBAxEB/8QAGAAAAwEBAAAAAAAAAAAAAAAAAAECBAP/xAAdEAEBAAEEAwAAAAAAAAAAAAAAARECAxITFCFR/8QAGQEAAwADAAAAAAAAAAAAAAAAAAEDAgQF/8QAGBEBAQEBAQAAAAAAAAAAAAAAAAETERL/2gAMAwEAAhEDEQA/ANeC4ldyI1b2EtIzzrrIqYZLvl5FGkGdbfQzGPvo76WsPxXLlfqbaA5va2iVJADgPELACsD/2Q==">
+          </media-poster-image>
+
+          <media-loading-indicator
+            slot="centered-chrome"
+            noautohide>
+          </media-loading-indicator>
+
+          <media-control-bar>
+            <media-play-button></media-play-button>
+            <media-mute-button></media-mute-button>
+            <media-volume-range></media-volume-range>
+            <media-time-display></media-time-display>
+            <media-time-range></media-time-range>
+            <media-duration-display></media-duration-display>
+            <media-playback-rate-button></media-playback-rate-button>
+            <media-fullscreen-button></media-fullscreen-button>
+          </media-control-bar>
+        `;
+        root.appendChild(controller);
+      }
+
+      function unmount() {
+        if (!controller) return;
+
+        controller.remove();
+        controller = null;
+      }
+
+      document.getElementById('mount').addEventListener('click', mount);
+      document.getElementById('unmount').addEventListener('click', unmount);
+    </script>
+  </body>
+</html>

--- a/examples/vanilla/memory-leak-tester.html
+++ b/examples/vanilla/memory-leak-tester.html
@@ -4,7 +4,6 @@
     <meta name="viewport" content="width=device-width" />
     <title>&lt;mux-video&gt; example</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css">
-    <link rel="stylesheet" href="./styles.css">
     <script type="module" src="../../dist/index.js"></script>
     <style>
       mux-video {

--- a/src/js/media-chrome-button.ts
+++ b/src/js/media-chrome-button.ts
@@ -198,7 +198,7 @@ class MediaChromeButton extends globalThis.HTMLElement {
     this.tooltipEl = this.shadowRoot.querySelector('media-tooltip');
   }
 
-  #clickListener = (e) => {
+  #clickListener = (e: MouseEvent) => {
     if (!this.preventClick) {
       this.handleClick(e);
     }
@@ -216,7 +216,7 @@ class MediaChromeButton extends globalThis.HTMLElement {
 
   // NOTE: There are definitely some "false positive" cases with multi-key pressing,
   // but this should be good enough for most use cases.
-  #keyupListener = (e) => {
+  #keyupListener = (e: KeyboardEvent) => {
     const { key } = e;
     if (!this.keysUsed.includes(key)) {
       this.removeEventListener('keyup', this.#keyupListener);
@@ -228,7 +228,7 @@ class MediaChromeButton extends globalThis.HTMLElement {
     }
   };
 
-  #keydownListener = (e) => {
+  #keydownListener = (e: KeyboardEvent) => {
     const { metaKey, altKey, key } = e;
     if (metaKey || altKey || !this.keysUsed.includes(key)) {
       this.removeEventListener('keyup', this.#keyupListener);
@@ -237,10 +237,15 @@ class MediaChromeButton extends globalThis.HTMLElement {
     this.addEventListener('keyup', this.#keyupListener, { once: true });
   };
 
+  /** Prevent events to be setup multiple times */
+  #eventsSetup: boolean = false;
   enable() {
+    if (this.#eventsSetup) return;
+
     this.addEventListener('click', this.#clickListener);
     this.addEventListener('keydown', this.#keydownListener);
     this.tabIndex = 0;
+    this.#eventsSetup = true;
   }
 
   disable() {
@@ -248,6 +253,8 @@ class MediaChromeButton extends globalThis.HTMLElement {
     this.removeEventListener('keydown', this.#keydownListener);
     this.removeEventListener('keyup', this.#keyupListener);
     this.tabIndex = -1;
+
+    this.#eventsSetup = false;
   }
 
   attributeChangedCallback(attrName, oldValue, newValue) {
@@ -379,9 +386,8 @@ class MediaChromeButton extends globalThis.HTMLElement {
 
   /**
    * @abstract
-   * @argument {Event} e
    */
-  handleClick(e) {} // eslint-disable-line
+  handleClick(_e: Event) {}
 }
 
 if (!globalThis.customElements.get('media-chrome-button')) {

--- a/src/js/media-chrome-button.ts
+++ b/src/js/media-chrome-button.ts
@@ -237,15 +237,10 @@ class MediaChromeButton extends globalThis.HTMLElement {
     this.addEventListener('keyup', this.#keyupListener, { once: true });
   };
 
-  /** Prevent events to be setup multiple times */
-  #eventsSetup: boolean = false;
   enable() {
-    if (this.#eventsSetup) return;
-
     this.addEventListener('click', this.#clickListener);
     this.addEventListener('keydown', this.#keydownListener);
     this.tabIndex = 0;
-    this.#eventsSetup = true;
   }
 
   disable() {
@@ -253,8 +248,6 @@ class MediaChromeButton extends globalThis.HTMLElement {
     this.removeEventListener('keydown', this.#keydownListener);
     this.removeEventListener('keyup', this.#keyupListener);
     this.tabIndex = -1;
-
-    this.#eventsSetup = false;
   }
 
   attributeChangedCallback(attrName, oldValue, newValue) {

--- a/src/js/media-chrome-dialog.ts
+++ b/src/js/media-chrome-dialog.ts
@@ -121,10 +121,6 @@ class MediaChromeDialog extends globalThis.HTMLElement {
 
   constructor() {
     super();
-
-    this.addEventListener('invoke', this);
-    this.addEventListener('focusout', this);
-    this.addEventListener('keydown', this);
   }
 
   get open() {
@@ -177,6 +173,16 @@ class MediaChromeDialog extends globalThis.HTMLElement {
     if (!this.role) {
       this.role = 'dialog';
     }
+
+    this.addEventListener('invoke', this);
+    this.addEventListener('focusout', this);
+    this.addEventListener('keydown', this);
+  }
+  
+  disconnectedCallback(): void {
+    this.removeEventListener('invoke', this);
+    this.removeEventListener('focusout', this);
+    this.removeEventListener('keydown', this);
   }
 
   attributeChangedCallback(attrName: string, oldValue: string | null, newValue: string | null) {

--- a/src/js/media-chrome-range.ts
+++ b/src/js/media-chrome-range.ts
@@ -373,9 +373,6 @@ class MediaChromeRange extends globalThis.HTMLElement {
      * {value: number, min: number, max: number}} */
     this.range = this.shadowRoot.querySelector('#range');
     this.appearance = this.shadowRoot.querySelector('#appearance');
-
-    this.#onFocusIn = this.#onFocusIn.bind(this);
-    this.#onFocusOut = this.#onFocusOut.bind(this);
   }
 
   #onFocusIn = (): void => {
@@ -568,12 +565,14 @@ class MediaChromeRange extends globalThis.HTMLElement {
     return this.hasAttribute('dragging');
   }
 
+  #userEventsSetup: boolean = false
   #enableUserEvents() {
-    if (this.hasAttribute('disabled')) return;
+    if (this.hasAttribute('disabled') || this.#userEventsSetup || !this.isConnected) return;
 
     this.addEventListener('input', this);
     this.addEventListener('pointerdown', this);
     this.addEventListener('pointerenter', this);
+    this.#userEventsSetup = true;
   }
 
   #disableUserEvents() {
@@ -583,6 +582,7 @@ class MediaChromeRange extends globalThis.HTMLElement {
     this.removeEventListener('pointerleave', this);
     globalThis.window?.removeEventListener('pointerup', this);
     globalThis.window?.removeEventListener('pointermove', this);
+    this.#userEventsSetup = false;
   }
 
   handleEvent(evt) {
@@ -612,14 +612,14 @@ class MediaChromeRange extends globalThis.HTMLElement {
     // Events outside the range element are handled manually below.
     this.#isInputTarget = evt.composedPath().includes(this.range);
 
-    globalThis.window?.addEventListener('pointerup', this);
+    globalThis.window?.addEventListener('pointerup', this, {once: true});
   }
 
   #handlePointerEnter(evt) {
     // On mobile a pointerdown is not required to drag the range.
     if (evt.pointerType !== 'mouse') this.#handlePointerDown(evt);
 
-    this.addEventListener('pointerleave', this);
+    this.addEventListener('pointerleave', this, {once: true});
     globalThis.window?.addEventListener('pointermove', this);
   }
 

--- a/src/js/media-chrome-range.ts
+++ b/src/js/media-chrome-range.ts
@@ -373,6 +373,9 @@ class MediaChromeRange extends globalThis.HTMLElement {
      * {value: number, min: number, max: number}} */
     this.range = this.shadowRoot.querySelector('#range');
     this.appearance = this.shadowRoot.querySelector('#appearance');
+
+    this.#onFocusIn = this.#onFocusIn.bind(this);
+    this.#onFocusOut = this.#onFocusOut.bind(this);
   }
 
   #onFocusIn = (): void => {
@@ -577,6 +580,7 @@ class MediaChromeRange extends globalThis.HTMLElement {
     this.removeEventListener('input', this);
     this.removeEventListener('pointerdown', this);
     this.removeEventListener('pointerenter', this);
+    this.removeEventListener('pointerleave', this);
     globalThis.window?.removeEventListener('pointerup', this);
     globalThis.window?.removeEventListener('pointermove', this);
   }

--- a/src/js/media-chrome-range.ts
+++ b/src/js/media-chrome-range.ts
@@ -565,14 +565,12 @@ class MediaChromeRange extends globalThis.HTMLElement {
     return this.hasAttribute('dragging');
   }
 
-  #userEventsSetup: boolean = false
   #enableUserEvents() {
-    if (this.hasAttribute('disabled') || this.#userEventsSetup || !this.isConnected) return;
+    if (this.hasAttribute('disabled') || !this.isConnected) return;
 
     this.addEventListener('input', this);
     this.addEventListener('pointerdown', this);
     this.addEventListener('pointerenter', this);
-    this.#userEventsSetup = true;
   }
 
   #disableUserEvents() {
@@ -582,7 +580,6 @@ class MediaChromeRange extends globalThis.HTMLElement {
     this.removeEventListener('pointerleave', this);
     globalThis.window?.removeEventListener('pointerup', this);
     globalThis.window?.removeEventListener('pointermove', this);
-    this.#userEventsSetup = false;
   }
 
   handleEvent(evt) {

--- a/src/js/media-container.ts
+++ b/src/js/media-container.ts
@@ -428,6 +428,7 @@ class MediaContainer extends globalThis.HTMLElement {
     const setVideoAccessibility = (videoEl: HTMLVideoElement) => {
       if (!videoEl.hasAttribute('aria-hidden')) {
         videoEl.setAttribute('aria-hidden', 'true');
+        videoEl.setAttribute('inert', 'true')
       }
     };
 

--- a/src/js/media-container.ts
+++ b/src/js/media-container.ts
@@ -408,23 +408,6 @@ class MediaContainer extends globalThis.HTMLElement {
       await globalThis.customElements.whenDefined(media.localName);
     }
 
-    const setVideoAccessibility = (videoEl: HTMLVideoElement) => {
-      if (!videoEl.hasAttribute('aria-hidden')) {
-        videoEl.setAttribute('aria-hidden', 'true');
-        videoEl.setAttribute('inert', 'true')
-      }
-    };
-
-    if (media instanceof HTMLVideoElement || media.tagName === 'VIDEO') {
-      setVideoAccessibility(media as HTMLVideoElement);
-    } else if (media.localName?.includes('-')) {
-      // If `media` is a custom media element search in its shadow DOM
-      const videoElement = media.shadowRoot?.querySelector('video') as HTMLVideoElement | null;
-      if (videoElement) {
-        setVideoAccessibility(videoElement);
-      }
-    }
-
     // Even if we are not connected to the DOM after this await still call mediaSetCallback
     // so the media state is already computed once, then when the container is connected
     // to the DOM mediaSetCallback is called again to attach the root node event listeners.

--- a/src/js/media-controller.ts
+++ b/src/js/media-controller.ts
@@ -599,7 +599,7 @@ class MediaController extends MediaContainer {
     els.splice(index, 1);
   }
 
-  #keyUpHandler(e: KeyboardEvent) {
+  #keyUpHandler = (e: KeyboardEvent) => {
     const { key, shiftKey } = e;
     // Check for Shift + / (which produces '?' on US keyboards or '/' on others)
     const isShiftSlash = shiftKey && (key === '/' || key === '?');

--- a/src/js/media-controller.ts
+++ b/src/js/media-controller.ts
@@ -470,6 +470,8 @@ class MediaController extends MediaContainer {
     // mediaUnsetCallback() is called in super.disconnectedCallback();
     super.disconnectedCallback?.();
 
+    this.disableHotkeys();
+
     if (this.#mediaStore) {
       // Save the current state of subtitles before disconnecting
       const currentState = this.#mediaStore.getState();
@@ -648,13 +650,19 @@ class MediaController extends MediaContainer {
     this.addEventListener('keyup', this.#keyUpHandler, { once: true });
   }
 
+  /** Used to prevent hotkeys event listeners from being set more than once */
+  #hotkeysEnabled: boolean = false;
   enableHotkeys() {
-    this.addEventListener('keydown', this.#keyDownHandler);
+    if (!this.#hotkeysEnabled) {
+      this.addEventListener('keydown', this.#keyDownHandler);
+      this.#hotkeysEnabled = true;
+    }
   }
 
   disableHotkeys() {
     this.removeEventListener('keydown', this.#keyDownHandler);
     this.removeEventListener('keyup', this.#keyUpHandler);
+    this.#hotkeysEnabled = false
   }
 
   get hotkeys(): string | undefined {

--- a/src/js/media-controller.ts
+++ b/src/js/media-controller.ts
@@ -507,9 +507,19 @@ class MediaController extends MediaContainer {
       detail: media,
     });
 
-    // TODO: What does this do? At least add comment, maybe move to media-container
+    /*
+     * Prevents the media element from being tab focusable, this is to prevent blue border, particularly when going full screen.
+     * The media controller should take on the accessibility responsabilities (clickable, keyboard controls, etc.)
+     * 
+     * Note: This implies we should never .focus on the media element.
+     * 
+     * See related links:
+     * - https://github.com/muxinc/media-chrome/issues/309
+     * - https://github.com/muxinc/media-chrome/pull/312
+     */
     if (!media.hasAttribute('tabindex')) {
       media.tabIndex = -1;
+      media.ariaHidden = "true"
     }
   }
 
@@ -650,19 +660,13 @@ class MediaController extends MediaContainer {
     this.addEventListener('keyup', this.#keyUpHandler, { once: true });
   }
 
-  /** Used to prevent hotkeys event listeners from being set more than once */
-  #hotkeysEnabled: boolean = false;
   enableHotkeys() {
-    if (!this.#hotkeysEnabled) {
-      this.addEventListener('keydown', this.#keyDownHandler);
-      this.#hotkeysEnabled = true;
-    }
+    this.addEventListener('keydown', this.#keyDownHandler);
   }
 
   disableHotkeys() {
     this.removeEventListener('keydown', this.#keyDownHandler);
     this.removeEventListener('keyup', this.#keyUpHandler);
-    this.#hotkeysEnabled = false
   }
 
   get hotkeys(): string | undefined {

--- a/src/js/media-controller.ts
+++ b/src/js/media-controller.ts
@@ -508,10 +508,9 @@ class MediaController extends MediaContainer {
     });
 
     /*
-     * Prevents the media element from being tab focusable, this is to prevent blue border, particularly when going full screen.
-     * The media controller should take on the accessibility responsabilities (clickable, keyboard controls, etc.)
-     * 
-     * Note: This implies we should never .focus on the media element.
+     * Prevents the media element from being tab focusable to avoid the blue focus ring,
+     * particularly when going full screen. The media controller handles all accessibility
+     * responsibilities (clickable, keyboard controls, etc.) instead.
      * 
      * See related links:
      * - https://github.com/muxinc/media-chrome/issues/309
@@ -519,7 +518,6 @@ class MediaController extends MediaContainer {
      */
     if (!media.hasAttribute('tabindex')) {
       media.tabIndex = -1;
-      media.ariaHidden = "true"
     }
   }
 

--- a/src/js/media-controller.ts
+++ b/src/js/media-controller.ts
@@ -490,6 +490,8 @@ class MediaController extends MediaContainer {
       this.#mediaStoreUnsubscribe?.();
       this.#mediaStoreUnsubscribe = undefined;
     }
+
+    this.unassociateElement(this);
   }
 
   /**

--- a/src/js/media-gesture-receiver.ts
+++ b/src/js/media-gesture-receiver.ts
@@ -88,8 +88,18 @@ class MediaGestureReceiver extends globalThis.HTMLElement {
       this.#mediaController?.associateElement?.(this);
     }
 
-    this.#mediaController?.addEventListener('pointerdown', this);
-    this.#mediaController?.addEventListener('click', this);
+    if (!this.#mediaController) return
+
+    this.#mediaController.addEventListener('pointerdown', this);
+    this.#mediaController.addEventListener('click', this);
+    
+    /* 
+     * Note: According to ARIA: "Clickable elements must be focusable and should have interactive semantics"
+     * Since this class adds the click listener, it also makes it focusable
+     */
+    if (!this.#mediaController.hasAttribute("tabindex")) {
+      this.#mediaController.tabIndex = 0;
+    }
   }
 
   disconnectedCallback(): void {

--- a/src/js/media-preview-thumbnail.ts
+++ b/src/js/media-preview-thumbnail.ts
@@ -182,6 +182,8 @@ class MediaPreviewThumbnail extends globalThis.HTMLElement {
         this.imgWidth = img.naturalWidth;
         this.imgHeight = img.naturalHeight;
         resize();
+
+        img.onload = null;
       };
       img.src = src;
       resize();

--- a/src/js/media-store/state-mediator.ts
+++ b/src/js/media-store/state-mediator.ts
@@ -1020,7 +1020,7 @@ export const stateMediator: StateMediator = {
       } else {
         enterFullscreen(stateOwners);
         const isPointer = event.detail;
-        if (isPointer) stateOwners.media?.focus();
+        if (isPointer && !stateOwners.media?.inert) stateOwners.media?.focus();
       }
     },
     // older Safari version may require webkit-specific events

--- a/src/js/media-store/util.ts
+++ b/src/js/media-store/util.ts
@@ -1,6 +1,7 @@
 import { TextTrackKinds, TextTrackModes } from '../constants.js';
 import { getTextTracksList, updateTracksModeTo } from '../utils/captions.js';
 import { TextTrackLike } from '../utils/TextTrackLike.js';
+import { globalThis } from '../utils/server-safe-globals.js';
 
 export const getSubtitleTracks = (stateOwners): TextTrackLike[] => {
   return getTextTracksList(stateOwners.media, (textTrack) => {

--- a/src/js/media-theme-element.ts
+++ b/src/js/media-theme-element.ts
@@ -59,6 +59,7 @@ export class MediaThemeElement extends globalThis.HTMLElement {
   #template: HTMLTemplateElement;
   #prevTemplate: HTMLTemplateElement;
   #prevTemplateId: string | null;
+  #observer: MutationObserver;
 
   constructor() {
     super();
@@ -71,7 +72,7 @@ export class MediaThemeElement extends globalThis.HTMLElement {
       this.createRenderer();
     }
 
-    const observer = new MutationObserver((mutationList) => {
+    this.#observer = new MutationObserver((mutationList) => {
       // Only update if `<media-controller>` has computed breakpoints at least once.
       if (this.mediaController && !this.mediaController?.breakpointsComputed)
         return;

--- a/src/js/media-theme-element.ts
+++ b/src/js/media-theme-element.ts
@@ -108,10 +108,7 @@ export class MediaThemeElement extends globalThis.HTMLElement {
       subtree: true,
     });
 
-    this.addEventListener(
-      MediaStateChangeEvents.BREAKPOINTS_COMPUTED,
-      this.render
-    );
+    this.#renderBind = this.render.bind(this);
 
     // In case the template prop was set before custom element upgrade.
     // https://web.dev/custom-elements-best-practices/#make-properties-lazy
@@ -196,7 +193,19 @@ export class MediaThemeElement extends globalThis.HTMLElement {
   }
 
   connectedCallback(): void {
+    this.addEventListener(
+      MediaStateChangeEvents.BREAKPOINTS_COMPUTED,
+      this.#renderBind
+    );
+    
     this.#updateTemplate();
+  }
+
+  disconnectedCallback(): void {
+    this.removeEventListener(
+      MediaStateChangeEvents.BREAKPOINTS_COMPUTED,
+      this.#renderBind
+    );
   }
 
   #updateTemplate(): void {
@@ -252,6 +261,7 @@ export class MediaThemeElement extends globalThis.HTMLElement {
     }
   }
 
+  #renderBind: () => void;
   render(): void {
     this.renderer?.update(this.props);
   }

--- a/src/js/media-theme-element.ts
+++ b/src/js/media-theme-element.ts
@@ -99,15 +99,6 @@ export class MediaThemeElement extends globalThis.HTMLElement {
       }
     });
 
-    // Observe the `<media-theme>` element for attribute changes.
-    observer.observe(this, { attributes: true });
-
-    // Observe the subtree of the render root, by default the elements in the shadow dom.
-    observer.observe(this.renderRoot, {
-      attributes: true,
-      subtree: true,
-    });
-
     this.#renderBind = this.render.bind(this);
 
     // In case the template prop was set before custom element upgrade.
@@ -198,6 +189,15 @@ export class MediaThemeElement extends globalThis.HTMLElement {
       this.#renderBind
     );
     
+    // Observe the `<media-theme>` element for attribute changes.
+    this.#observer.observe(this, { attributes: true });
+
+    // Observe the subtree of the render root, by default the elements in the shadow dom.
+    this.#observer.observe(this.renderRoot, {
+      attributes: true,
+      subtree: true,
+    });
+
     this.#updateTemplate();
   }
 
@@ -206,6 +206,7 @@ export class MediaThemeElement extends globalThis.HTMLElement {
       MediaStateChangeEvents.BREAKPOINTS_COMPUTED,
       this.#renderBind
     );
+    this.#observer.disconnect();
   }
 
   #updateTemplate(): void {

--- a/src/js/media-time-display.ts
+++ b/src/js/media-time-display.ts
@@ -110,13 +110,13 @@ class MediaTimeDisplay extends MediaTextDisplay {
   #slot: HTMLSlotElement;
   #keyUpHandler: ((evt: KeyboardEvent) => void) | null = null;
   #keyDownHandler = (evt: KeyboardEvent) => {
-      const { metaKey, altKey, key } = evt;
-      if (metaKey || altKey || !ButtonPressedKeys.includes(key)) {
-        this.removeEventListener('keyup', this.#keyUpHandler);
-        return;
-      }
-      this.addEventListener('keyup', this.#keyUpHandler);
+    const { metaKey, altKey, key } = evt;
+    if (metaKey || altKey || !ButtonPressedKeys.includes(key)) {
+      this.removeEventListener('keyup', this.#keyUpHandler);
+      return;
     }
+    this.addEventListener('keyup', this.#keyUpHandler);
+  }
 
   static get observedAttributes(): string[] {
     return [...super.observedAttributes, ...CombinedAttributes, 'disabled'];
@@ -127,7 +127,6 @@ class MediaTimeDisplay extends MediaTextDisplay {
 
     this.#slot = this.shadowRoot.querySelector('slot');
     this.#slot.innerHTML = `${formatTimesLabel(this)}`;
-    this.#keyDownHandler = this.#keyDownHandler.bind(this);
   }
 
   connectedCallback(): void {
@@ -161,7 +160,6 @@ class MediaTimeDisplay extends MediaTextDisplay {
 
       this.toggleTimeDisplay();
     };
-    this.#keyUpHandler = this.#keyUpHandler.bind(this);
     this.addEventListener('keydown', this.#keyDownHandler);
     this.addEventListener('click', this.toggleTimeDisplay);
   }

--- a/src/js/media-time-range.ts
+++ b/src/js/media-time-range.ts
@@ -427,8 +427,8 @@ class MediaTimeRange extends MediaChromeRange {
     ];
   }
 
-  #rootNode;
-  #animation;
+  #rootNode: Node | null = null;
+  #animation: RangeAnimation;
   #boxes;
   #previewTime: number;
   #previewBox: HTMLElement;
@@ -517,7 +517,7 @@ class MediaTimeRange extends MediaChromeRange {
     }
   }
 
-  #toggleRangeAnimation(): void {
+  #toggleRangeAnimation = (): void => {
     if (this.#shouldRangeAnimate()) {
       this.#animation.start();
     } else {

--- a/src/js/media-volume-range.ts
+++ b/src/js/media-volume-range.ts
@@ -38,11 +38,6 @@ class MediaVolumeRange extends MediaChromeRange {
     ];
   }
 
-  constructor() {
-    super();
-    this.#handleRangeInput = this.#handleRangeInput.bind(this);
-  }
-
   #handleRangeInput: () => void = () => {
     const detail = this.range.value;
     const evt = new globalThis.CustomEvent(

--- a/src/js/media-volume-range.ts
+++ b/src/js/media-volume-range.ts
@@ -40,24 +40,31 @@ class MediaVolumeRange extends MediaChromeRange {
 
   constructor() {
     super();
+    this.#handleRangeInput = this.#handleRangeInput.bind(this);
+  }
 
-    this.range.addEventListener('input', () => {
-      const detail = this.range.value;
-      const evt = new globalThis.CustomEvent(
-        MediaUIEvents.MEDIA_VOLUME_REQUEST,
-        {
-          composed: true,
-          bubbles: true,
-          detail,
-        }
-      );
-      this.dispatchEvent(evt);
-    });
+  #handleRangeInput: () => void = () => {
+    const detail = this.range.value;
+    const evt = new globalThis.CustomEvent(
+      MediaUIEvents.MEDIA_VOLUME_REQUEST,
+      {
+        composed: true,
+        bubbles: true,
+        detail,
+      }
+    );
+    this.dispatchEvent(evt);
   }
 
   connectedCallback(): void {
     super.connectedCallback();
     this.range.setAttribute('aria-label', t('volume'));
+    this.range.addEventListener('input', this.#handleRangeInput);
+  }
+
+  disconnectedCallback(): void {
+    this.range.removeEventListener('input', this.#handleRangeInput);
+    super.disconnectedCallback();
   }
 
   attributeChangedCallback(

--- a/src/js/menu/media-chrome-menu-item.ts
+++ b/src/js/menu/media-chrome-menu-item.ts
@@ -183,7 +183,7 @@ class MediaChromeMenuItem extends globalThis.HTMLElement {
   }
 
   #dirty = false;
-  #ownerElement;
+  #ownerElement: MediaChromeMenu | null;
 
   constructor() {
     super();
@@ -195,8 +195,6 @@ class MediaChromeMenuItem extends globalThis.HTMLElement {
       const attrs = namedNodeMapToObject(this.attributes);
       this.shadowRoot.innerHTML = (this.constructor as typeof MediaChromeMenuItem).getTemplateHTML(attrs);
     }
-
-    this.shadowRoot.addEventListener('slotchange', this);
   }
 
   enable() {
@@ -269,6 +267,7 @@ class MediaChromeMenuItem extends globalThis.HTMLElement {
     if (this.submenuElement) {
       this.#submenuConnected();
     }
+    this.shadowRoot.addEventListener('slotchange', this);
   }
 
   disconnectedCallback(): void {
@@ -276,6 +275,7 @@ class MediaChromeMenuItem extends globalThis.HTMLElement {
 
     this.#reset();
     this.#ownerElement = null;
+    this.shadowRoot.removeEventListener('slotchange', this);
   }
 
   get invokeTarget() {
@@ -440,7 +440,7 @@ class MediaChromeMenuItem extends globalThis.HTMLElement {
     return ['Enter', ' '];
   }
 
-  #handleKeyUp(event) {
+  #handleKeyUp = (event: KeyboardEvent) => {
     const { key } = event;
 
     if (!this.keysUsed.includes(key)) {
@@ -451,7 +451,7 @@ class MediaChromeMenuItem extends globalThis.HTMLElement {
     this.handleClick(event);
   }
 
-  #handleKeyDown(event) {
+  #handleKeyDown = (event: KeyboardEvent) => {
     const { metaKey, altKey, key } = event;
 
     if (metaKey || altKey || !this.keysUsed.includes(key)) {

--- a/src/js/menu/media-chrome-menu.ts
+++ b/src/js/menu/media-chrome-menu.ts
@@ -422,6 +422,8 @@ class MediaChromeMenu extends globalThis.HTMLElement {
   }
 
   disconnectedCallback(): void {
+    this.#mutationObserver.disconnect();
+
     unobserveResize(getBoundsElement(this), this.#handleBoundsResize);
     unobserveResize(this, this.#handleMenuResize);
 

--- a/src/js/menu/media-chrome-menu.ts
+++ b/src/js/menu/media-chrome-menu.ts
@@ -348,10 +348,7 @@ class MediaChromeMenu extends globalThis.HTMLElement {
       'slot:not([name])'
     ) as HTMLSlotElement;
 
-    this.shadowRoot.addEventListener('slotchange', this);
-
     this.#mutationObserver = new MutationObserver(this.#handleMenuItems);
-    this.#mutationObserver.observe(this.defaultSlot, { childList: true });
   }
 
   enable(): void {
@@ -394,6 +391,7 @@ class MediaChromeMenu extends globalThis.HTMLElement {
   }
 
   connectedCallback(): void {
+    this.#mutationObserver.observe(this.defaultSlot, { childList: true });
     this.#cssRule = insertCSSRule(this.shadowRoot, ':host');
 
     this.#updateLayoutStyle();
@@ -419,6 +417,8 @@ class MediaChromeMenu extends globalThis.HTMLElement {
 
     // Required when using declarative shadow DOM.
     this.#toggleHeader();
+
+    this.shadowRoot.addEventListener('slotchange', this);
   }
 
   disconnectedCallback(): void {
@@ -432,6 +432,8 @@ class MediaChromeMenu extends globalThis.HTMLElement {
     // Use cached mediaController, getRootNode() doesn't work if disconnected.
     this.#mediaController?.unassociateElement?.(this);
     this.#mediaController = null;
+
+    this.shadowRoot.removeEventListener('slotchange', this);
   }
 
   attributeChangedCallback(

--- a/src/js/utils/element-utils.ts
+++ b/src/js/utils/element-utils.ts
@@ -271,10 +271,8 @@ export function insertCSSRule(
     };
   }
 
-  style?.sheet.insertRule(`${selectorText}{}`, style.sheet.cssRules.length);
-  return /** @type {CSSStyleRule} */ style.sheet.cssRules?.[
-    style.sheet.cssRules.length - 1
-  ];
+  const cssRuleId = style?.sheet.insertRule(`${selectorText}{}`, style.sheet.cssRules.length);
+  return style.sheet.cssRules?.[cssRuleId];
 }
 
 /**

--- a/src/js/utils/resize-observer.ts
+++ b/src/js/utils/resize-observer.ts
@@ -3,6 +3,7 @@ import { globalThis } from './server-safe-globals.js';
 // Use 1 resize observer instance for many elements for best performance.
 // https://groups.google.com/a/chromium.org/g/blink-dev/c/z6ienONUb5A/m/F5-VcUZtBAAJ
 
+// This weakmap may hold detached references for a while, which may appear as a leak, but get replaced/removed eventually
 const callbacksMap = new WeakMap<Element, Set<ResizeCallback>>();
 
 type ResizeCallback = (entry: ResizeObserverEntry) => void;


### PR DESCRIPTION
This PR addresses some memory leak issues across many of media-chrome components. Relates to https://github.com/muxinc/elements/issues/1235

The main idea in these changes is to clean references on component disconnect. It includes changes like removing added event listeners, disconnecting MutationObservers, and making sure we keep reference to the functions passed as callbacks to these types of objects.

It also includes some minor fixes like: adding typing; moving some logic from the components constructor to connectedCallback, for example adding event listeners or reinitializing stuff that is removed on disconnect; adding guards so that listeners are not added more than once.

## Testing
To test this I added the `examples/vanilla/memory-leak-tester.html` file which allows mounting and unmounting a `<media-controller>` element. 

The process consisted on mounting and unmounting the component and taking a heap snapshot to verify no leaks are present. To track memory leaks you can check the element's retainer tree to try and find who is holding the reference. It's highly recommended to use a non minified version of the code when testing. 

## Some extra details
1. Hanging `<video>` tag
When debugging media chrome, even if it's not specifically a component being leaked, we may find a Detached video tag

<img width="737" height="363" alt="image" src="https://github.com/user-attachments/assets/2555d11c-2787-4600-bd25-c7e42a699245" />

It should be an empty `<video>` tag, which relates to `testMediaEl` used in `src/js/utils/platform-tests.ts` as we can see from it's retainers. It is purposefully maintained in memory to not create several ones when checking some browser compatibilities.

Meaning that a "clean" heap snapshot looks like this:
<img width="920" height="267" alt="image" src="https://github.com/user-attachments/assets/47c3f000-a69a-468a-8fdb-1e6e8e982feb" />

2. Another video tag is held by a console warning about aria-hidden, which in turn holds the media controller:

```
Blocked aria-hidden on an element because its descendant retained focus. The focus must not be hidden from assistive technology users. Avoid using aria-hidden on a focused element or its ancestor. Consider using the inert attribute instead, which will also prevent focus. For more details, see the aria-hidden section of the WAI-ARIA specification at https://w3c.github.io/aria/#aria-hidden.
Element with focus: <video slot=media>
Ancestor with aria-hidden: 
<video slot=media> 
<video slot=​"media" playsinline src=​"https:​/​/​stream.mux.com/​A3VXy02VoUinw01pwyomEO3bHnG4P32xzV7u1j1FSzjNg/​high.mp4" aria-hidden=​"true" tabindex=​"-1">​</video>
```
To remove this I added the `inert` attribute on `media-container.ts:414`, but this makes the element non clickable, which may not be desired. Alternatively, we can remove the aria-hidden attribute, but I understand this was added to address accessibility issues in a previous PR. https://github.com/muxinc/elements/issues/1040
On media-controller:510 (mediaSetCallback), we set media tabIndex to -1, meaning it's not keyboard accessible.

3. Also, when debugging, sometimes Chrome will cache some elements (holding reference to the whole tree of components), which looks like a memory leak. Generally, if `<symbol Window#DocumentCachedAccessor>inWindow (global*) /` appears as one of the first retainers, it means that this is happening.
<img width="980" height="450" alt="image" src="https://github.com/user-attachments/assets/258bbb3e-f0ad-4f74-9722-00369168b800" />
One way to check this is not actually a leak is to mount the component again, play the video, and unmount it. Now on another heap snapshot we should no longer see these elements.  
