### PR TITLE
cd: remove NODE_AUTH_TOKEN from cd workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -44,7 +44,6 @@ jobs:
       id-token: write
     if: github.event_name == 'workflow_dispatch'
     env:
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
@@ -98,9 +97,6 @@ jobs:
     permissions:
       contents: write
       id-token: write
-
-    env:
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4

--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -3,7 +3,7 @@ export * as timeUtils from './utils/time.js';
 export { t } from './utils/i18n.js';
 
 // Import media-controller first to ensure it's available for other components
-// when calling `associateElement(this)` in connectedCallback.
+// when calling `associateElement(this)` in `connectedCallback()`.
 import MediaController from './media-controller.js';
 import MediaAirplayButton from './media-airplay-button.js';
 import MediaCaptionsButton from './media-captions-button.js';


### PR DESCRIPTION
not needed since we use another auth method

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow only removes an unused secret env var from release jobs, with no runtime code behavior changes (aside from a comment tweak).
> 
> **Overview**
> Removes `NODE_AUTH_TOKEN` from the CD GitHub Actions workflow (`deploy` and `canary` jobs), relying on the existing OIDC/provenance publishing flow instead of an NPM token env var.
> 
> Also makes a tiny docs-only tweak in `src/js/index.ts` to clarify the `connectedCallback()` reference in an import-order comment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb83d238a9856b8be293977684024e7d5ab2b910. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->