### PR TITLE
fix: round playback rate display to avoid Safari float drift

### DIFF
--- a/src/js/media-playback-rate-button.ts
+++ b/src/js/media-playback-rate-button.ts
@@ -12,7 +12,16 @@ export const Attributes = {
 export const DEFAULT_RATES = [1, 1.2, 1.5, 1.7, 2];
 export const DEFAULT_RATE = 1;
 
+// Round to 2 decimals so binary-float drift from HTMLMediaElement.playbackRate
+// (e.g. Safari returning 1.1499999999999999 for 1.15) doesn't leak into the UI.
+export function normalizePlaybackRate(rate: number): number {
+  return Math.round(rate * 100) / 100;
+}
+
 function getSlotTemplateHTML(attrs: Record<string, string>) {
+  const rate = attrs['mediaplaybackrate']
+    ? normalizePlaybackRate(+attrs['mediaplaybackrate'])
+    : DEFAULT_RATE;
   return /*html*/ `
     <style>
       :host {
@@ -20,7 +29,7 @@ function getSlotTemplateHTML(attrs: Record<string, string>) {
         padding: var(--media-button-padding, var(--media-control-padding, 10px 5px));
       }
     </style>
-    <slot name="icon">${attrs['mediaplaybackrate'] || DEFAULT_RATE}x</slot>
+    <slot name="icon">${rate}x</slot>
   `;
 }
 
@@ -55,7 +64,7 @@ class MediaPlaybackRateButton extends MediaChromeButton {
   constructor() {
     super();
     this.container = this.shadowRoot.querySelector('slot[name="icon"]');
-    this.container.innerHTML = `${this.mediaPlaybackRate ?? DEFAULT_RATE}x`;
+    this.container.innerHTML = `${normalizePlaybackRate(this.mediaPlaybackRate ?? DEFAULT_RATE)}x`;
   }
 
   attributeChangedCallback(
@@ -70,9 +79,9 @@ class MediaPlaybackRateButton extends MediaChromeButton {
     }
     if (attrName === MediaUIAttributes.MEDIA_PLAYBACK_RATE) {
       const newPlaybackRate = newValue ? +newValue : Number.NaN;
-      const playbackRate = !Number.isNaN(newPlaybackRate)
-        ? newPlaybackRate
-        : DEFAULT_RATE;
+      const playbackRate = normalizePlaybackRate(
+        !Number.isNaN(newPlaybackRate) ? newPlaybackRate : DEFAULT_RATE
+      );
       this.container.innerHTML = `${playbackRate}x`;
       this.setAttribute(
         'aria-label',

--- a/src/js/menu/media-playback-rate-menu-button.ts
+++ b/src/js/menu/media-playback-rate-menu-button.ts
@@ -7,17 +7,21 @@ import {
   getMediaController,
 } from '../utils/element-utils.js';
 import { t } from '../utils/i18n.js';
+import { normalizePlaybackRate } from '../media-playback-rate-button.js';
 
 export const DEFAULT_RATE = 1;
 
 function getSlotTemplateHTML(attrs: Record<string, string>) {
+  const rate = attrs['mediaplaybackrate']
+    ? normalizePlaybackRate(+attrs['mediaplaybackrate'])
+    : DEFAULT_RATE;
   return /*html*/ `
     <style>
       :host {
         min-width: 5ch;
         padding: var(--media-button-padding, var(--media-control-padding, 10px 5px));
       }
-      
+
       :host([aria-expanded="true"]) slot {
         display: block;
       }
@@ -26,7 +30,7 @@ function getSlotTemplateHTML(attrs: Record<string, string>) {
         display: none;
       }
     </style>
-    <slot name="icon">${attrs['mediaplaybackrate'] || DEFAULT_RATE}x</slot>
+    <slot name="icon">${rate}x</slot>
   `;
 }
 
@@ -55,7 +59,7 @@ class MediaPlaybackRateMenuButton extends MediaChromeMenuButton {
   constructor() {
     super();
     this.container = this.shadowRoot.querySelector('slot[name="icon"]');
-    this.container.innerHTML = `${this.mediaPlaybackRate ?? DEFAULT_RATE}x`;
+    this.container.innerHTML = `${normalizePlaybackRate(this.mediaPlaybackRate ?? DEFAULT_RATE)}x`;
   }
 
   attributeChangedCallback(
@@ -67,9 +71,9 @@ class MediaPlaybackRateMenuButton extends MediaChromeMenuButton {
 
     if (attrName === MediaUIAttributes.MEDIA_PLAYBACK_RATE) {
       const newPlaybackRate = newValue ? +newValue : Number.NaN;
-      const playbackRate = !Number.isNaN(newPlaybackRate)
-        ? newPlaybackRate
-        : DEFAULT_RATE;
+      const playbackRate = normalizePlaybackRate(
+        !Number.isNaN(newPlaybackRate) ? newPlaybackRate : DEFAULT_RATE
+      );
       this.container.innerHTML = `${playbackRate}x`;
       this.setAttribute(
         'aria-label',

--- a/src/js/menu/media-playback-rate-menu.ts
+++ b/src/js/menu/media-playback-rate-menu.ts
@@ -6,7 +6,11 @@ import {
   setNumericAttr,
   getMediaController,
 } from '../utils/element-utils.js';
-import { DEFAULT_RATES, DEFAULT_RATE } from '../media-playback-rate-button.js';
+import {
+  DEFAULT_RATES,
+  DEFAULT_RATE,
+  normalizePlaybackRate,
+} from '../media-playback-rate-button.js';
 import {
   MediaChromeMenu,
   createMenuItem,
@@ -124,9 +128,11 @@ class MediaPlaybackRateMenu extends MediaChromeMenu {
   #render(): void {
     this.defaultSlot.textContent = '';
 
-    const currentRate = this.mediaPlaybackRate;
-    const ratesSet = new Set(Array.from(this.#rates).map(rate => Number(rate)));
-    
+    const currentRate = normalizePlaybackRate(this.mediaPlaybackRate);
+    const ratesSet = new Set(
+      Array.from(this.#rates).map((rate) => normalizePlaybackRate(Number(rate)))
+    );
+
     // If current rate is not in the list, add it to show it as selected
     if (currentRate > 0 && !ratesSet.has(currentRate)) {
       ratesSet.add(currentRate);

--- a/test/unit/media-playback-rate-button.spec.ts
+++ b/test/unit/media-playback-rate-button.spec.ts
@@ -32,4 +32,12 @@ describe('<media-playback-rate-button>', () => {
     el.rates = [0.5, 1, 2];
     assert.equal(el.rates, '0.5 1 2');
   });
+
+  it('rounds float-precision drift in the displayed rate', () => {
+    // Safari returns 1.15 as 1.1499999999999999 from HTMLMediaElement.playbackRate
+    el.setAttribute('mediaplaybackrate', '1.1499999999999999');
+    const slot = el.shadowRoot.querySelector('slot[name="icon"]');
+    assert.equal(slot.innerHTML, '1.15x');
+    assert.equal(el.getAttribute('aria-label'), 'Playback rate 1.15');
+  });
 });


### PR DESCRIPTION
## Summary

- Safari returns `HTMLMediaElement.playbackRate` as `1.1499999999999999` for `1.15` (binary float representation), and that raw value was being stringified into the playback rate button label, menu button label, aria-label, and menu items.
- Added `normalizePlaybackRate(n)` helper that rounds to 2 decimals — `Number.toString` naturally strips trailing zeros so exact rates like `1.5` and `2` are unaffected.
- Applied in `media-playback-rate-button`, `media-playback-rate-menu-button`, and `media-playback-rate-menu` (the menu also previously could append a phantom duplicate entry when `currentRate` had drifted from the value in the rates list — fixed as a side-effect).

Reported in muxinc/elements#1333.

## Test plan

- [x] Unit test added: `mediaplaybackrate="1.1499999999999999"` renders as `1.15x` with matching aria-label.
- [x] `npm run test:unit` passes (4/4 in the affected spec).
- [x] `npm run lint` clean.
- [x] `npm run build:types` clean.
- [x] Manually verify in Safari/macOS that programmatically setting `playbackRate = 1.15` shows `1.15x` (not `1.1499999...x`) in both the standalone button and the menu button.
- [x] Verify exactly-representable rates (`1`, `1.5`, `2`, `0.5`) still render without a trailing `.0`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: UI-only formatting change that rounds playback-rate values and slightly adjusts menu item deduping; no changes to media control behavior.
> 
> **Overview**
> Fixes Safari float-precision drift leaking into playback-rate UI by introducing `normalizePlaybackRate()` (round to 2 decimals) and applying it to the playback rate button, menu button, and menu rendering.
> 
> This ensures the displayed `Nx` label and `aria-label` use the normalized value, and prevents the menu from showing duplicate/phantom rates when the current rate differs from the configured list only due to float drift. Adds a unit test covering `mediaplaybackrate="1.1499999999999999"` rendering as `1.15x`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36b385e5a81c26dedcf6d5c39ecc0c54e99c91c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->