### PR TITLE
fix: return '0 seconds' for zero input in formatAsTimePhrase

### DIFF
--- a/src/js/utils/time.ts
+++ b/src/js/utils/time.ts
@@ -58,6 +58,7 @@ export const formatAsTimePhrase = (seconds) => {
     return t('{time} remaining', { time: timeString });
   }
 
+  // timeString will be empty for 0 seconds, so we explicitly build '0 seconds'
   return timeString || toTimeUnitPhrase(0, 2);
 };
 

--- a/src/js/utils/time.ts
+++ b/src/js/utils/time.ts
@@ -58,7 +58,7 @@ export const formatAsTimePhrase = (seconds) => {
     return t('{time} remaining', { time: timeString });
   }
 
-  return timeString;
+  return timeString || toTimeUnitPhrase(0, 2);
 };
 
 /**

--- a/src/js/utils/time.ts
+++ b/src/js/utils/time.ts
@@ -58,7 +58,7 @@ export const formatAsTimePhrase = (seconds) => {
     return t('{time} remaining', { time: timeString });
   }
 
-  return timeString || toTimeUnitPhrase(0, 2);
+  return positiveSeconds === 0 ? toTimeUnitPhrase(0, 2) : timeString;
 };
 
 /**

--- a/test/unit/utils/time.spec.ts
+++ b/test/unit/utils/time.spec.ts
@@ -3,7 +3,7 @@ import { formatAsTimePhrase, formatTime } from '../../../src/js/utils/time.js';
 
 describe('formatAsTimePhrase', () => {
   it('formats time in seconds as a phrase', () => {
-    assert.equal(formatAsTimePhrase(0), '');
+    assert.equal(formatAsTimePhrase(0), '0 seconds');
     assert.equal(formatAsTimePhrase(1), '1 second');
     assert.equal(formatAsTimePhrase(176), '2 minutes, 56 seconds');
     assert.equal(formatAsTimePhrase(48932), '13 hours, 35 minutes, 32 seconds');


### PR DESCRIPTION
Fixes #1299
`formatAsTimePhrase(0)` was returning an empty string due to a falsy check on zero-value time units, causing <media-time-display> to render an aria-description like " of 48 minutes, 10 seconds" on load. Changed the return to fall back to "0 seconds" when all time units are zero, and updated the corresponding unit test assertion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small display/i18n formatting change in a utility with an updated unit test; no auth, data, or core playback logic.
> 
> **Overview**
> **`formatAsTimePhrase(0)`** now returns **`0 seconds`** instead of an empty string. Zero-valued hour/minute/second parts are still omitted from the joined phrase, so the function adds an explicit fallback via **`toTimeUnitPhrase(0, 2)`** when **`positiveSeconds === 0`**.
> 
> This fixes broken **`aria-description`** text on **`media-time-display`** (and similar **`{currentTime} of {totalTime}`** strings) when the current time is 0 at load—e.g. **" of 48 minutes, 10 seconds"** instead of a proper current-time phrase. The **`formatAsTimePhrase`** unit test expectation for **`0`** is updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4045ae2385c46ab2788f9004cbc71fcb41405b28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->