### PR TITLE
Docs/improve lang import and set

### DIFF
--- a/docs/src/pages/docs/en/internationalization/adding-language-support.mdx
+++ b/docs/src/pages/docs/en/internationalization/adding-language-support.mdx
@@ -8,6 +8,8 @@ Media Chrome supports multiple languages for its UI components. By default, it u
 ## Available Languages
 Currently, the supported languages are:
 
+- **Chinese (Simplified)** (`zh-CN`)
+- **Chinese (Traditional)** (`zh-TW`)
 - **English** (default)
 - **French** (`fr`)
 - **German** (`de`)
@@ -37,9 +39,34 @@ import "media-chrome/lang/pt.js";
 Again, replace `pt.js` with the desired language code.
 
 ## How Language Selection Works
-Media Chrome automatically detects the user's preferred language based on their browser settings. If the corresponding language file has been imported, the UI will switch to that language.
+Media Chrome automatically detects the user's preferred language based on their browser settings. If the corresponding language file has been imported, the UI will switch to that language. 
+
+> **Note:** When using HTML, make sure the language file `<script>` tag is loaded **before** the main Media Chrome script so the translations are registered before the components initialize.
 
 If the user’s preferred language is not available, the UI will fall back to English.
+
+## Manually Setting the Language
+
+You can also override the language explicitly by setting the `lang` attribute on the `<media-controller>` element after the language file has been loaded:
+
+```html
+<script type="module" src="https://cdn.jsdelivr.net/npm/media-chrome@4/dist/lang/es.js"></script>
+
+<media-controller lang="es">
+  ...
+</media-controller>
+```
+
+Or dynamically via JavaScript after the language module is imported:
+
+```js
+import "media-chrome/lang/es.js";
+
+const controller = document.querySelector("media-controller");
+controller.setAttribute("lang", "es");
+```
+
+This is useful when you want to set the language programmatically regardless of the user’s browser settings.
 
 
 ## Adding a New Language
@@ -47,12 +74,16 @@ If you want to add support for a new language, you can create your own language 
 
 1. Copy the contents of an existing language file (e.g., `es.js`).
 2. Modify the translations to match your desired language.
-3. Save it as a new file, e.g., `de.js` for German.
+3. Save it as a new file, e.g., `it.js` for Italian.
 4. Import it into your project using:
 
    ```js
-   import "./path-to-your-lang/de.js";
+   import "./path-to-your-lang/it.js";
    ```
 
 5. Ensure the browser can detect and apply the language based on user preferences.
