### PR TITLE
fix: Re associate element on reconnect

### DIFF
--- a/src/js/media-controller.ts
+++ b/src/js/media-controller.ts
@@ -158,10 +158,6 @@ class MediaController extends MediaContainer {
       });
       prevState = nextState;
     };
-
-    this.hasAttribute(Attributes.NO_HOTKEYS)
-      ? this.disableHotkeys()
-      : this.enableHotkeys();
   }
 
   #setupDefaultStore() {
@@ -440,6 +436,8 @@ class MediaController extends MediaContainer {
   }
 
   connectedCallback(): void {
+    this.associateElement(this);
+
     // NOTE: Need to defer default MediaStore creation until connected for use cases that
     // rely on createElement('media-controller') (like many frameworks "under the hood") (CJP).
     if (!this.#mediaStore && !this.hasAttribute(Attributes.NO_DEFAULT_STORE)) {


### PR DESCRIPTION
Closes https://github.com/muxinc/devextravaganza/issues/218

On memory leak patch, when disconnecting the media-controller we added a `this.disassociateElement(this)`, but did not add `this.associateElement(this)` on connected callback (originally done in constructor). 

This change adds this new line to connected callback. There's no problem with calling this twice (constructor and on connect) since assosicate element already handles deduplication. 

Also removed enable and disable hotkeys on constructor since it's unnecesary and also handled on connect (both functions just add or remove event listeners). 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk lifecycle tweak that re-adds `associateElement(this)` on `connectedCallback` and removes redundant constructor hotkey toggling; main risk is unintended duplicate listeners, but `associateElement` dedupes and hotkeys remain managed on connect/disconnect.
> 
> **Overview**
> Ensures `MediaController` re-establishes its associated-element subscriptions after being disconnected and reconnected by calling `associateElement(this)` in `connectedCallback`.
> 
> Removes the constructor-time hotkey enable/disable toggle so hotkey listeners are only managed during connect/disconnect, avoiding redundant listener churn.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fad0430bf471b39837e24bb35b9e35dd618f30d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->