### PR TITLE
fix(docs): correct broken link to defaultstreamtype on stream-type page

### DIFF
--- a/docs/src/pages/docs/en/stream-type.md
+++ b/docs/src/pages/docs/en/stream-type.md
@@ -29,4 +29,4 @@ For example, you can hide the media time range (progress bar) during a live stre
 </media-controller>
 ```
 
-[See also default-stream-type.](./media-controller#default-stream-type)
+[See also default-stream-type.](./components/media-controller#defaultstreamtype)


### PR DESCRIPTION
Closes #1297

The link on the [stream-type docs page](https://www.media-chrome.org/docs/en/stream-type) pointing to `defaultstreamtype` on the media-controller page was returning 404. Two problems:

- Wrong path: `./media-controller` → `./components/media-controller`
- Wrong anchor: `#default-stream-type` → `#defaultstreamtype` (matches the actual heading)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link fix with no runtime or API impact.
> 
> **Overview**
> Fixes a **404** on the stream-type docs page by updating the “See also default-stream-type” link.
> 
> The href now points to `./components/media-controller#defaultstreamtype` instead of `./media-controller#default-stream-type`, matching the real media-controller doc path and the `### defaultstreamtype` heading anchor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec5375613bfb9990f7a5ea1ba4fea70652011fe3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->