### PR TITLE
fix: Auto rendition label for vertical videos

### DIFF
--- a/src/js/menu/media-rendition-menu.ts
+++ b/src/js/menu/media-rendition-menu.ts
@@ -38,6 +38,7 @@ class MediaRenditionMenu extends MediaChromeMenu {
       MediaUIAttributes.MEDIA_RENDITION_SELECTED,
       MediaUIAttributes.MEDIA_RENDITION_UNAVAILABLE,
       MediaUIAttributes.MEDIA_HEIGHT,
+      MediaUIAttributes.MEDIA_WIDTH,
     ];
   }
 
@@ -82,23 +83,21 @@ class MediaRenditionMenu extends MediaChromeMenu {
   ): void {
     super.attributeChangedCallback(attrName, oldValue, newValue);
 
-    if (
-      attrName === MediaUIAttributes.MEDIA_RENDITION_SELECTED &&
-      oldValue !== newValue
-    ) {
-      this.value = newValue ?? 'auto';
-      this.#render();
-    } else if (
-      attrName === MediaUIAttributes.MEDIA_RENDITION_LIST &&
-      oldValue !== newValue
-    ) {
-      this.#renditionList = parseRenditionList(newValue);
-      this.#render();
-    } else if (
-      attrName === MediaUIAttributes.MEDIA_HEIGHT &&
-      oldValue !== newValue
-    ) {
-      this.#render();
+    if (oldValue !== newValue) {
+      switch (attrName) {
+        case MediaUIAttributes.MEDIA_RENDITION_SELECTED:
+          this.value = newValue ?? 'auto';
+          this.#render();
+          break;
+        case MediaUIAttributes.MEDIA_RENDITION_LIST:
+          this.#renditionList = parseRenditionList(newValue);
+          this.#render();
+          break;
+        case MediaUIAttributes.MEDIA_HEIGHT:
+        case MediaUIAttributes.MEDIA_WIDTH:
+          this.#render();
+          break
+      }
     }
   }
 
@@ -150,11 +149,20 @@ class MediaRenditionMenu extends MediaChromeMenu {
     setNumericAttr(this, MediaUIAttributes.MEDIA_HEIGHT, height);
   }
 
+  get mediaWidth(): number {
+    return getNumericAttr(this, MediaUIAttributes.MEDIA_WIDTH);
+  }
+
+  set mediaWidth(width: number) {
+    setNumericAttr(this, MediaUIAttributes.MEDIA_WIDTH, width);
+  }
+
   #render(): void {
     if (
       this.#prevState.mediaRenditionList ===
         JSON.stringify(this.mediaRenditionList) &&
-      this.#prevState.mediaHeight === this.mediaHeight
+      this.#prevState.mediaHeight === this.mediaHeight &&
+      this.#prevState.mediaWidth === this.mediaWidth
     )
       return;
 
@@ -162,12 +170,13 @@ class MediaRenditionMenu extends MediaChromeMenu {
       this.mediaRenditionList
     );
     this.#prevState.mediaHeight = this.mediaHeight;
+    this.#prevState.mediaWidth = this.mediaWidth;
 
     const renditionList = this.mediaRenditionList.sort(
       this.compareRendition.bind(this)
     );
 
-    const selectedRendition = renditionList.find(
+    const selectedRendition: Rendition | undefined = renditionList.find(
       (rendition) => rendition.id === this.mediaRenditionSelected
     );
 
@@ -209,7 +218,7 @@ class MediaRenditionMenu extends MediaChromeMenu {
             })}`,
             selectedRendition
           )
-        : this.formatMenuItemText(`${t('Auto')} (${this.mediaHeight}p)`)
+        : this.formatMenuItemText(`${t('Auto')} (${Math.min(this.mediaWidth, this.mediaHeight)}p)`)
       : this.formatMenuItemText(t('Auto'));
 
     const item = createMenuItem({

--- a/src/js/menu/media-rendition-menu.ts
+++ b/src/js/menu/media-rendition-menu.ts
@@ -158,11 +158,14 @@ class MediaRenditionMenu extends MediaChromeMenu {
   }
 
   #render(): void {
+    const isAuto = !this.mediaRenditionSelected;
+
     if (
       this.#prevState.mediaRenditionList ===
         JSON.stringify(this.mediaRenditionList) &&
       this.#prevState.mediaHeight === this.mediaHeight &&
-      this.#prevState.mediaWidth === this.mediaWidth
+      this.#prevState.mediaWidth === this.mediaWidth && 
+      this.#prevState.isAuto === isAuto
     )
       return;
 
@@ -171,6 +174,7 @@ class MediaRenditionMenu extends MediaChromeMenu {
     );
     this.#prevState.mediaHeight = this.mediaHeight;
     this.#prevState.mediaWidth = this.mediaWidth;
+    this.#prevState.isAuto = isAuto;
 
     const renditionList = this.mediaRenditionList.sort(
       this.compareRendition.bind(this)
@@ -189,8 +193,6 @@ class MediaRenditionMenu extends MediaChromeMenu {
 
     this.defaultSlot.textContent = '';
 
-    const isAuto = !this.mediaRenditionSelected;
-
     for (const rendition of renditionList) {
       const text = this.formatRendition(rendition, {
         showBitrate: this.showRenditionBitrate(rendition),
@@ -208,18 +210,30 @@ class MediaRenditionMenu extends MediaChromeMenu {
 
     const showSelectedBitrate =
       selectedRendition && this.showRenditionBitrate(selectedRendition);
-
-    const autoText = isAuto
-      ? // Auto • 1080p (4 Mbps)
-        selectedRendition
-        ? this.formatMenuItemText(
-            `${t('Auto')} • ${this.formatRendition(selectedRendition, {
-              showBitrate: showSelectedBitrate,
-            })}`,
-            selectedRendition
-          )
-        : this.formatMenuItemText(`${t('Auto')} (${Math.min(this.mediaWidth, this.mediaHeight)}p)`)
-      : this.formatMenuItemText(t('Auto'));
+    
+    let autoText = undefined;
+    if (isAuto) {
+      // TODO: If isAuto === true -> selectedRendition will be undefined
+      //    so this is effectively dead code, but I'm leaving it here because
+      //    it's a nice to have. 
+      // We would need a way to get the active rendition in a similar way as we
+      // get selectedRendition or a way to get mediaBitrate (not currently provided by state).
+      if (selectedRendition) {
+        // Auto • 1080p (4 Mbps)
+        autoText = this.formatMenuItemText(
+          `${t('Auto')} • ${this.formatRendition(selectedRendition, {
+            showBitrate: showSelectedBitrate,
+          })}`,
+          selectedRendition
+        )
+      } else if (this.mediaHeight > 0 && this.mediaWidth > 0) {
+        autoText = this.formatMenuItemText(`${t('Auto')} (${Math.min(this.mediaWidth, this.mediaHeight)}p)`)
+      }
+    }
+    
+    if (!autoText) {
+      autoText = this.formatMenuItemText(t('Auto'));
+    }
 
     const item = createMenuItem({
       type: 'radio',


### PR DESCRIPTION
Closes https://github.com/muxinc/devextravaganza/issues/205

- Added Math.min check between width and height to display correct name of auto rendition on vertical videos. Also added `mediaWidth` getter and setter
- Added isAuto to rendition menu prevState so Auto text updates correctly when switching off auto. (*)
- Added check to avoid displaying 0p before rendition list is correctly initialized.
- Left previous behavior when isAuto && selectedRendition, which would never run. Added a comment explaining why and what could be done, but felt unnecessary for now.

(*) Images showing the previous behavior when switching off auto
For some seconds after selecting another option (note 1080p is selected), Auto rendition would display the previous state text
<img width="128" height="192" alt="image" src="https://github.com/user-attachments/assets/8c62799f-b67d-4c56-8434-7148b63ee1a4" />
When quality changes for the video the menu would re render correctly
<img width="97" height="191" alt="image" src="https://github.com/user-attachments/assets/c1aa0229-e63d-4344-8ef9-31be67b55eee" />
The changes now cause the menu to re render when auto is selected/de-selected 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/state update limited to `media-rendition-menu`, mainly affecting when the menu re-renders and how the Auto label is computed; no security or data persistence impact.
> 
> **Overview**
> Fixes the *Auto* quality label in `media-rendition-menu` for vertical videos by incorporating `mediaWidth` and displaying the smaller dimension (e.g. `min(width,height)p`) instead of relying on height alone.
> 
> The menu now observes `mediaWidth`, re-renders on width/height changes, and tracks `isAuto` in its render cache so the Auto text updates immediately when toggling Auto on/off. It also avoids showing an initial `0p` Auto label until valid dimensions are available.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37f91b8b6b8643703abaad7ee0af86bf10b35029. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->