+
+## Contributing a Language to the Library
+
+Want to share your translation? Add your language file to `src/js/lang/` and open a [Pull Request](https://github.com/muxinc/media-chrome/pulls).
 

--- a/docs/src/pages/docs/en/internationalization/adding-language-support.mdx
+++ b/docs/src/pages/docs/en/internationalization/adding-language-support.mdx
@@ -85,5 +85,4 @@ If you want to add support for a new language, you can create your own language 
 
 ## Contributing a Language to the Library
 
-Want to share your translation? Add your language file to `src/js/lang/` and open a [Pull Request](https://github.com/muxinc/media-chrome/pulls).
-
+Want to share your translation? Create a fork of the [muxinc/media-chrome](https://github.com/muxinc/media-chrome) repository, add your language file to `src/js/lang/`, and open a [Pull Request](https://github.com/muxinc/media-chrome/pulls).

--- a/examples/vanilla/internationalization.html
+++ b/examples/vanilla/internationalization.html
@@ -63,6 +63,7 @@
 
       <media-controller
         id="mc"
+        lang="en"
         defaultsubtitles
         keyboardforwardseekoffset="15"
         keyboardbackwardseekoffset="5"
@@ -128,7 +129,7 @@
       <select id="lang-select" onchange='setLang(this.value)'>
         <option value="zh-CN">Chinese (Simplified)</option>
         <option value="zh-TW">Chinese (Traditional)</option>
-        <option value="en" selected>English</option>
+        <option value="en">English</option>
         <option value="fr">French</option>
         <option value="de">German</option>
         <option value="pt">Portuguese</option>
@@ -142,6 +143,18 @@
       document.getElementById('browser-lang-info').innerHTML =
         `Browser language detected: <strong>[${browserLang}]</strong> - (${displayName})`;
 
+      function getAvailableLangs() {
+        return Array.from(document.getElementById('lang-select').options)
+          .map(o => o.value)
+          .filter(v => v !== '');
+      }
+
+      function resolveLang(lang, available) {
+        if (available.includes(lang)) return lang;
+        const base = lang.split('-')[0];
+        return available.find(l => l === base || l.startsWith(base + '-')) ?? 'en';
+      }
+
       function updateSetLangInfo() {
         const active = document.getElementById('mc').resolvedLang ?? 'en';
         const setDisplayName = new Intl.DisplayNames([active], { type: 'language' }).of(active);
@@ -150,12 +163,16 @@
         document.documentElement.lang = active;
       }
 
-      customElements.whenDefined('media-controller').then(updateSetLangInfo);
-
       function setLang(lang) {
-          document.getElementById('mc').setAttribute('lang', lang);
-          updateSetLangInfo();
+        document.getElementById('mc').setAttribute('lang', lang);
+        document.getElementById('lang-select').value = lang;
+        updateSetLangInfo();
       }
+
+      customElements.whenDefined('media-controller').then(() => {
+        const lang = resolveLang(browserLang, getAvailableLangs());
+        setLang(lang);
+      });
     </script>
 
     <div class="examples">

--- a/examples/vanilla/internationalization.html
+++ b/examples/vanilla/internationalization.html
@@ -4,13 +4,14 @@
     <meta name="viewport" content="width=device-width">
     <title>Media Chrome Advanced Video Usage Example</title>
     <script type="module" src="https://cdn.jsdelivr.net/npm/hls-video-element@1.1/+esm"></script>
-    <script type="module" src="../../dist/index.js"></script>
-    <script type="module" src="../../dist/menu/index.js"></script>
-    <script type="module" src="../../dist/lang/es.js"></script>
-    <script type="module" src="../../dist/lang/pt.js"></script>
-    <script type="module" src="../../dist/lang/fr.js"></script>
     <script type="module" src="../../dist/lang/zh-CN.js"></script>
     <script type="module" src="../../dist/lang/zh-TW.js"></script>
+    <script type="module" src="../../dist/lang/es.js"></script>
+    <script type="module" src="../../dist/lang/de.js"></script>    
+    <script type="module" src="../../dist/lang/fr.js"></script>
+    <script type="module" src="../../dist/lang/pt.js"></script>
+    <script type="module" src="../../dist/index.js"></script>
+    <script type="module" src="../../dist/menu/index.js"></script>
     <style>
       /* Hide custom elements that are not defined yet */
       :not(:defined) {
@@ -62,7 +63,6 @@
 
       <media-controller
         id="mc"
-        lang='en'
         defaultsubtitles
         keyboardforwardseekoffset="15"
         keyboardbackwardseekoffset="5"
@@ -120,19 +120,41 @@
       </media-controller>
     </main>
 
+    <p id="browser-lang-info"></p>
+    <p id="set-lang-info"></p>
+<hr/>
     <p>
-      <button onclick='setLang("en")'>Switch to English</button>
-      <button onclick='setLang("es")'>Switch to Spanish</button>
-      <button onclick='setLang("fr")'>Switch to French</button>
-      <button onclick='setLang("pt")'>Switch to Portuguese</button>
-      <button onclick='setLang("zh-CN")'>Switch to Chinese (Simplified)</button>
-      <button onclick='setLang("zh-TW")'>Switch to Chinese (Traditional)</button>
+      <label for="lang-select">Switch Language:</label>
+      <select id="lang-select" onchange='setLang(this.value)'>
+        <option value="zh-CN">Chinese (Simplified)</option>
+        <option value="zh-TW">Chinese (Traditional)</option>
+        <option value="en" selected>English</option>
+        <option value="fr">French</option>
+        <option value="de">German</option>
+        <option value="pt">Portuguese</option>
+        <option value="es">Spanish</option>
+      </select>
     </p>
 
     <script>
+      const browserLang = navigator.language;
+      const displayName = new Intl.DisplayNames([browserLang], { type: 'language' }).of(browserLang);
+      document.getElementById('browser-lang-info').innerHTML =
+        `Browser language detected: <strong>[${browserLang}]</strong> - (${displayName})`;
+
+      function updateSetLangInfo() {
+        const active = document.getElementById('mc').resolvedLang ?? 'en';
+        const setDisplayName = new Intl.DisplayNames([active], { type: 'language' }).of(active);
+        document.getElementById('set-lang-info').innerHTML =
+          `Language set: <strong>[${active}]</strong> - (${setDisplayName})`;
+        document.documentElement.lang = active;
+      }
+
+      customElements.whenDefined('media-controller').then(updateSetLangInfo);
+
       function setLang(lang) {
-          const mediaController = document.getElementById('mc');
-          mediaController.setAttribute('lang', lang);
+          document.getElementById('mc').setAttribute('lang', lang);
+          updateSetLangInfo();
       }
     </script>
 

--- a/src/js/media-controller.ts
+++ b/src/js/media-controller.ts
@@ -34,7 +34,7 @@ import {
 } from './utils/element-utils.js';
 import { createMediaStore, MediaStore } from './media-store/media-store.js';
 import { CustomElement } from './utils/CustomElement.js';
-import { setLanguage } from './utils/i18n.js';
+import { setLanguage, getResolvedLanguage } from './utils/i18n.js';
 
 const ButtonPressedKeys = [
   'ArrowLeft',
@@ -315,6 +315,10 @@ class MediaController extends MediaContainer {
 
   set noDefaultStore(value: boolean | undefined) {
     setBooleanAttr(this, Attributes.NO_DEFAULT_STORE, value);
+  }
+
+  get resolvedLang(): string {
+    return getResolvedLanguage();
   }
 
   attributeChangedCallback(

--- a/src/js/utils/i18n.ts
+++ b/src/js/utils/i18n.ts
@@ -28,6 +28,13 @@ const resolveTranslation = (key: TranslateKeys): string => {
   );
 };
 
+export const getResolvedLanguage = (): string => {
+  const [base] = currentLang.split('-');
+  if (translations[currentLang]) return currentLang;
+  if (translations[base]) return base;
+  return 'en';
+};
+
 export const t = (
   key: TranslateKeys,
   vars: Record<string, string | number> = {}


### PR DESCRIPTION
Improve docs for adding/setting lang support and include German option to examples.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly documentation/example updates with a small additive API (`resolvedLang`/`getResolvedLanguage`) that should not affect existing behavior but could surface edge cases if consumers start relying on the resolved value.
> 
> **Overview**
> Improves internationalization guidance by documenting script load order, manual `lang` overrides on `<media-controller>`, and how to contribute new language files; also updates the language list and examples (including German).
> 
> Enhances the vanilla i18n example to auto-select a best-match language from `navigator.language`, switch via a dropdown UI, and display both the detected browser language and the controller’s active resolved language.
> 
> Adds `getResolvedLanguage()` to `utils/i18n` and exposes it as a `resolvedLang` getter on `MediaController` so apps can query which language is actually being used after fallback resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47d2c6b5b8a7bdaa8aa167f2a686430d1f712c48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->