### PR TITLE
fix: treat only remote.state === "connected" as casting

### DIFF
--- a/src/js/media-store/state-mediator.ts
+++ b/src/js/media-store/state-mediator.ts
@@ -1040,7 +1040,7 @@ export const stateMediator: StateMediator = {
       if (!media?.remote || media.remote?.state === 'disconnected')
         return false;
 
-      return !!media.remote.state;
+      return media.remote.state === 'connected';
     },
     set(value, stateOwners) {
       const { media } = stateOwners;


### PR DESCRIPTION
`mediaIsCasting` was returning `true` for `"connecting",` which on iOS Safari can get stuck there indefinitely. That kept `mediaiscasting` on the controller, blocking autohide for the whole session. One-liner fix: only `"connected"` counts as casting.

fixes [1335](https://github.com/muxinc/elements/issues/1335)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line getter change in casting state; aligns with existing setter checks and reduces false-positive casting UI behavior.
> 
> **Overview**
> Tightens when the controller reports **casting** so transient remote states no longer count as active cast.
> 
> `mediaIsCasting` in `state-mediator.ts` now returns `true` only when `media.remote.state === 'connected'`, instead of any truthy remote state after the disconnected check. That stops **`"connecting"`** (and similar) from setting **`mediaiscasting`**, which on iOS Safari could stay stuck and **block control autohide** for the whole session. Cast button behavior and disconnect logic were already keyed off **`connected`**; the getter now matches that.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 637e5e65e0f5f3d7a483629c6a3487f203cff2f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->