### PR TITLE
fix: input range margin on focus

### DIFF
--- a/src/js/media-chrome-range.ts
+++ b/src/js/media-chrome-range.ts
@@ -78,8 +78,8 @@ function getTemplateHTML(_attrs: Record<string, string>) {
       #range {
         ${/* The input range acts as a hover and hit zone for input events. */ ''}
         display: var(--media-time-range-hover-display, block);
-        bottom: var(--media-time-range-hover-bottom, -7px);
-        height: var(--media-time-range-hover-height, max(100% + 7px, 25px));
+        bottom: var(--media-time-range-hover-bottom, 0);
+        height: var(--media-time-range-hover-height, max(calc(100% + 7px), 25px));
         width: 100%;
         position: absolute;
         cursor: var(--media-cursor, pointer);
@@ -95,8 +95,8 @@ function getTemplateHTML(_attrs: Record<string, string>) {
 
       @media (hover: hover) {
         #range {
-          bottom: var(--media-time-range-hover-bottom, -5px);
-          height: var(--media-time-range-hover-height, max(100% + 5px, 20px));
+          bottom: var(--media-time-range-hover-bottom, 0);
+          height: var(--media-time-range-hover-height, max(calc(100%), 20px));
         }
       }
 

--- a/src/js/media-chrome-range.ts
+++ b/src/js/media-chrome-range.ts
@@ -79,7 +79,7 @@ function getTemplateHTML(_attrs: Record<string, string>) {
         ${/* The input range acts as a hover and hit zone for input events. */ ''}
         display: var(--media-time-range-hover-display, block);
         bottom: var(--media-time-range-hover-bottom, 0);
-        height: var(--media-time-range-hover-height, max(calc(100% + 7px), 25px));
+        height: var(--media-time-range-hover-height, max(100% , 25px));
         width: 100%;
         position: absolute;
         cursor: var(--media-cursor, pointer);

--- a/src/js/media-chrome-range.ts
+++ b/src/js/media-chrome-range.ts
@@ -96,7 +96,7 @@ function getTemplateHTML(_attrs: Record<string, string>) {
       @media (hover: hover) {
         #range {
           bottom: var(--media-time-range-hover-bottom, 0);
-          height: var(--media-time-range-hover-height, max(calc(100%), 20px));
+          height: var(--media-time-range-hover-height, max(100%, 20px));
         }
       }
 


### PR DESCRIPTION
Removes the negative bottom offset (-7px / -5px) from the #range hit zone that was causing a layout shift when the range control received focus (issue #1254).

Also fixes invalid CSS syntax in the height property by wrapping arithmetic expressions in calc() (max(100% + 7px) → max(calc(100% + 7px))).

Fixes [1254](https://github.com/muxinc/media-chrome/issues/1254)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only change; may slightly alter the time range hit/hover area sizing/position across browsers.
> 
> **Overview**
> Prevents layout shift when the range input receives focus by removing the negative `bottom` offset on the `#range` hit/hover zone and normalizing its default height in both base and `@media (hover: hover)` styles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51b2ed54dfab5446611f84962640521239a37116. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->