### PR TITLE
chore: Upgraded node version for failing CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
           # this line is required for the setup-node action to be able to run the npm publish below.
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
Canary release job has been failing since [Feb 15](https://github.com/muxinc/media-chrome/actions/runs/22188305885/job/64168737040). 

This PR updates node version as we did with similar cases on other repos.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates the Node.js runtime used in CI (including the canary publish job), which could surface new runtime/tooling incompatibilities but does not change product code.
> 
> **Overview**
> Updates the GitHub Actions CI workflow to run with **Node.js 24** instead of 20, including the `canary` prerelease publish job, to address the failing release pipeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4018d87e5df3c1efe4ac4bdd4a7ac6262187b788. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->